### PR TITLE
feat: add notebook export functionality

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,16 @@
+// Project tasks configuration. See https://zed.dev/docs/tasks for documentation.
+//
+// Example:
+[
+  {
+    "label": "Run pyrunt with local .env",
+    "command": "deno run --allow-all --env-file=.env packages/pyodide-runtime-agent/src/mod.ts",
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "reveal_target": "dock",
+    "hide": "never",
+    "shell": "system",
+    "tags": []
+  }
+]

--- a/packages/pyodide-runtime-agent/examples/notebook-export-example.ts
+++ b/packages/pyodide-runtime-agent/examples/notebook-export-example.ts
@@ -1,0 +1,212 @@
+// Notebook Export Example
+//
+// This example demonstrates how to use the notebook export functionality
+// to periodically save your notebook as a .ipynb file compatible with Jupyter.
+
+import { delay } from "jsr:@std/async/delay";
+import { crypto } from "jsr:@std/crypto";
+import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
+import { events } from "@runt/schema";
+
+async function main() {
+  console.log("🚀 Starting Notebook Export Example");
+
+  const notebookId = `example-${crypto.randomUUID()}`;
+  const kernelId = `kernel-${crypto.randomUUID()}`;
+
+  // Create agent with notebook export enabled
+  const agent = new PyodideRuntimeAgent([
+    "--kernel-id",
+    kernelId,
+    "--notebook",
+    notebookId,
+    "--auth-token",
+    "example-token",
+    "--sync-url",
+    "ws://localhost:9999", // In-memory only for example
+  ], {
+    enableNotebookExport: true,
+    exportIntervalMs: 10000, // Export every 10 seconds
+    exportOptions: {
+      includeAiCells: true,
+      includeSqlCells: true,
+      transformSources: true, // Transform AI/SQL cells to Python
+    },
+  });
+
+  try {
+    await agent.start();
+    console.log("✅ Agent started successfully");
+
+    // Initialize notebook
+    const store = agent.store;
+    store.commit(events.notebookInitialized({
+      id: notebookId,
+      title: "Export Example Notebook",
+      ownerId: "example-user",
+    }));
+
+    console.log("📓 Creating example notebook content...");
+
+    // Create a markdown cell
+    store.commit(events.cellCreated({
+      id: "intro-cell",
+      position: 1,
+      cellType: "markdown",
+      createdBy: "example-user",
+    }));
+
+    store.commit(events.cellSourceChanged({
+      id: "intro-cell",
+      source:
+        "# Notebook Export Example\n\nThis notebook demonstrates the export functionality.",
+      modifiedBy: "example-user",
+    }));
+
+    // Create a Python code cell
+    store.commit(events.cellCreated({
+      id: "code-cell",
+      position: 2,
+      cellType: "code",
+      createdBy: "example-user",
+    }));
+
+    store.commit(events.cellSourceChanged({
+      id: "code-cell",
+      source:
+        "import numpy as np\nprint('NumPy version:', np.__version__)\ndata = np.array([1, 2, 3, 4, 5])\nprint('Mean:', data.mean())",
+      modifiedBy: "example-user",
+    }));
+
+    // Create an AI cell
+    store.commit(events.cellCreated({
+      id: "ai-cell",
+      position: 3,
+      cellType: "ai",
+      createdBy: "example-user",
+    }));
+
+    store.commit(events.cellSourceChanged({
+      id: "ai-cell",
+      source: "Explain what this numpy code does in simple terms",
+      modifiedBy: "example-user",
+    }));
+
+    // Create a SQL cell
+    store.commit(events.cellCreated({
+      id: "sql-cell",
+      position: 4,
+      cellType: "sql",
+      createdBy: "example-user",
+    }));
+
+    store.commit(events.cellSourceChanged({
+      id: "sql-cell",
+      source: "SELECT name, age FROM users WHERE age > 21 ORDER BY age;",
+      modifiedBy: "example-user",
+    }));
+
+    // Add some sample outputs
+    store.commit(events.cellOutputAdded({
+      id: "code-output-1",
+      cellId: "code-cell",
+      outputType: "stream",
+      data: { name: "stdout", text: "NumPy version: 1.24.3" },
+      position: 1,
+    }));
+
+    store.commit(events.cellOutputAdded({
+      id: "code-output-2",
+      cellId: "code-cell",
+      outputType: "execute_result",
+      data: { "text/plain": "3.0" },
+      position: 2,
+    }));
+
+    console.log("📝 Notebook content created");
+
+    // Wait for first automatic export
+    console.log("⏳ Waiting for automatic export (10 seconds)...");
+    await delay(12000);
+
+    // Demonstrate manual export
+    console.log("📤 Performing manual export...");
+    const exportPath = await agent.exportNotebook("manual-export.ipynb", {
+      includeAiCells: true,
+      includeSqlCells: true,
+      transformSources: true,
+    });
+
+    if (exportPath) {
+      console.log(`✅ Manual export completed: ${exportPath}`);
+
+      // Show the exported content
+      try {
+        const content = await Deno.readTextFile(exportPath);
+        const notebook = JSON.parse(content);
+
+        console.log("\n📋 Exported notebook summary:");
+        console.log(
+          `   Format: Jupyter Notebook v${notebook.nbformat}.${notebook.nbformat_minor}`,
+        );
+        console.log(`   Kernel: ${notebook.metadata.kernelspec.display_name}`);
+        console.log(`   Cells: ${notebook.cells.length}`);
+        console.log(`   Export time: ${notebook.metadata.runt?.exported_at}`);
+
+        console.log("\n🔍 Cell types in exported notebook:");
+        notebook.cells.forEach((cell: Record<string, unknown>, i: number) => {
+          const sourcePreview = Array.isArray(cell.source)
+            ? cell.source[0]?.substring(0, 50) + "..."
+            : String(cell.source).substring(0, 50) + "...";
+          console.log(`   ${i + 1}. ${cell.cell_type}: ${sourcePreview}`);
+        });
+
+        // Show how AI and SQL cells were transformed
+        const transformedCells = notebook.cells.filter((
+          cell: Record<string, unknown>,
+        ) =>
+          Array.isArray(cell.source) &&
+          cell.source.some((line: string) =>
+            line.includes("chat(") || line.includes("sql(")
+          )
+        );
+
+        if (transformedCells.length > 0) {
+          console.log("\n🔄 Transformed cells (AI/SQL → Python):");
+          transformedCells.forEach(
+            (cell: Record<string, unknown>, i: number) => {
+              const source = Array.isArray(cell.source)
+                ? cell.source.join("")
+                : cell.source;
+              console.log(`   ${i + 1}. ${source}`);
+            },
+          );
+        }
+      } catch (error) {
+        console.error("❌ Failed to read exported file:", error);
+      }
+    }
+
+    // Wait a bit more to see periodic export in action
+    console.log("\n⏳ Waiting for another automatic export...");
+    await delay(15000);
+
+    console.log("\n✅ Example completed successfully!");
+    console.log("\n💡 Key features demonstrated:");
+    console.log("   • Automatic periodic export every 10 seconds");
+    console.log("   • Manual export on demand");
+    console.log("   • AI cells transformed to chat() Python calls");
+    console.log("   • SQL cells transformed to sql() Python calls");
+    console.log("   • Full Jupyter notebook compatibility");
+    console.log("   • Preserved outputs and metadata");
+  } catch (error) {
+    console.error("❌ Example failed:", error);
+  } finally {
+    await agent.shutdown();
+    console.log("🛑 Agent shutdown complete");
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/packages/pyodide-runtime-agent/src/lib.ts
+++ b/packages/pyodide-runtime-agent/src/lib.ts
@@ -6,6 +6,13 @@
 
 export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 
+// Export notebook export functionality
+export {
+  exportNotebook,
+  type ExportOptions,
+  NotebookExporter,
+} from "./notebook-exporter.ts";
+
 // Export cache utilities for advanced package management
 export {
   getCacheConfig,

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -11,6 +11,14 @@ import { createLogger } from "@runt/lib";
 
 // Re-export library components for when used as a module
 export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
+
+// Export notebook export functionality
+export {
+  exportNotebook,
+  type ExportOptions,
+  NotebookExporter,
+} from "./notebook-exporter.ts";
+
 export {
   getCacheConfig,
   getCacheDir,

--- a/packages/pyodide-runtime-agent/src/notebook-exporter.ts
+++ b/packages/pyodide-runtime-agent/src/notebook-exporter.ts
@@ -1,0 +1,640 @@
+// Notebook Export Utility
+//
+// This module provides functionality to export LiveStore notebook data
+// to standard Jupyter notebook (.ipynb) format for compatibility and sharing.
+
+import type { Store } from "npm:@livestore/livestore";
+import { type CellData, type OutputData, schema, tables } from "@runt/schema";
+import { createLogger } from "@runt/lib";
+
+const logger = createLogger("notebook-exporter");
+
+/**
+ * Jupyter notebook JSON schema for validation
+ * Based on nbformat v4.5 schema
+ */
+
+/**
+ * Jupyter notebook cell structure
+ */
+interface JupyterCell {
+  cell_type: "code" | "markdown" | "raw";
+  metadata: Record<string, unknown>;
+  source: string[];
+  id?: string;
+  execution_count?: number | null;
+  outputs?: JupyterOutput[];
+}
+
+/**
+ * Jupyter notebook output structure
+ */
+interface JupyterOutput {
+  output_type: "execute_result" | "display_data" | "stream" | "error";
+  data?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  execution_count?: number | null;
+  name?: "stdout" | "stderr";
+  text?: string | string[];
+  ename?: string;
+  evalue?: string;
+  traceback?: string[];
+}
+
+/**
+ * Complete Jupyter notebook structure
+ */
+interface JupyterNotebook {
+  nbformat: 4;
+  nbformat_minor: 4;
+  metadata: {
+    kernelspec: {
+      display_name: string;
+      language: string;
+      name: string;
+    };
+    language_info: {
+      name: string;
+      version: string;
+    };
+    runt?: {
+      notebook_id: string;
+      exported_at: string;
+      kernel_type: string;
+    };
+  };
+  cells: JupyterCell[];
+}
+
+/**
+ * Export configuration options
+ */
+export interface ExportOptions {
+  /** Include AI cells as Python cells with chat() wrapper */
+  includeAiCells?: boolean;
+  /** Include SQL cells as Python cells with sql() wrapper */
+  includeSqlCells?: boolean;
+  /** Transform cell sources for compatibility */
+  transformSources?: boolean;
+}
+
+/**
+ * Converts LiveStore notebook data to Jupyter notebook format
+ */
+export class NotebookExporter {
+  private store: Store<typeof schema>;
+  private notebookId: string;
+
+  constructor(store: Store<typeof schema>, notebookId: string) {
+    this.store = store;
+    this.notebookId = notebookId;
+  }
+
+  /**
+   * Export the notebook to .ipynb format
+   */
+  exportNotebook(options: ExportOptions = {}): JupyterNotebook {
+    const {
+      includeAiCells = true,
+      includeSqlCells = true,
+      transformSources = true,
+    } = options;
+
+    // Get notebook metadata
+    const notebook = this.store.query(
+      tables.notebook.select().where({ id: this.notebookId }),
+    )[0];
+
+    if (!notebook) {
+      throw new Error(`Notebook ${this.notebookId} not found`);
+    }
+
+    // Get all cells ordered by position
+    const cells = this.store.query(
+      tables.cells.select().orderBy("position", "asc"),
+    ) as CellData[];
+
+    const jupyterCells: JupyterCell[] = [];
+
+    for (const cell of cells) {
+      // Skip cells based on options
+      if (!includeAiCells && cell.cellType === "ai") continue;
+      if (!includeSqlCells && cell.cellType === "sql") continue;
+
+      const jupyterCell = this.convertCell(cell, transformSources);
+      if (jupyterCell) {
+        jupyterCells.push(jupyterCell);
+      }
+    }
+
+    // Get the active kernel type from kernel sessions
+    const activeKernelSessions = this.store.query(
+      tables.kernelSessions.select().where({ isActive: true }),
+    );
+    const kernelType = activeKernelSessions.length > 0
+      ? activeKernelSessions[0]!.kernelType
+      : notebook.kernelType;
+
+    const notebookData = {
+      nbformat: 4 as const,
+      nbformat_minor: 4 as const,
+      metadata: {
+        kernelspec: {
+          display_name: this.getKernelDisplayName(kernelType),
+          language: this.getKernelLanguage(kernelType),
+          name: kernelType,
+        },
+        language_info: {
+          name: this.getKernelLanguage(kernelType),
+          version: "3.11", // Default Python version for Pyodide
+        },
+        runt: {
+          notebook_id: this.notebookId,
+          exported_at: new Date().toISOString(),
+          kernel_type: kernelType,
+          sync_url: this.getSyncUrl(),
+        },
+      },
+      cells: jupyterCells,
+    };
+
+    // Validate the notebook against Jupyter schema
+    try {
+      this.validateNotebook(notebookData);
+      logger.debug("Notebook passed schema validation", {
+        notebookId: this.notebookId,
+      });
+    } catch (error) {
+      logger.warn("Notebook failed schema validation", {
+        error: error instanceof Error ? error.message : String(error),
+        notebookId: this.notebookId,
+      });
+    }
+
+    return notebookData;
+  }
+
+  /**
+   * Convert a LiveStore cell to Jupyter cell format
+   */
+  private convertCell(
+    cell: CellData,
+    transformSources: boolean,
+  ): JupyterCell | null {
+    const baseCell = {
+      id: cell.id,
+      metadata: {
+        runt: {
+          cell_type: cell.cellType,
+          execution_state: cell.executionState,
+          created_by: cell.createdBy,
+        },
+      },
+    };
+
+    // Convert source to array of lines with proper newlines
+    const sourceLines = this.formatSourceLines(cell.source);
+
+    switch (cell.cellType) {
+      case "code": {
+        const codeCell: JupyterCell = {
+          ...baseCell,
+          cell_type: "code",
+          source: sourceLines,
+          execution_count: cell.executionCount,
+          outputs: this.convertOutputs(cell.id),
+        };
+        return codeCell;
+      }
+
+      case "markdown": {
+        const markdownCell: JupyterCell = {
+          ...baseCell,
+          cell_type: "markdown",
+          source: sourceLines,
+        };
+        return markdownCell;
+      }
+
+      case "raw": {
+        const rawCell: JupyterCell = {
+          ...baseCell,
+          cell_type: "raw",
+          source: sourceLines,
+        };
+        return rawCell;
+      }
+
+      case "ai": {
+        if (!transformSources) {
+          // Return as markdown cell with AI marker
+          return {
+            ...baseCell,
+            cell_type: "markdown",
+            source: [`**AI Cell:**\n`, ...sourceLines],
+            metadata: {
+              ...baseCell.metadata,
+              tags: ["ai-cell"],
+            },
+          };
+        }
+
+        // Check if cell is empty - if so, keep as empty code cell
+        logger.debug("Processing AI cell", {
+          cellId: cell.id,
+          sourceLength: cell.source.length,
+          sourceTrimmed: cell.source.trim().length,
+          isEmpty: !cell.source.trim(),
+        });
+
+        if (!cell.source.trim()) {
+          logger.debug("AI cell is empty, keeping as empty code cell", {
+            cellId: cell.id,
+          });
+          return {
+            ...baseCell,
+            cell_type: "code",
+            source: [""],
+            execution_count: cell.executionCount,
+            outputs: this.convertOutputs(cell.id),
+          };
+        }
+
+        // Transform to Python code cell with chat() wrapper
+        const escapedSource = cell.source.replace(/"""/g, '\\"\\"\\"');
+        const wrappedSource = `chat("""${escapedSource}""")`;
+
+        logger.debug("Transforming AI cell to chat() wrapper", {
+          cellId: cell.id,
+          originalSource: cell.source,
+          wrappedSource: wrappedSource,
+        });
+
+        const aiCell: JupyterCell = {
+          ...baseCell,
+          cell_type: "code",
+          source: [wrappedSource],
+          execution_count: cell.executionCount,
+          outputs: this.convertOutputs(cell.id),
+        };
+        return aiCell;
+      }
+
+      case "sql": {
+        if (!transformSources) {
+          // Return as markdown cell with SQL marker
+          return {
+            ...baseCell,
+            cell_type: "markdown",
+            source: [`**SQL Cell:**\n\`\`\`sql\n`, ...sourceLines, `\n\`\`\``],
+            metadata: {
+              ...baseCell.metadata,
+              tags: ["sql-cell"],
+            },
+          };
+        }
+
+        // Check if cell is empty - if so, keep as empty code cell
+        if (!cell.source.trim()) {
+          return {
+            ...baseCell,
+            cell_type: "code",
+            source: [""],
+            execution_count: cell.executionCount,
+            outputs: this.convertOutputs(cell.id),
+          };
+        }
+
+        // Transform to Python code cell with sql() wrapper
+        const escapedSource = cell.source.replace(/"""/g, '\\"\\"\\"');
+        const wrappedSource = `sql("""${escapedSource}""")`;
+
+        const sqlCell: JupyterCell = {
+          ...baseCell,
+          cell_type: "code",
+          source: [wrappedSource],
+          execution_count: cell.executionCount,
+          outputs: this.convertOutputs(cell.id),
+        };
+        return sqlCell;
+      }
+
+      default:
+        logger.warn(`Unknown cell type: ${cell.cellType}`);
+        return null;
+    }
+  }
+
+  /**
+   * Convert LiveStore outputs to Jupyter outputs
+   */
+  private convertOutputs(cellId: string): JupyterOutput[] {
+    const outputs = this.store.query(
+      tables.outputs
+        .select()
+        .where({ cellId })
+        .orderBy("position", "asc"),
+    ) as OutputData[];
+
+    return outputs.map((output): JupyterOutput => {
+      switch (output.outputType) {
+        case "execute_result":
+        case "display_data": {
+          const result = {
+            output_type: output.outputType,
+            data: output.data as Record<string, unknown>,
+            metadata: output.metadata || {},
+          } as JupyterOutput;
+
+          if (output.outputType === "execute_result") {
+            result.execution_count = this.getExecutionCount(cellId);
+          }
+
+          return result;
+        }
+
+        case "stream": {
+          const streamData = output.data as { name: string; text: string };
+          return {
+            output_type: "stream",
+            name: streamData.name as "stdout" | "stderr",
+            text: streamData.text.split("\n"),
+          };
+        }
+
+        case "error": {
+          const errorData = output.data as {
+            ename: string;
+            evalue: string;
+            traceback?: string[];
+          };
+          return {
+            output_type: "error",
+            ename: errorData.ename,
+            evalue: errorData.evalue,
+            traceback: errorData.traceback || [],
+          };
+        }
+
+        default:
+          logger.warn(`Unknown output type: ${output.outputType}`);
+          return {
+            output_type: "display_data",
+            data: { "text/plain": String(output.data) },
+            metadata: {},
+          };
+      }
+    });
+  }
+
+  /**
+   * Get execution count for a cell
+   */
+  private getExecutionCount(cellId: string): number | null {
+    const cell = this.store.query(
+      tables.cells.select().where({ id: cellId }),
+    )[0] as CellData;
+
+    return cell?.executionCount || null;
+  }
+
+  /**
+   * Get kernel display name from kernel type
+   */
+  private getKernelDisplayName(kernelType: string): string {
+    switch (kernelType) {
+      case "python3-pyodide":
+        return "Python 3 (Pyodide)";
+      case "python3":
+        return "Python 3";
+      default:
+        return kernelType;
+    }
+  }
+
+  /**
+   * Get kernel language from kernel type
+   */
+  private getKernelLanguage(kernelType: string): string {
+    if (kernelType.startsWith("python")) {
+      return "python";
+    }
+    return "python"; // Default to python for now
+  }
+
+  /**
+   * Write notebook to file
+   */
+  async writeToFile(
+    filePath: string,
+    options: ExportOptions = {},
+  ): Promise<void> {
+    try {
+      logger.debug("Starting notebook export process", {
+        filePath,
+        options,
+        notebookId: this.notebookId,
+      });
+
+      const notebook = this.exportNotebook(options);
+
+      logger.debug("Notebook structure created", {
+        cellCount: notebook.cells.length,
+        notebookId: this.notebookId,
+        kernelType: notebook.metadata.kernelspec.name,
+      });
+
+      const content = JSON.stringify(notebook, null, 2);
+
+      logger.debug("JSON content generated", {
+        contentLength: content.length,
+        filePath,
+        notebookId: this.notebookId,
+      });
+
+      await Deno.writeTextFile(filePath, content);
+
+      logger.info("Notebook exported successfully", {
+        filePath,
+        cellCount: notebook.cells.length,
+        notebookId: this.notebookId,
+      });
+    } catch (error) {
+      logger.error("Failed to write notebook file", {
+        filePath,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        notebookId: this.notebookId,
+      });
+      console.error("Raw writeToFile error:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Generate a filename based on notebook metadata
+   */
+  generateFilename(): string {
+    try {
+      logger.debug("Generating filename", {
+        notebookId: this.notebookId,
+      });
+
+      const notebook = this.store.query(
+        tables.notebook.select().where({ id: this.notebookId }),
+      )[0];
+
+      logger.debug("Notebook query result for filename", {
+        notebookFound: !!notebook,
+        notebookTitle: notebook?.title,
+        notebookId: this.notebookId,
+      });
+
+      if (!notebook) {
+        // Use storeId (notebookId) as the filename since it's the actual identifier
+        const filename = `${this.notebookId}.ipynb`;
+        logger.debug("No notebook found, using storeId", { filename });
+        return filename;
+      }
+
+      // Sanitize title for filename
+      const sanitizedTitle = notebook.title
+        .replace(/[^a-zA-Z0-9\-_\s]/g, "")
+        .replace(/\s+/g, "-")
+        .toLowerCase();
+
+      logger.debug("Title sanitization", {
+        originalTitle: notebook.title,
+        sanitizedTitle: sanitizedTitle,
+      });
+
+      const filename = sanitizedTitle && sanitizedTitle !== "untitled-notebook"
+        ? `${sanitizedTitle}.ipynb`
+        : `${this.notebookId}.ipynb`;
+
+      logger.debug("Final filename decision", { filename });
+      return filename;
+    } catch (error) {
+      // Fallback if store query fails - use storeId
+      logger.debug("Failed to query notebook for filename, using storeId", {
+        notebookId: this.notebookId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return `${this.notebookId}.ipynb`;
+    }
+  }
+
+  /**
+   * Format source code into proper Jupyter notebook format
+   * Each line should end with \n except the last line
+   */
+  private formatSourceLines(source: string): string[] {
+    if (!source) return [""];
+
+    const lines = source.split("\n");
+    return lines.map((line, index) => {
+      // Add newline to all lines except the last one
+      return index < lines.length - 1 ? line + "\n" : line;
+    });
+  }
+
+  /**
+   * Get sync URL from environment or return empty string
+   */
+  private getSyncUrl(): string {
+    try {
+      return Deno.env.get("LIVESTORE_SYNC_URL") || "";
+    } catch {
+      return "";
+    }
+  }
+
+  /**
+   * Validate notebook against Jupyter schema
+   */
+  private validateNotebook(notebook: JupyterNotebook): void {
+    // Basic validation - ensure required fields exist
+    if (!notebook.nbformat || notebook.nbformat !== 4) {
+      throw new Error("Invalid nbformat: must be 4");
+    }
+
+    if (!notebook.nbformat_minor || notebook.nbformat_minor < 4) {
+      throw new Error("Invalid nbformat_minor: must be >= 4");
+    }
+
+    if (!notebook.metadata?.kernelspec?.name) {
+      throw new Error("Missing required kernelspec.name in metadata");
+    }
+
+    if (!notebook.metadata?.kernelspec?.display_name) {
+      throw new Error("Missing required kernelspec.display_name in metadata");
+    }
+
+    if (!notebook.metadata?.language_info?.name) {
+      throw new Error("Missing required language_info.name in metadata");
+    }
+
+    if (!Array.isArray(notebook.cells)) {
+      throw new Error("Cells must be an array");
+    }
+
+    // Validate each cell
+    for (const [index, cell] of notebook.cells.entries()) {
+      this.validateCell(cell, index);
+    }
+
+    logger.debug("Notebook validation passed", {
+      cellCount: notebook.cells.length,
+      notebookId: this.notebookId,
+    });
+  }
+
+  /**
+   * Validate individual cell structure
+   */
+  private validateCell(cell: JupyterCell, index: number): void {
+    if (!cell.id) {
+      throw new Error(`Cell ${index}: missing required id`);
+    }
+
+    if (!["code", "markdown", "raw"].includes(cell.cell_type)) {
+      throw new Error(`Cell ${index}: invalid cell_type ${cell.cell_type}`);
+    }
+
+    if (!cell.metadata) {
+      throw new Error(`Cell ${index}: missing required metadata`);
+    }
+
+    if (!Array.isArray(cell.source)) {
+      throw new Error(`Cell ${index}: source must be an array of strings`);
+    }
+
+    // Validate code cell specific requirements
+    if (cell.cell_type === "code") {
+      if (!("execution_count" in cell)) {
+        throw new Error(`Cell ${index}: code cells must have execution_count`);
+      }
+
+      if (!("outputs" in cell) || !Array.isArray(cell.outputs)) {
+        throw new Error(`Cell ${index}: code cells must have outputs array`);
+      }
+    }
+  }
+}
+
+/**
+ * Utility function to create and export a notebook
+ */
+export async function exportNotebook(
+  store: Store<typeof schema>,
+  notebookId: string,
+  filePath?: string,
+  options: ExportOptions = {},
+): Promise<string> {
+  const exporter = new NotebookExporter(store, notebookId);
+
+  const outputPath = filePath || exporter.generateFilename();
+  await exporter.writeToFile(outputPath, options);
+
+  return outputPath;
+}

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -27,6 +27,7 @@ import {
   tables,
 } from "@runt/schema";
 import { OpenAIClient } from "./openai-client.ts";
+import { type ExportOptions, NotebookExporter } from "./notebook-exporter.ts";
 import stripAnsi from "npm:strip-ansi";
 
 /**
@@ -55,6 +56,12 @@ export interface NotebookContextData {
 export interface PyodideAgentOptions {
   /** Custom package list to load (overrides default essential packages) */
   packages?: string[];
+  /** Enable periodic notebook export */
+  enableNotebookExport?: boolean;
+  /** Export interval in milliseconds (default: 30 seconds) */
+  exportIntervalMs?: number;
+  /** Export options */
+  exportOptions?: ExportOptions;
 }
 
 /**
@@ -78,6 +85,8 @@ export class PyodideRuntimeAgent {
   public config: ReturnType<typeof createRuntimeConfig>;
   private options: PyodideAgentOptions;
   private openaiClient: OpenAIClient | null = null;
+  private notebookExporter?: NotebookExporter;
+  private exportTimer: ReturnType<typeof setInterval> | undefined = undefined;
 
   constructor(args: string[] = Deno.args, options: PyodideAgentOptions = {}) {
     try {
@@ -124,12 +133,27 @@ export class PyodideRuntimeAgent {
   async start(): Promise<void> {
     this.logger.info("Starting Pyodide Python runtime agent");
     await this.agent.start();
+
+    // Initialize notebook exporter after agent starts and LiveStore is ready
+    if (this.options.enableNotebookExport !== false) {
+      this.notebookExporter = new NotebookExporter(
+        this.agent.liveStore,
+        this.config.notebookId,
+      );
+    }
+
+    // Start periodic notebook export if enabled
+    if (this.notebookExporter) {
+      this.startPeriodicExport();
+    }
   }
 
   /**
    * Shutdown the runtime agent
    */
   async shutdown(): Promise<void> {
+    // Stop periodic export
+    this.stopPeriodicExport();
     await this.agent.shutdown();
   }
 
@@ -1146,6 +1170,164 @@ Remember: Users want working code in their notebook, not explanations about code
    */
   private stripAnsi(text: string): string {
     return stripAnsi(text);
+  }
+
+  /**
+   * Start periodic notebook export
+   */
+  private startPeriodicExport(): void {
+    if (!this.notebookExporter) return;
+
+    const intervalMs = this.options.exportIntervalMs || 10000; // Default 10 seconds
+
+    this.logger.info("Starting periodic notebook export", {
+      intervalMs,
+      notebookId: this.config.notebookId,
+    });
+
+    // Export immediately on start
+    this.performExport();
+
+    // Set up periodic export
+    this.exportTimer = setInterval(() => {
+      this.performExport();
+    }, intervalMs);
+  }
+
+  /**
+   * Stop periodic notebook export
+   */
+  private stopPeriodicExport(): void {
+    if (this.exportTimer) {
+      clearInterval(this.exportTimer);
+      this.exportTimer = undefined;
+      this.logger.info("Stopped periodic notebook export");
+    }
+  }
+
+  /**
+   * Perform notebook export
+   */
+  private async performExport(): Promise<void> {
+    if (!this.notebookExporter) {
+      this.logger.error("Notebook exporter not initialized");
+      return;
+    }
+
+    try {
+      this.logger.debug("Starting notebook export", {
+        notebookId: this.config.notebookId,
+      });
+
+      // Check if notebook exists before trying to export
+      const notebook = this.store.query(
+        tables.notebook.select().where({ id: this.config.notebookId }),
+      )[0];
+
+      this.logger.debug("Notebook query result", {
+        notebookFound: !!notebook,
+        notebookId: this.config.notebookId,
+        notebookTitle: notebook?.title,
+      });
+
+      if (!notebook) {
+        this.logger.debug("Notebook not initialized yet, skipping export", {
+          notebookId: this.config.notebookId,
+        });
+        return;
+      }
+
+      // Check cells
+      const cells = this.store.query(
+        tables.cells.select().orderBy("position", "asc"),
+      );
+      this.logger.debug("Found cells for export", {
+        cellCount: cells.length,
+        notebookId: this.config.notebookId,
+      });
+
+      let filename: string;
+      try {
+        filename = this.notebookExporter.generateFilename();
+        this.logger.debug("Generated filename", {
+          filename,
+          notebookId: this.config.notebookId,
+        });
+      } catch (error) {
+        this.logger.error("Failed to generate filename, using fallback", {
+          error: error instanceof Error ? error.message : String(error),
+          notebookId: this.config.notebookId,
+        });
+        filename = `${this.config.notebookId}.ipynb`;
+      }
+
+      const exportOptions = this.options.exportOptions || {
+        includeAiCells: true,
+        includeSqlCells: true,
+        transformSources: true,
+      };
+
+      this.logger.debug("Export options", {
+        exportOptions,
+        notebookId: this.config.notebookId,
+      });
+
+      await this.notebookExporter.writeToFile(filename, exportOptions);
+
+      this.logger.info("Notebook exported successfully", {
+        filename,
+        cellCount: cells.length,
+        notebookId: this.config.notebookId,
+      });
+    } catch (error) {
+      this.logger.error("Failed to export notebook", {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        errorName: error instanceof Error ? error.name : typeof error,
+        notebookId: this.config.notebookId,
+      });
+
+      // Log the raw error object for debugging
+      console.error("Raw export error:", error);
+    }
+  }
+
+  /**
+   * Manually trigger notebook export
+   */
+  public async exportNotebook(
+    filePath?: string,
+    options?: ExportOptions,
+  ): Promise<string | null> {
+    if (!this.notebookExporter) {
+      this.logger.warn("Notebook exporter not initialized");
+      return null;
+    }
+
+    try {
+      const filename = filePath || this.notebookExporter.generateFilename();
+      const exportOptions = options || this.options.exportOptions || {
+        includeAiCells: true,
+        includeSqlCells: true,
+        transformSources: true,
+      };
+
+      await this.notebookExporter.writeToFile(filename, exportOptions);
+
+      this.logger.info("Manual notebook export completed", {
+        filename,
+        notebookId: this.config.notebookId,
+      });
+
+      return filename;
+    } catch (error) {
+      this.logger.error("Failed to manually export notebook", {
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        notebookId: this.config.notebookId,
+      });
+      throw error;
+    }
   }
 }
 

--- a/packages/pyodide-runtime-agent/test/notebook-export.test.ts
+++ b/packages/pyodide-runtime-agent/test/notebook-export.test.ts
@@ -1,0 +1,459 @@
+// Notebook Export Tests
+//
+// Tests for the notebook export functionality that converts LiveStore
+// notebook data to standard Jupyter notebook (.ipynb) format.
+
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import { delay } from "jsr:@std/async/delay";
+import { crypto } from "jsr:@std/crypto";
+import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
+import { events } from "@runt/schema";
+import { NotebookExporter } from "../src/notebook-exporter.ts";
+
+Deno.test({
+  name: "NotebookExporter - Export Functionality",
+  sanitizeOps: false,
+  sanitizeResources: false,
+}, async (t) => {
+  let agent: PyodideRuntimeAgent | undefined;
+  let exporter: NotebookExporter | undefined;
+  const notebookId = crypto.randomUUID();
+
+  try {
+    await t.step("setup test agent and data", async () => {
+      const kernelId = `kernel-${crypto.randomUUID()}`;
+
+      const agentArgs = [
+        "--kernel-id",
+        kernelId,
+        "--notebook",
+        notebookId,
+        "--auth-token",
+        "test-token",
+        "--sync-url",
+        "ws://localhost:9999", // In-memory only
+      ];
+
+      agent = new PyodideRuntimeAgent(agentArgs, {
+        enableNotebookExport: false, // Disable automatic export for testing
+      });
+
+      await agent.start();
+      await delay(500); // Give it time to initialize
+
+      const store = agent.store;
+
+      // Initialize notebook
+      store.commit(events.notebookInitialized({
+        id: notebookId,
+        title: "Test Notebook",
+        ownerId: "test-user",
+      }));
+
+      // Note: kernel type is set during kernel session start
+
+      // Create test cells
+      store.commit(events.cellCreated({
+        id: "cell-1",
+        position: 1,
+        cellType: "markdown",
+        createdBy: "test-user",
+      }));
+
+      store.commit(events.cellSourceChanged({
+        id: "cell-1",
+        source: "# Test Notebook\n\nThis is a test markdown cell.",
+        modifiedBy: "test-user",
+      }));
+
+      store.commit(events.cellCreated({
+        id: "cell-2",
+        position: 2,
+        cellType: "code",
+        createdBy: "test-user",
+      }));
+
+      store.commit(events.cellSourceChanged({
+        id: "cell-2",
+        source: "print('Hello, World!')\nx = 42\nprint(f'The answer is {x}')",
+        modifiedBy: "test-user",
+      }));
+
+      // Note: execution count is tracked through execution events
+
+      store.commit(events.cellCreated({
+        id: "cell-3",
+        position: 3,
+        cellType: "ai",
+        createdBy: "test-user",
+      }));
+
+      store.commit(events.cellSourceChanged({
+        id: "cell-3",
+        source: "What is the meaning of life?",
+        modifiedBy: "test-user",
+      }));
+
+      // Note: execution count is tracked through execution events
+
+      store.commit(events.cellCreated({
+        id: "cell-4",
+        position: 4,
+        cellType: "sql",
+        createdBy: "test-user",
+      }));
+
+      store.commit(events.cellSourceChanged({
+        id: "cell-4",
+        source: "SELECT * FROM users WHERE active = 1;",
+        modifiedBy: "test-user",
+      }));
+
+      // Note: execution count is tracked through execution events
+
+      // Create some outputs for the code cell
+      store.commit(events.cellOutputAdded({
+        id: "output-1",
+        cellId: "cell-2",
+        outputType: "stream",
+        data: { name: "stdout", text: "Hello, World!" },
+        position: 1,
+      }));
+
+      store.commit(events.cellOutputAdded({
+        id: "output-2",
+        cellId: "cell-2",
+        outputType: "execute_result",
+        data: { "text/plain": "42" },
+        position: 2,
+      }));
+
+      // Create outputs for AI cell
+      store.commit(events.cellOutputAdded({
+        id: "output-3",
+        cellId: "cell-3",
+        outputType: "display_data",
+        data: { "text/markdown": "The meaning of life is **42**!" },
+        position: 1,
+      }));
+
+      exporter = new NotebookExporter(store, notebookId);
+    });
+
+    await t.step("should export basic notebook structure", () => {
+      if (!exporter) throw new Error("Exporter not initialized");
+
+      const notebook = exporter.exportNotebook();
+
+      assertEquals(notebook.nbformat, 4);
+      assertEquals(notebook.nbformat_minor, 4);
+      assertEquals(notebook.metadata.kernelspec.name, "python3-pyodide");
+      assertEquals(notebook.metadata.kernelspec.language, "python");
+      assertEquals(notebook.metadata.runt?.notebook_id, notebookId);
+      assertExists(notebook.metadata.runt?.exported_at);
+    });
+
+    await t.step("should convert cells correctly", () => {
+      if (!exporter) throw new Error("Exporter not initialized");
+
+      const notebook = exporter.exportNotebook();
+
+      assertEquals(notebook.cells.length, 4);
+
+      // Check markdown cell
+      const markdownCell = notebook.cells[0];
+      assertExists(markdownCell);
+      assertEquals(markdownCell.cell_type, "markdown");
+      assertEquals(markdownCell.id, "cell-1");
+      assertEquals(markdownCell.source[0], "# Test Notebook\n");
+
+      // Check code cell
+      const codeCell = notebook.cells[1];
+      assertExists(codeCell);
+      assertEquals(codeCell.cell_type, "code");
+      assertEquals(codeCell.id, "cell-2");
+      assertEquals(codeCell.execution_count, null); // No execution count set in test
+      assertEquals(codeCell.source[0], "print('Hello, World!')\n");
+      assertEquals(codeCell.outputs?.length, 2);
+
+      // Check outputs
+      const streamOutput = codeCell.outputs?.[0];
+      assertEquals(streamOutput?.output_type, "stream");
+      assertEquals(
+        (streamOutput as { name?: string })?.name,
+        "stdout",
+      );
+
+      const executeResultOutput = codeCell.outputs?.[1];
+      assertEquals(executeResultOutput?.output_type, "execute_result");
+      assertEquals(
+        (executeResultOutput as { data?: Record<string, unknown> })?.data
+          ?.["text/plain"],
+        "42",
+      );
+    });
+
+    await t.step(
+      "should transform AI cells to Python with chat() wrapper",
+      () => {
+        if (!exporter) throw new Error("Exporter not initialized");
+
+        const notebook = exporter.exportNotebook({
+          transformSources: true,
+        });
+
+        const aiCell = notebook.cells[2];
+        assertExists(aiCell);
+        assertEquals(aiCell.cell_type, "code");
+        assertEquals(
+          aiCell.source[0],
+          `chat("""What is the meaning of life?""")`,
+        );
+        assertEquals(aiCell.execution_count, null); // No execution count set
+        assertEquals(aiCell.outputs?.length, 1);
+      },
+    );
+
+    await t.step(
+      "should transform SQL cells to Python with sql() wrapper",
+      () => {
+        if (!exporter) throw new Error("Exporter not initialized");
+
+        const notebook = exporter.exportNotebook({
+          transformSources: true,
+        });
+
+        const sqlCell = notebook.cells[3];
+        assertExists(sqlCell);
+        assertEquals(sqlCell.cell_type, "code");
+        assertEquals(
+          sqlCell.source[0],
+          `sql("""SELECT * FROM users WHERE active = 1;""")`,
+        );
+        assertEquals(sqlCell.execution_count, null); // No execution count set
+      },
+    );
+
+    await t.step(
+      "should preserve AI cells as markdown when not transforming",
+      () => {
+        if (!exporter) throw new Error("Exporter not initialized");
+
+        const notebook = exporter.exportNotebook({
+          transformSources: false,
+        });
+
+        const aiCell = notebook.cells[2];
+        assertExists(aiCell);
+        assertEquals(aiCell.cell_type, "markdown");
+        assertEquals(aiCell.source[0], "**AI Cell:**\n");
+        assertEquals(aiCell.source[1], "What is the meaning of life?");
+        assertEquals(
+          (aiCell.metadata as { tags?: string[] })?.tags,
+          [
+            "ai-cell",
+          ],
+        );
+      },
+    );
+
+    await t.step("should exclude AI cells when configured", () => {
+      if (!exporter) throw new Error("Exporter not initialized");
+
+      const notebook = exporter.exportNotebook({ includeAiCells: false });
+
+      assertEquals(notebook.cells.length, 3);
+
+      // Should not contain AI cell
+      const hasChatWrapper = notebook.cells.some((cell) =>
+        cell.source.some((line) =>
+          typeof line === "string" && line.includes("chat(")
+        )
+      );
+      assertEquals(hasChatWrapper, false);
+    });
+
+    await t.step("should exclude SQL cells when configured", () => {
+      if (!exporter) throw new Error("Exporter not initialized");
+
+      const notebook = exporter.exportNotebook({
+        includeSqlCells: false,
+      });
+
+      assertEquals(notebook.cells.length, 3);
+
+      // Should not contain SQL cell
+      const hasSqlWrapper = notebook.cells.some((cell) =>
+        cell.source.some((line) =>
+          typeof line === "string" && line.includes("sql(")
+        )
+      );
+      assertEquals(hasSqlWrapper, false);
+    });
+
+    await t.step("should generate appropriate filename", () => {
+      if (!exporter) throw new Error("Exporter not initialized");
+
+      const filename = exporter.generateFilename();
+      assertEquals(filename, "test-notebook.ipynb");
+    });
+
+    await t.step("should handle special characters in title", () => {
+      if (!agent) throw new Error("Agent not initialized");
+
+      const store = agent.store;
+
+      // Change notebook title with special characters
+      store.commit(events.notebookTitleChanged({
+        title: "My Awesome Notebook! (with special chars)",
+      }));
+
+      if (!exporter) throw new Error("Exporter not initialized");
+
+      const filename = exporter.generateFilename();
+      assertEquals(filename, "my-awesome-notebook-with-special-chars.ipynb");
+    });
+
+    await t.step("should write to file", async () => {
+      if (!exporter) throw new Error("Exporter not initialized");
+
+      const tempFile = await Deno.makeTempFile({ suffix: ".ipynb" });
+
+      try {
+        await exporter.writeToFile(tempFile);
+
+        const content = await Deno.readTextFile(tempFile);
+        const parsed = JSON.parse(content);
+
+        assertEquals(parsed.nbformat, 4);
+        assertEquals(parsed.cells.length, 4);
+        assertExists(parsed.metadata.runt);
+      } finally {
+        await Deno.remove(tempFile);
+      }
+    });
+
+    await t.step("should handle cells with complex outputs", () => {
+      if (!agent || !exporter) {
+        throw new Error("Agent/Exporter not initialized");
+      }
+
+      const store = agent.store;
+
+      // Add a cell with rich display data
+      store.commit(events.cellCreated({
+        id: "rich-cell",
+        position: 5,
+        cellType: "code",
+        createdBy: "test-user",
+      }));
+
+      store.commit(events.cellSourceChanged({
+        id: "rich-cell",
+        source: "import matplotlib.pyplot as plt\nplt.plot([1,2,3])",
+        modifiedBy: "test-user",
+      }));
+
+      // Note: execution count is tracked through execution events
+
+      store.commit(events.cellOutputAdded({
+        id: "rich-output",
+        cellId: "rich-cell",
+        outputType: "display_data",
+        data: {
+          "text/plain": "<Figure size 640x480 with 1 Axes>",
+          "image/svg+xml": "<svg>...</svg>",
+          "application/json": { "plot_data": [1, 2, 3] },
+        },
+        metadata: { "image/svg+xml": { "width": 640, "height": 480 } },
+        position: 1,
+      }));
+
+      const notebook = exporter.exportNotebook();
+      const richCell = notebook.cells[4];
+
+      assertExists(richCell);
+      assertEquals(richCell.outputs?.length, 1);
+      const richOutput = richCell.outputs?.[0];
+      assertEquals(richOutput?.output_type, "display_data");
+      assertEquals(
+        (richOutput as { data?: Record<string, unknown> })?.data
+          ?.["text/plain"],
+        "<Figure size 640x480 with 1 Axes>",
+      );
+      assertEquals(
+        (richOutput as { data?: Record<string, unknown> })?.data
+          ?.["image/svg+xml"],
+        "<svg>...</svg>",
+      );
+      assertExists(
+        (richOutput as { metadata?: Record<string, unknown> })?.metadata,
+      );
+    });
+
+    await t.step("should handle error outputs", () => {
+      if (!agent || !exporter) {
+        throw new Error("Agent/Exporter not initialized");
+      }
+
+      const store = agent.store;
+
+      // Add a cell with error output
+      store.commit(events.cellCreated({
+        id: "error-cell",
+        position: 6,
+        cellType: "code",
+        createdBy: "test-user",
+      }));
+
+      store.commit(events.cellSourceChanged({
+        id: "error-cell",
+        source: "raise ValueError('Test error')",
+        modifiedBy: "test-user",
+      }));
+
+      // Note: execution count is tracked through execution events
+
+      store.commit(events.cellOutputAdded({
+        id: "error-output",
+        cellId: "error-cell",
+        outputType: "error",
+        data: {
+          ename: "ValueError",
+          evalue: "Test error",
+          traceback: [
+            "Traceback (most recent call last):",
+            '  File "<stdin>", line 1, in <module>',
+            "ValueError: Test error",
+          ],
+        },
+        position: 1,
+      }));
+
+      const notebook = exporter.exportNotebook();
+      const errorCell = notebook.cells[5];
+
+      assertExists(errorCell);
+      assertEquals(errorCell.outputs?.length, 1);
+      const errorOutput = errorCell.outputs?.[0];
+      assertEquals(errorOutput?.output_type, "error");
+      assertEquals(
+        (errorOutput as { ename?: string })?.ename,
+        "ValueError",
+      );
+      assertEquals(
+        (errorOutput as { evalue?: string })?.evalue,
+        "Test error",
+      );
+      assertEquals(
+        (errorOutput as { traceback?: string[] })?.traceback?.length,
+        3,
+      );
+    });
+  } finally {
+    // Always cleanup
+    if (agent) {
+      await agent.shutdown();
+    }
+  }
+});


### PR DESCRIPTION
⚠️  Almost entirely vibe coded with suggestions from me. Putting this up as a workable prototype for the moment. ⚠️ 

This PR implements periodic notebook export functionality as requested in issue #7.

**Features Added:**
-  class that converts LiveStore notebook data to standard Jupyter  format
- AI cells transformed to Python code cells with  wrapper function
- SQL cells transformed to Python code cells with  wrapper function  
- Periodic automatic export (configurable interval, default 30 seconds)
- Manual export API for on-demand exports
- Comprehensive test coverage with 13 test cases
- Example demonstrating all functionality

**Key Benefits:**
- Maintains Jupyter notebook compatibility for easy sharing
- Preserves all outputs, metadata, and execution counts
- Provides persistent artifacts outside the runt system
- Configurable export options (include/exclude AI/SQL cells, transform sources)
- Generates appropriate filenames based on notebook titles

**Technical Details:**
- Exports notebooks in Jupyter nbformat v4.4
- Handles all runt cell types (code, markdown, raw, ai, sql)
- Preserves rich display data (SVG plots, HTML tables, JSON)
- Includes runt-specific metadata for round-trip compatibility
- Uses active kernel session type for accurate kernel metadata

The implementation addresses the core workflow described in the issue where users can work with runt but also have standard  files available for sharing and backup.