### PR TITLE
Fix publish workflow create-tags job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -262,12 +262,18 @@ jobs:
     name: Create Release Tags
     runs-on: ubuntu-latest
     needs: [changes, publish-schema, publish-lib, publish-pyodide]
-    if: always() && needs.changes.outputs.schema == 'true' || needs.changes.outputs.lib == 'true' || needs.changes.outputs.pyodide == 'true' && github.event.inputs.dry_run != 'true'
+    if: always() && (needs.changes.outputs.schema == 'true' || needs.changes.outputs.lib == 'true' || needs.changes.outputs.pyodide == 'true') && github.event.inputs.dry_run != 'true'
     permissions:
       contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+          cache: true
 
       - name: Create tags for published packages
         run: |
@@ -297,14 +303,15 @@ jobs:
   summary:
     name: Summary
     runs-on: ubuntu-latest
-    needs: [
-      changes,
-      validate,
-      publish-schema,
-      publish-lib,
-      publish-pyodide,
-      create-tags,
-    ]
+    needs:
+      [
+        changes,
+        validate,
+        publish-schema,
+        publish-lib,
+        publish-pyodide,
+        create-tags,
+      ]
     if: always()
     steps:
       - name: Report results


### PR DESCRIPTION
Fixes the publish workflow tagging job that failed in #23.

## Issue
The `create-tags` job failed because:
- Missing Deno setup (couldn't run `deno eval` commands)
- Incorrect conditional logic in `if` statement

## Fix
- **Add Deno setup**: Added `denoland/setup-deno@v2` to the create-tags job
- **Fix conditional**: Added proper parentheses around the OR conditions
- **Environment consistency**: Uses same `DENO_VERSION` env var as other jobs

## Result
The workflow can now properly:
- Read package versions from `deno.json` files
- Create version tags like `v0.2.3-schema`, `v0.2.3-lib`, `v0.2.3-pyodide`
- Push tags to the repository

This should complete the publishing workflow successfully.