### PR TITLE
Fix AI package publish configuration

### DIFF
--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -25,7 +25,7 @@
     "lint": "deno lint"
   },
   "publish": {
-    "include": ["mod.ts", "src/", "README.md"],
+    "include": ["mod.ts", "openai-client.ts", "tool-registry.ts", "README.md"],
     "exclude": ["**/*.test.ts", "**/test_*.ts", "examples/"]
   }
 }


### PR DESCRIPTION
Fixes the excluded-module error by including openai-client.ts and tool-registry.ts in the publish.include array. These files are imported by mod.ts but were being excluded from the package.