### PR TITLE
clear_output handling

### DIFF
--- a/packages/lib/src/execution-context.test.ts
+++ b/packages/lib/src/execution-context.test.ts
@@ -12,7 +12,12 @@ interface MockOutputCommit {
   type: "cellOutputAdded";
   id: string;
   cellId: string;
-  outputType: "stream" | "display_data" | "execute_result" | "error";
+  outputType:
+    | "stream"
+    | "display_data"
+    | "execute_result"
+    | "error"
+    | "clear_output";
   data: {
     name?: "stdout" | "stderr";
     text?: string;
@@ -187,6 +192,18 @@ Deno.test("ExecutionContext Output Methods", async (t) => {
             clearedBy: `kernel-${config.kernelId}`,
           });
           outputPosition = 0;
+        },
+
+        clearOutput: (wait = false) => {
+          mockStore.commit({
+            type: "cellOutputAdded",
+            id: crypto.randomUUID(),
+            cellId: cell.id!,
+            outputType: "clear_output",
+            data: { wait },
+            metadata: {},
+            position: outputPosition++,
+          });
         },
       };
     })();

--- a/packages/lib/src/execution-context.test.ts
+++ b/packages/lib/src/execution-context.test.ts
@@ -37,8 +37,10 @@ interface MockClearCommit {
 
 interface MockClearPendingCommit {
   type: "cellOutputClearPending";
+  id: string;
   cellId: string;
   clearedBy: string;
+  requestedAt: number;
 }
 
 type MockCommit = MockOutputCommit | MockClearCommit | MockClearPendingCommit;
@@ -204,8 +206,10 @@ Deno.test("ExecutionContext Output Methods", async (t) => {
             // For wait=true: mock a pending clear request
             mockStore.commit({
               type: "cellOutputClearPending",
+              id: crypto.randomUUID(),
               cellId: cell.id!,
               clearedBy: `kernel-${config.kernelId}`,
+              requestedAt: Date.now(),
             });
           } else {
             // For wait=false: clear immediately

--- a/packages/lib/src/execution-context.test.ts
+++ b/packages/lib/src/execution-context.test.ts
@@ -16,8 +16,7 @@ interface MockOutputCommit {
     | "stream"
     | "display_data"
     | "execute_result"
-    | "error"
-    | "clear_output";
+    | "error";
   data: {
     name?: "stdout" | "stderr";
     text?: string;
@@ -36,7 +35,13 @@ interface MockClearCommit {
   clearedBy: string;
 }
 
-type MockCommit = MockOutputCommit | MockClearCommit;
+interface MockClearPendingCommit {
+  type: "cellOutputClearPending";
+  cellId: string;
+  clearedBy: string;
+}
+
+type MockCommit = MockOutputCommit | MockClearCommit | MockClearPendingCommit;
 
 const createMockStore = () => {
   const commits: MockCommit[] = [];
@@ -195,15 +200,22 @@ Deno.test("ExecutionContext Output Methods", async (t) => {
         },
 
         clearOutput: (wait = false) => {
-          mockStore.commit({
-            type: "cellOutputAdded",
-            id: crypto.randomUUID(),
-            cellId: cell.id!,
-            outputType: "clear_output",
-            data: { wait },
-            metadata: {},
-            position: outputPosition++,
-          });
+          if (wait) {
+            // For wait=true: mock a pending clear request
+            mockStore.commit({
+              type: "cellOutputClearPending",
+              cellId: cell.id!,
+              clearedBy: `kernel-${config.kernelId}`,
+            });
+          } else {
+            // For wait=false: clear immediately
+            mockStore.commit({
+              type: "cellOutputsCleared",
+              cellId: cell.id!,
+              clearedBy: `kernel-${config.kernelId}`,
+            });
+            outputPosition = 0;
+          }
         },
       };
     })();

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -524,15 +524,21 @@ export class RuntimeAgent {
       },
 
       clearOutput: (wait = false) => {
-        // Emit clear_output as a proper output type with wait semantics
-        this.store.commit(events.cellOutputAdded({
-          id: crypto.randomUUID(),
-          cellId: cell.id,
-          outputType: "clear_output",
-          data: { wait },
-          metadata: {},
-          position: outputPosition++,
-        }));
+        if (wait) {
+          // For wait=true: store a pending clear request
+          // Next output will trigger the actual clear
+          this.store.commit(events.cellOutputClearPending({
+            cellId: cell.id,
+            clearedBy: `kernel-${this.config.kernelId}`,
+          }));
+        } else {
+          // For wait=false: clear immediately like the existing clear() method
+          this.store.commit(events.cellOutputsCleared({
+            cellId: cell.id,
+            clearedBy: `kernel-${this.config.kernelId}`,
+          }));
+          outputPosition = 0;
+        }
       },
     };
 

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -528,8 +528,10 @@ export class RuntimeAgent {
           // For wait=true: store a pending clear request
           // Next output will trigger the actual clear
           this.store.commit(events.cellOutputClearPending({
+            id: crypto.randomUUID(),
             cellId: cell.id,
             clearedBy: `kernel-${this.config.kernelId}`,
+            requestedAt: Date.now(),
           }));
         } else {
           // For wait=false: clear immediately like the existing clear() method

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -522,6 +522,18 @@ export class RuntimeAgent {
         }));
         outputPosition = 0;
       },
+
+      clearOutput: (wait = false) => {
+        // Emit clear_output as a proper output type with wait semantics
+        this.store.commit(events.cellOutputAdded({
+          id: crypto.randomUUID(),
+          cellId: cell.id,
+          outputType: "clear_output",
+          data: { wait },
+          metadata: {},
+          position: outputPosition++,
+        }));
+      },
     };
 
     try {

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -85,6 +85,8 @@ export interface ExecutionContext {
   error: (ename: string, evalue: string, traceback: string[]) => void;
   /** Clear all previous outputs for this cell */
   clear: () => void;
+  /** Clear display output (Jupyter clear_output) with optional wait parameter */
+  clearOutput: (wait?: boolean) => void;
 }
 
 /**

--- a/packages/pyodide-runtime-agent/src/ipython-setup.py
+++ b/packages/pyodide-runtime-agent/src/ipython-setup.py
@@ -83,8 +83,12 @@ class RichDisplayPublisher(DisplayPublisher):
 
     def clear_output(self, wait=False):
         """Clear output signal"""
-        # TODO: Implement clear_output with our schema and protocol
-        print(f"[CLEAR_OUTPUT:{wait}]", flush=True)
+        if self.js_callback:
+            # Send clear signal through JavaScript callback to integrate with runt schema
+            self.js_callback("clear_output", {"wait": wait}, {}, False)
+        else:
+            # Fallback to print for debugging when callback not available
+            print(f"[CLEAR_OUTPUT:{wait}]", flush=True)
 
     def _make_serializable(self, obj):
         """Convert objects to JSON-serializable format"""

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -272,9 +272,12 @@ export class PyodideRuntimeAgent {
               data.data.traceback || [String(data.data)],
             );
             break;
-          case "clear_output":
-            this.currentExecutionContext.clear();
+          case "clear_output": {
+            // Extract wait parameter from metadata
+            const wait = (data.data as { wait?: boolean })?.wait || false;
+            this.currentExecutionContext.clearOutput(wait);
             break;
+          }
         }
       }
       return;

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -272,6 +272,9 @@ export class PyodideRuntimeAgent {
               data.data.traceback || [String(data.data)],
             );
             break;
+          case "clear_output":
+            this.currentExecutionContext.clear();
+            break;
         }
       }
       return;

--- a/packages/pyodide-runtime-agent/src/pyodide-worker.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-worker.ts
@@ -224,6 +224,26 @@ async function executePython(code: string): Promise<{
         update = false,
       ) => {
         try {
+          // Handle clear_output signal
+          if (data === "clear_output") {
+            self.postMessage({
+              type: "stream_output",
+              data: {
+                type: "clear_output",
+                data: ensureSerializable(metadata),
+              },
+            });
+
+            outputs.push({
+              type: "display",
+              data: {
+                type: "clear_output",
+                data: ensureSerializable(metadata),
+              },
+            });
+            return;
+          }
+
           // Ensure data is serializable
           const serializedData = ensureSerializable(data);
           const serializedMetadata = ensureSerializable(metadata);

--- a/packages/pyodide-runtime-agent/test/clear-output.test.ts
+++ b/packages/pyodide-runtime-agent/test/clear-output.test.ts
@@ -146,29 +146,40 @@ pub.clear_output(wait=True)
     async () => {
       await withQuietLogging(() => {
         // Test that the agent correctly processes clear_output messages
-        let clearCalled = false;
+        let clearOutputCalled = false;
+        let clearOutputWait = false;
 
         const mockContext = {
-          clear: () => {
-            clearCalled = true;
+          clearOutput: (wait = false) => {
+            clearOutputCalled = true;
+            clearOutputWait = wait;
           },
         };
 
         // Simulate the handleWorkerMessage logic from pyodide-agent.ts
         const handleStreamOutput = (data: { type: string; data: unknown }) => {
           if (data.type === "clear_output") {
-            mockContext.clear();
+            const wait = (data.data as { wait?: boolean })?.wait || false;
+            mockContext.clearOutput(wait);
           }
         };
 
-        // Test that clear_output message triggers context.clear()
+        // Test that clear_output message triggers context.clearOutput()
         handleStreamOutput({ type: "clear_output", data: { wait: false } });
 
         assertEquals(
-          clearCalled,
+          clearOutputCalled,
           true,
-          "context.clear() should be called when clear_output message is received",
+          "context.clearOutput() should be called when clear_output message is received",
         );
+        assertEquals(clearOutputWait, false, "wait parameter should be false");
+
+        // Test with wait=true
+        clearOutputCalled = false;
+        handleStreamOutput({ type: "clear_output", data: { wait: true } });
+
+        assertEquals(clearOutputCalled, true);
+        assertEquals(clearOutputWait, true, "wait parameter should be true");
       });
     },
   );

--- a/packages/pyodide-runtime-agent/test/clear-output.test.ts
+++ b/packages/pyodide-runtime-agent/test/clear-output.test.ts
@@ -1,0 +1,175 @@
+import { assertEquals } from "jsr:@std/assert";
+import { withQuietLogging } from "@runt/lib";
+
+Deno.test("PyodideRuntimeAgent - Clear Output Implementation", async (t) => {
+  await t.step("Python clear_output should send clear signal", async () => {
+    await withQuietLogging(() => {
+      // Test that the Python implementation properly calls the JavaScript callback
+      const mockCallbacks: Array<
+        { type: string; data: unknown; metadata: unknown; update: boolean }
+      > = [];
+
+      // Create a mock js_callback function
+      const mockJsCallback = (
+        data: unknown,
+        metadata: unknown,
+        _transient: unknown,
+        update = false,
+      ) => {
+        mockCallbacks.push({ type: "display", data, metadata, update });
+      };
+
+      // Test the Python code that should be executed
+      const _pythonCode = `
+# Simulate what happens in ipython-setup.py
+class MockDisplayPublisher:
+    def __init__(self):
+        self.js_callback = None
+
+    def clear_output(self, wait=False):
+        if self.js_callback:
+            self.js_callback("clear_output", {"wait": wait}, {}, False)
+        else:
+            print(f"[CLEAR_OUTPUT:{wait}]", flush=True)
+
+# Test the implementation
+pub = MockDisplayPublisher()
+pub.js_callback = js_callback
+pub.clear_output()
+pub.clear_output(wait=True)
+`;
+
+      // This test verifies the logic without needing full Pyodide initialization
+      // The actual integration happens in the worker where js_callback is set
+
+      // Test 1: Verify callback is called with correct parameters for clear_output()
+      const _clearOutputData = {
+        data: "clear_output",
+        metadata: { wait: false },
+        update: false,
+      };
+      mockJsCallback("clear_output", { wait: false }, {}, false);
+
+      assertEquals(mockCallbacks.length, 1);
+      assertEquals(mockCallbacks[0]?.data, "clear_output");
+      assertEquals(
+        (mockCallbacks[0]?.metadata as { wait: boolean })?.wait,
+        false,
+      );
+
+      // Test 2: Verify callback is called with wait=True
+      mockCallbacks.length = 0; // Reset
+      mockJsCallback("clear_output", { wait: true }, {}, false);
+
+      assertEquals(mockCallbacks.length, 1);
+      assertEquals(mockCallbacks[0]?.data, "clear_output");
+      assertEquals(
+        (mockCallbacks[0]?.metadata as { wait: boolean })?.wait,
+        true,
+      );
+    });
+  });
+
+  await t.step(
+    "TypeScript worker should handle clear_output signal",
+    async () => {
+      await withQuietLogging(() => {
+        // Test that the TypeScript worker correctly processes clear_output signals
+        const streamOutputs: Array<{ type: string; data: unknown }> = [];
+        const displayOutputs: Array<{ type: string; data: unknown }> = [];
+
+        // Mock the postMessage and outputs array from pyodide-worker.ts
+        const mockPostMessage = (
+          message: { type: string; data: { type: string; data: unknown } },
+        ) => {
+          if (message.type === "stream_output") {
+            streamOutputs.push(message.data);
+          }
+        };
+
+        const mockOutputsPush = (output: { type: string; data: unknown }) => {
+          displayOutputs.push(output);
+        };
+
+        // Simulate the display callback logic from pyodide-worker.ts
+        const handleDisplayCallback = (
+          data: unknown,
+          metadata: unknown,
+          _transient: unknown,
+          _update = false,
+        ) => {
+          // Handle clear_output signal (this is our new code)
+          if (data === "clear_output") {
+            mockPostMessage({
+              type: "stream_output",
+              data: {
+                type: "clear_output",
+                data: metadata,
+              },
+            });
+
+            mockOutputsPush({
+              type: "display",
+              data: {
+                type: "clear_output",
+                data: metadata,
+              },
+            });
+            return;
+          }
+
+          // Normal display handling would continue here...
+        };
+
+        // Test clear_output signal processing
+        handleDisplayCallback("clear_output", { wait: false }, {}, false);
+
+        assertEquals(streamOutputs.length, 1);
+        assertEquals(streamOutputs[0]?.type, "clear_output");
+        assertEquals(
+          (streamOutputs[0]?.data as { wait: boolean })?.wait,
+          false,
+        );
+
+        assertEquals(displayOutputs.length, 1);
+        assertEquals(displayOutputs[0]?.type, "display");
+        assertEquals(
+          (displayOutputs[0]?.data as { type: string })?.type,
+          "clear_output",
+        );
+      });
+    },
+  );
+
+  await t.step(
+    "PyodideAgent should handle clear_output stream message",
+    async () => {
+      await withQuietLogging(() => {
+        // Test that the agent correctly processes clear_output messages
+        let clearCalled = false;
+
+        const mockContext = {
+          clear: () => {
+            clearCalled = true;
+          },
+        };
+
+        // Simulate the handleWorkerMessage logic from pyodide-agent.ts
+        const handleStreamOutput = (data: { type: string; data: unknown }) => {
+          if (data.type === "clear_output") {
+            mockContext.clear();
+          }
+        };
+
+        // Test that clear_output message triggers context.clear()
+        handleStreamOutput({ type: "clear_output", data: { wait: false } });
+
+        assertEquals(
+          clearCalled,
+          true,
+          "context.clear() should be called when clear_output message is received",
+        );
+      });
+    },
+  );
+});

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -389,8 +389,10 @@ export const events = {
   cellOutputClearPending: Events.synced({
     name: "v1.CellOutputClearPending",
     schema: Schema.Struct({
+      id: Schema.String,
       cellId: Schema.String,
       clearedBy: Schema.String,
+      requestedAt: Schema.Number,
     }),
   }),
 
@@ -620,12 +622,12 @@ const materializers = State.SQLite.materializers(events, {
   "v1.CellOutputsCleared": ({ cellId }) =>
     tables.outputs.delete().where({ cellId }),
 
-  "v1.CellOutputClearPending": ({ cellId, clearedBy }) =>
+  "v1.CellOutputClearPending": ({ id, cellId, clearedBy, requestedAt }) =>
     tables.pendingClears.insert({
-      id: crypto.randomUUID(),
+      id,
       cellId,
       clearedBy,
-      requestedAt: Date.now(),
+      requestedAt,
     }),
 
   // SQL materializers

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -77,6 +77,7 @@ export const tables = {
           "execute_result",
           "stream",
           "error",
+          "clear_output",
         ),
       }),
       data: State.SQLite.json({ schema: Schema.Any }),
@@ -360,6 +361,7 @@ export const events = {
         "execute_result",
         "stream",
         "error",
+        "clear_output",
       ),
       data: Schema.Any,
       metadata: Schema.optional(Schema.Any), // For additional output metadata

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -77,12 +77,22 @@ export const tables = {
           "execute_result",
           "stream",
           "error",
-          "clear_output",
         ),
       }),
       data: State.SQLite.json({ schema: Schema.Any }),
       metadata: State.SQLite.json({ nullable: true, schema: Schema.Any }), // For additional output metadata
       position: State.SQLite.real(),
+    },
+  }),
+
+  // Pending clear output requests (for wait=true semantics)
+  pendingClears: State.SQLite.table({
+    name: "pending_clears",
+    columns: {
+      id: State.SQLite.text({ primaryKey: true }),
+      cellId: State.SQLite.text(),
+      clearedBy: State.SQLite.text(),
+      requestedAt: State.SQLite.real(), // timestamp
     },
   }),
 
@@ -361,7 +371,6 @@ export const events = {
         "execute_result",
         "stream",
         "error",
-        "clear_output",
       ),
       data: Schema.Any,
       metadata: Schema.optional(Schema.Any), // For additional output metadata
@@ -371,6 +380,14 @@ export const events = {
 
   cellOutputsCleared: Events.synced({
     name: "v1.CellOutputsCleared",
+    schema: Schema.Struct({
+      cellId: Schema.String,
+      clearedBy: Schema.String,
+    }),
+  }),
+
+  cellOutputClearPending: Events.synced({
+    name: "v1.CellOutputClearPending",
     schema: Schema.Struct({
       cellId: Schema.String,
       clearedBy: Schema.String,
@@ -602,6 +619,14 @@ const materializers = State.SQLite.materializers(events, {
 
   "v1.CellOutputsCleared": ({ cellId }) =>
     tables.outputs.delete().where({ cellId }),
+
+  "v1.CellOutputClearPending": ({ cellId, clearedBy }) =>
+    tables.pendingClears.insert({
+      id: crypto.randomUUID(),
+      cellId,
+      clearedBy,
+      requestedAt: Date.now(),
+    }),
 
   // SQL materializers
   "v1.SqlConnectionCreated": ({


### PR DESCRIPTION
Draft handling of Jupyter's `clear_output(wait=True)`. Technically `clear_output(wait=False)` is already supported. 