### PR TITLE
Patch release: @runt/lib v0.2.1

### DIFF
--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Runtime agent library for building Anode kernels",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Patch release to ensure KNOWN_MIME_TYPES export is available on JSR.

This fixes the import error in @runt/pyodide-runtime-agent v0.2.1:


**Testing**: ✅ All tests pass
**Publishing**: Ready for JSR publish to resolve dependency issue