### PR TITLE
Add package.json to schema package for npm/pnpm compatibility

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1033,7 +1033,12 @@
       "packages/schema": {
         "dependencies": [
           "npm:@livestore/livestore@~0.3.1"
-        ]
+        ],
+        "packageJson": {
+          "dependencies": [
+            "npm:@livestore/livestore@~0.3.1"
+          ]
+        }
       }
     }
   }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@runt/schema",
+  "version": "0.2.0",
+  "description": "This package.json is solely here to make linking possible for npm users",
+  "type": "module",
+  "main": "./mod.ts",
+  "types": "./mod.ts",
+  "exports": {
+    ".": {
+      "import": "./mod.ts",
+      "types": "./mod.ts"
+    }
+  },
+  "files": [
+    "mod.ts",
+    "README.md"
+  ],
+  "dependencies": {
+    "@livestore/livestore": "^0.3.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/runtimed/runt.git",
+    "directory": "packages/schema"
+  },
+  "license": "BSD-3-Clause",
+  "keywords": [
+    "anode",
+    "schema",
+    "livestore",
+    "event-sourcing",
+    "typescript"
+  ]
+}


### PR DESCRIPTION
Enables cross-repo development workflows by adding npm/pnpm linking support to the schema package.

## Changes

- Add package.json to packages/schema/
- Enables pnpm link --global for local development
- Maintains JSR as primary publication method

## Benefits

- **Cross-repo development**: Link local schema changes in runt to anode
- **npm ecosystem compatibility**: Works with existing npm/pnpm tooling  
- **Development workflow**: Test schema changes before publishing