### PR TITLE
feat: implement Jupyter update_display_data functionality

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1011,7 +1011,7 @@
     "members": {
       "packages/lib": {
         "dependencies": [
-          "jsr:@runt/schema@0.3",
+          "jsr:@runt/schema@0.4",
           "jsr:@std/cli@1",
           "npm:@livestore/adapter-node@~0.3.1",
           "npm:@livestore/livestore@~0.3.1",
@@ -1022,8 +1022,8 @@
       "packages/pyodide-runtime-agent": {
         "dependencies": [
           "jsr:@openai/openai@^4.98.0",
-          "jsr:@runt/lib@0.3",
-          "jsr:@runt/schema@0.3",
+          "jsr:@runt/lib@0.4",
+          "jsr:@runt/schema@0.4",
           "jsr:@std/async@1",
           "npm:@livestore/livestore@~0.3.1",
           "npm:pyodide@~0.27.7",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Runtime agent library for building Anode kernels",
   "license": "MIT",
   "repository": {
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.3.0",
+    "@runt/schema": "jsr:@runt/schema@^0.4.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -307,6 +307,15 @@ export class RuntimeAgent {
 
           if (entries.length > 0) {
             const logger = createLogger(`${this.config.kernelType}-agent`);
+
+            // Log cell count for sync debugging
+            const allCells = this.store.query(tables.cells.select());
+            logger.info("Runtime sync status", {
+              pendingExecutions: entries.length,
+              totalCells: allCells.length,
+              cellIds: allCells.map((c) => c.id),
+            });
+
             logger.debug("Pending executions", {
               count: entries.length,
               executions: entries.map((e) => ({ id: e.id, cellId: e.cellId })),
@@ -475,6 +484,7 @@ export class RuntimeAgent {
       display: (
         data: RichOutputData,
         metadata?: Record<string, unknown>,
+        displayId?: string,
       ) => {
         this.store.commit(events.cellOutputAdded({
           id: crypto.randomUUID(),
@@ -483,6 +493,19 @@ export class RuntimeAgent {
           data,
           metadata: metadata || {},
           position: outputPosition++,
+          displayId,
+        }));
+      },
+
+      updateDisplay: (
+        displayId: string,
+        data: RichOutputData,
+        metadata?: Record<string, unknown>,
+      ) => {
+        this.store.commit(events.cellOutputUpdated({
+          id: displayId,
+          data,
+          metadata: metadata || {},
         }));
       },
 

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -75,6 +75,13 @@ export interface ExecutionContext {
   display: (
     data: RichOutputData,
     metadata?: Record<string, unknown>,
+    displayId?: string,
+  ) => void;
+  /** Update existing display data by display ID */
+  updateDisplay: (
+    displayId: string,
+    data: RichOutputData,
+    metadata?: Record<string, unknown>,
   ) => void;
   /** Emit execution result (final output) */
   result: (

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "MIT",
   "repository": {
@@ -15,8 +15,8 @@
     "pyrunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.3.0",
-    "@runt/schema": "jsr:@runt/schema@^0.3.0",
+    "@runt/lib": "jsr:@runt/lib@^0.4.0",
+    "@runt/schema": "jsr:@runt/schema@^0.4.0",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -248,21 +248,32 @@ export class PyodideRuntimeAgent {
             break;
           case "display_data":
             if (data.data !== null && data.data !== undefined) {
+              // Extract display_id from transient data if present
+              const displayId = data.transient?.display_id;
               this.currentExecutionContext.display(
                 this.formatRichOutput(data.data, data.metadata),
                 data.metadata || {},
+                displayId,
               );
             }
             break;
           case "update_display_data":
             if (data.data != null) {
-              // Handle display updates - could extend ExecutionContext to support this
-              this.currentExecutionContext.display(
-                this.formatRichOutput(data.data, data.metadata),
-                data.metadata
-                  ? { ...data.metadata, update: true }
-                  : { update: true },
-              );
+              // Extract display_id from transient data
+              const displayId = data.transient?.display_id;
+              if (displayId) {
+                this.currentExecutionContext.updateDisplay(
+                  displayId,
+                  this.formatRichOutput(data.data, data.metadata),
+                  data.metadata || {},
+                );
+              } else {
+                // Fallback to regular display if no display_id
+                this.currentExecutionContext.display(
+                  this.formatRichOutput(data.data, data.metadata),
+                  data.metadata || {},
+                );
+              }
             }
             break;
           case "error":

--- a/packages/pyodide-runtime-agent/src/pyodide-worker.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-worker.ts
@@ -289,13 +289,14 @@ async function executePython(code: string): Promise<{
       (
         data: unknown,
         metadata: unknown,
-        _transient: unknown,
+        transient: unknown,
         update = false,
       ) => {
         try {
           // Ensure data is serializable
           const serializedData = ensureSerializable(data);
           const serializedMetadata = ensureSerializable(metadata);
+          const serializedTransient = ensureSerializable(transient);
 
           const outputType = update ? "update_display_data" : "display_data";
 
@@ -305,6 +306,7 @@ async function executePython(code: string): Promise<{
               type: outputType,
               data: serializedData,
               metadata: serializedMetadata,
+              transient: serializedTransient,
             },
           });
 
@@ -313,6 +315,7 @@ async function executePython(code: string): Promise<{
             data: {
               data: serializedData,
               metadata: serializedMetadata,
+              transient: serializedTransient,
               update,
             },
           });

--- a/packages/pyodide-runtime-agent/test/agentic-tool-calls.test.ts
+++ b/packages/pyodide-runtime-agent/test/agentic-tool-calls.test.ts
@@ -43,6 +43,16 @@ function createMockContext() {
       });
     },
     clear: () => {},
+    updateDisplay: (displayId, data, metadata) => {
+      // Find and update existing outputs with matching displayId
+      for (let i = 0; i < outputs.length; i++) {
+        const output = outputs[i];
+        if (output && output.metadata?.display_id === displayId) {
+          output.data = data as Record<string, unknown>;
+          output.metadata = metadata || {};
+        }
+      }
+    },
   };
 
   return { mockContext, outputs };

--- a/packages/pyodide-runtime-agent/test/immediate-output.test.ts
+++ b/packages/pyodide-runtime-agent/test/immediate-output.test.ts
@@ -39,6 +39,7 @@ Deno.test("OpenAI Client - Immediate Output Emission", async () => {
       result: () => {},
       error: () => {},
       clear: () => {},
+      updateDisplay: () => {},
     };
 
     // Mock client that simulates slow tool execution
@@ -192,6 +193,7 @@ Deno.test("OpenAI Client - Multiple Tool Calls Stream Individually", async () =>
       result: () => {},
       error: () => {},
       clear: () => {},
+      updateDisplay: () => {},
     };
 
     // Mock client that returns multiple tool calls

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.2.3",
+  "version": "0.4.0",
   "description": "This package.json is solely here to make linking possible for npm users",
   "type": "module",
   "main": "./mod.ts",


### PR DESCRIPTION

- **Multiple outputs per display_id**: Each  creates new output, even with same ID
- **Cross-cell updates**:  updates ALL outputs with matching ID
- **Real-time sync**: Updates propagate immediately via LiveStore reactivity
- **Jupyter semantics**: Follows standard Jupyter display_id behavior

## Example Usage

```python
# Cell 1
h = display("hello", display_id="123")

# Cell 2  
display("world", display_id="123")  # Creates new output, both linked

# Cell 3
h.update("updated!")  # Updates both outputs to show "updated!"
```
