### PR TITLE
Bump @runt/pyodide-runtime-agent to v0.2.1

### DIFF
--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
This patch release includes:

- Fix newline handling in Python stdout/stderr output
- Remove redundant TTY hacks from IPython setup
- Improved output processing reliability