### PR TITLE
Clean up SQL cell schema and add field update events

### DIFF
--- a/packages/pyodide-runtime-agent/test/real-execution.test.ts
+++ b/packages/pyodide-runtime-agent/test/real-execution.test.ts
@@ -62,7 +62,7 @@ function createTestExecutionContext(code: string): {
       assignedRuntimeSession: null,
       lastExecutionDurationMs: null,
       sqlConnectionId: null,
-      sqlResultData: null,
+      sqlResultVariable: null,
       aiProvider: null,
       aiModel: null,
       aiSettings: null,

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -457,17 +457,7 @@ export const events = {
     }),
   }),
 
-  // SQL events
-  sqlQueryExecuted: Events.synced({
-    name: "v1.SqlQueryExecuted",
-    schema: Schema.Struct({
-      cellId: Schema.String,
-      connectionId: Schema.String,
-      query: Schema.String,
-      resultVariable: Schema.String,
-      executedBy: Schema.String,
-    }),
-  }),
+  // SQL events - none needed, SQL cells use standard execution flow
 
   // AI events
   aiSettingsChanged: Events.synced({
@@ -886,16 +876,7 @@ const materializers = State.SQLite.materializers(events, {
     }
   },
 
-  // SQL materializers
-  "v1.SqlQueryExecuted": ({ cellId, connectionId, query, resultVariable }) =>
-    tables.cells
-      .update({
-        source: query,
-        sqlConnectionId: connectionId,
-        sqlResultVariable: resultVariable,
-        executionState: "completed",
-      })
-      .where({ id: cellId }),
+  // SQL materializers - none needed, SQL cells use standard execution flow
 
   // AI materializers
   "v1.AiSettingsChanged": ({ cellId, provider, model, settings }) =>

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -65,7 +65,7 @@ export const tables = {
 
       // SQL-specific fields
       sqlConnectionId: State.SQLite.text({ nullable: true }),
-      sqlResultData: State.SQLite.json({ nullable: true, schema: Schema.Any }),
+      sqlResultVariable: State.SQLite.text({ nullable: true }),
 
       // AI-specific fields
       aiProvider: State.SQLite.text({ nullable: true }), // 'openai', 'anthropic', 'local'
@@ -179,19 +179,6 @@ export const tables = {
       startedAt: State.SQLite.datetime({ nullable: true }),
       completedAt: State.SQLite.datetime({ nullable: true }),
       executionDurationMs: State.SQLite.integer({ nullable: true }),
-    },
-  }),
-
-  // Data connections for SQL cells
-  dataConnections: State.SQLite.table({
-    name: "dataConnections",
-    columns: {
-      id: State.SQLite.text({ primaryKey: true }),
-      name: State.SQLite.text(),
-      type: State.SQLite.text({ schema: Schema.String }),
-      connectionString: State.SQLite.text(), // encrypted connection details
-      isDefault: State.SQLite.boolean({ default: false }),
-      createdBy: State.SQLite.text(),
     },
   }),
 
@@ -471,25 +458,13 @@ export const events = {
   }),
 
   // SQL events
-  sqlConnectionCreated: Events.synced({
-    name: "v1.SqlConnectionCreated",
-    schema: Schema.Struct({
-      id: Schema.String,
-      name: Schema.String,
-      type: Schema.String,
-      connectionString: Schema.String,
-      isDefault: Schema.Boolean,
-      createdBy: Schema.String,
-    }),
-  }),
-
   sqlQueryExecuted: Events.synced({
     name: "v1.SqlQueryExecuted",
     schema: Schema.Struct({
       cellId: Schema.String,
       connectionId: Schema.String,
       query: Schema.String,
-      resultData: Schema.Any,
+      resultVariable: Schema.String,
       executedBy: Schema.String,
     }),
   }),
@@ -912,29 +887,12 @@ const materializers = State.SQLite.materializers(events, {
   },
 
   // SQL materializers
-  "v1.SqlConnectionCreated": ({
-    id,
-    name,
-    type,
-    connectionString,
-    isDefault,
-    createdBy,
-  }) =>
-    tables.dataConnections.insert({
-      id,
-      name,
-      type,
-      connectionString,
-      isDefault,
-      createdBy,
-    }),
-
-  "v1.SqlQueryExecuted": ({ cellId, connectionId, query, resultData }) =>
+  "v1.SqlQueryExecuted": ({ cellId, connectionId, query, resultVariable }) =>
     tables.cells
       .update({
         source: query,
         sqlConnectionId: connectionId,
-        sqlResultData: resultData,
+        sqlResultVariable: resultVariable,
         executionState: "completed",
       })
       .where({ id: cellId }),
@@ -963,7 +921,6 @@ export type OutputData = typeof tables.outputs.Type;
 
 export type RuntimeSessionData = typeof tables.runtimeSessions.Type;
 export type ExecutionQueueData = typeof tables.executionQueue.Type;
-export type DataConnectionData = typeof tables.dataConnections.Type;
 export type UiStateData = typeof tables.uiState.Type;
 
 // Cell types
@@ -1007,14 +964,6 @@ export type MediaRepresentation = {
   artifactId: string;
   metadata?: Record<string, unknown>;
 };
-
-// SQL-specific types
-export interface SqlResultData {
-  columns: string[];
-  rows: unknown[][];
-  rowCount: number;
-  executionTime: string;
-}
 
 // Output data types for different output formats
 export interface RichOutputData {

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -457,8 +457,6 @@ export const events = {
     }),
   }),
 
-  // SQL events - none needed, SQL cells use standard execution flow
-
   // AI events
   aiSettingsChanged: Events.synced({
     name: "v1.AiSettingsChanged",
@@ -471,6 +469,25 @@ export const events = {
         maxTokens: Schema.optional(Schema.Number),
         systemPrompt: Schema.optional(Schema.String),
       }),
+    }),
+  }),
+
+  // SQL events
+  sqlConnectionChanged: Events.synced({
+    name: "v1.SqlConnectionChanged",
+    schema: Schema.Struct({
+      cellId: Schema.String,
+      connectionId: Schema.optional(Schema.String),
+      changedBy: Schema.String,
+    }),
+  }),
+
+  sqlResultVariableChanged: Events.synced({
+    name: "v1.SqlResultVariableChanged",
+    schema: Schema.Struct({
+      cellId: Schema.String,
+      resultVariable: Schema.optional(Schema.String),
+      changedBy: Schema.String,
     }),
   }),
 
@@ -876,8 +893,6 @@ const materializers = State.SQLite.materializers(events, {
     }
   },
 
-  // SQL materializers - none needed, SQL cells use standard execution flow
-
   // AI materializers
   "v1.AiSettingsChanged": ({ cellId, provider, model, settings }) =>
     tables.cells
@@ -885,6 +900,21 @@ const materializers = State.SQLite.materializers(events, {
         aiProvider: provider,
         aiModel: model,
         aiSettings: settings,
+      })
+      .where({ id: cellId }),
+
+  // SQL materializers
+  "v1.SqlConnectionChanged": ({ cellId, connectionId }) =>
+    tables.cells
+      .update({
+        sqlConnectionId: connectionId ?? null,
+      })
+      .where({ id: cellId }),
+
+  "v1.SqlResultVariableChanged": ({ cellId, resultVariable }) =>
+    tables.cells
+      .update({
+        sqlResultVariable: resultVariable ?? null,
       })
       .where({ id: cellId }),
 });


### PR DESCRIPTION
Cleans up the SQL cell schema by removing unimplemented placeholders and adds proper events for updating SQL cell fields in the prototype UI.