### PR TITLE
Patch release: @runt/pyodide-runtime-agent v0.2.2

### DIFF
--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "MIT",
   "repository": {
@@ -15,7 +15,7 @@
     "pyrunt": "--env-file=.env ./src/mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.2.0",
+    "@runt/lib": "jsr:@runt/lib@^0.2.1",
     "@runt/schema": "jsr:@runt/schema@^0.2.0",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",


### PR DESCRIPTION
Fix JSR dependency resolution issue from v0.2.1.

Updates dependency to use @runt/lib@^0.2.1 to ensure KNOWN_MIME_TYPES import works correctly.

This resolves the import error that was preventing the pyodide runtime agent from starting.

Testing: All tests pass
Publishing: Ready for JSR with fixed dependencies