### PR TITLE
Fix CLI UX issues in pyodide runtime agent

### DIFF
--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -12,7 +12,7 @@
     "./lib": "./src/lib.ts"
   },
   "bin": {
-    "pyrunt": "./src/mod.ts"
+    "pyrunt": "--env-file=.env ./src/mod.ts"
   },
   "imports": {
     "@runt/lib": "jsr:@runt/lib@^0.2.0",

--- a/packages/pyodide-runtime-agent/src/lib.ts
+++ b/packages/pyodide-runtime-agent/src/lib.ts
@@ -16,7 +16,7 @@ export {
 } from "./cache-utils.ts";
 
 // Export OpenAI client for AI cell support
-export { OpenAIClient, openaiClient } from "./openai-client.ts";
+export { OpenAIClient } from "./openai-client.ts";
 
 // Re-export useful types from @runt/lib for convenience
 export type {

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -20,7 +20,7 @@ export {
 } from "./cache-utils.ts";
 
 // Export OpenAI client for AI cell support
-export { OpenAIClient, openaiClient } from "./openai-client.ts";
+export { OpenAIClient } from "./openai-client.ts";
 
 // Re-export useful types from @runt/lib for convenience
 export type {

--- a/packages/pyodide-runtime-agent/src/openai-client.ts
+++ b/packages/pyodide-runtime-agent/src/openai-client.ts
@@ -513,8 +513,5 @@ export class RuntOpenAIClient {
   }
 }
 
-// Export singleton instance - will only configure when first used
-export const openaiClient = new RuntOpenAIClient();
-
 // Export class for testing
 export { RuntOpenAIClient as OpenAIClient };

--- a/packages/pyodide-runtime-agent/src/openai-client.ts
+++ b/packages/pyodide-runtime-agent/src/openai-client.ts
@@ -88,16 +88,17 @@ export class RuntOpenAIClient {
   private logger = createLogger("openai-client");
 
   constructor(config?: OpenAIConfig) {
-    this.configure(config);
+    // Don't configure immediately to avoid early initialization logs
+    if (config) {
+      this.configure(config);
+    }
   }
 
   configure(config?: OpenAIConfig) {
     const apiKey = config?.apiKey || Deno.env.get("OPENAI_API_KEY");
 
     if (!apiKey) {
-      this.logger.warn(
-        "OpenAI API key not found. Set OPENAI_API_KEY environment variable or pass apiKey in config.",
-      );
+      // Don't log warning at startup - only when actually trying to use OpenAI
       this.isConfigured = false;
       return;
     }
@@ -117,6 +118,10 @@ export class RuntOpenAIClient {
   }
 
   isReady(): boolean {
+    // Try to configure if not already configured and not already failed
+    if (!this.isConfigured && this.client === null) {
+      this.configure();
+    }
     return this.isConfigured && this.client !== null;
   }
 
@@ -508,7 +513,7 @@ export class RuntOpenAIClient {
   }
 }
 
-// Export singleton instance
+// Export singleton instance - will only configure when first used
 export const openaiClient = new RuntOpenAIClient();
 
 // Export class for testing

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -84,11 +84,16 @@ export class PyodideRuntimeAgent {
       console.error(error instanceof Error ? error.message : String(error));
       console.error("\nExample usage:");
       console.error(
-        "  deno run --allow-all --env-file=.env pyodide-agent.ts --notebook my-notebook --auth-token your-token",
+        '  deno run --allow-all "jsr:@runt/pyodide-runtime-agent" --notebook my-notebook --auth-token your-token',
       );
       console.error("\nOr set environment variables in .env:");
       console.error("  NOTEBOOK_ID=my-notebook");
       console.error("  AUTH_TOKEN=your-token");
+      console.error("\nOr install globally:");
+      console.error(
+        "  deno install -gf --allow-all jsr:@runt/pyodide-runtime-agent",
+      );
+      console.error("  pyrunt --notebook my-notebook --auth-token your-token");
       Deno.exit(1);
     }
 


### PR DESCRIPTION
- Fix error message to show JSR command instead of local file path
- Add global installation example in error message
- Fix OpenAI client to only initialize when needed, not at module load
- Remove premature OpenAI logs during CLI usage

Resolves user CLI confusion when running:
deno run --allow-all 'jsr:@runt/pyodide-runtime-agent'