### PR TITLE
Release v0.6.0

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,7 +2,6 @@
   "version": "5",
   "specifiers": {
     "jsr:@openai/openai@^4.98.0": "4.102.0",
-    "jsr:@runt/ai@~0.5.3": "0.5.3",
     "jsr:@std/assert@*": "1.0.13",
     "jsr:@std/assert@1.0.13": "1.0.13",
     "jsr:@std/async@*": "1.0.13",
@@ -28,13 +27,6 @@
       "integrity": "ea5201bc5c8a696d3a5139a9cd2252e3ab9b2b880769a9cd7f05602ea1a02acf",
       "dependencies": [
         "npm:zod"
-      ]
-    },
-    "@runt/ai@0.5.3": {
-      "integrity": "2ac8e1935fbfb7ca269768b368d60c830fc1b7783f5deb15fd20b6cd143807e0",
-      "dependencies": [
-        "jsr:@openai/openai",
-        "npm:strip-ansi"
       ]
     },
     "@std/assert@1.0.13": {
@@ -1027,8 +1019,8 @@
       "packages/ai": {
         "dependencies": [
           "jsr:@openai/openai@^4.98.0",
-          "jsr:@runt/lib@~0.5.3",
-          "jsr:@runt/schema@~0.5.3",
+          "jsr:@runt/lib@0.6",
+          "jsr:@runt/schema@0.6",
           "jsr:@std/async@1",
           "npm:@livestore/livestore@~0.3.1",
           "npm:pyodide@~0.27.7",
@@ -1037,7 +1029,7 @@
       },
       "packages/lib": {
         "dependencies": [
-          "jsr:@runt/schema@~0.5.3",
+          "jsr:@runt/schema@0.6",
           "jsr:@std/cli@1",
           "npm:@livestore/adapter-node@~0.3.1",
           "npm:@livestore/livestore@~0.3.1",
@@ -1047,9 +1039,9 @@
       },
       "packages/pyodide-runtime-agent": {
         "dependencies": [
-          "jsr:@runt/ai@~0.5.3",
-          "jsr:@runt/lib@~0.5.3",
-          "jsr:@runt/schema@~0.5.3",
+          "jsr:@runt/ai@0.6",
+          "jsr:@runt/lib@0.6",
+          "jsr:@runt/schema@0.6",
           "jsr:@std/async@1",
           "npm:@livestore/livestore@~0.3.1",
           "npm:pyodide@~0.27.7",

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/ai",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Runtime AI Clients",
   "license": "MIT",
   "repository": {
@@ -11,8 +11,8 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.5.3",
-    "@runt/schema": "jsr:@runt/schema@^0.5.3",
+    "@runt/lib": "jsr:@runt/lib@^0.6.0",
+    "@runt/schema": "jsr:@runt/schema@^0.6.0",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Runtime agent library for building Anode runtime agents",
   "license": "MIT",
   "repository": {
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.5.3",
+    "@runt/schema": "jsr:@runt/schema@^0.6.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "MIT",
   "repository": {
@@ -14,9 +14,9 @@
     "pyrunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/ai": "jsr:@runt/ai@^0.5.3",
-    "@runt/lib": "jsr:@runt/lib@^0.5.3",
-    "@runt/schema": "jsr:@runt/schema@^0.5.3",
+    "@runt/ai": "jsr:@runt/ai@^0.6.0",
+    "@runt/lib": "jsr:@runt/lib@^0.6.0",
+    "@runt/schema": "jsr:@runt/schema@^0.6.0",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.4.2",
+  "version": "0.6.0",
   "description": "This package.json is solely here to make linking possible for npm users",
   "type": "module",
   "main": "./mod.ts",


### PR DESCRIPTION
Release v0.6.0 with version bumps for all packages

This PR bumps all packages to version 0.6.0:
- @runt/schema: 0.5.3 → 0.6.0
- @runt/lib: 0.5.3 → 0.6.0  
- @runt/ai: 0.5.3 → 0.6.0
- @runt/pyodide-runtime-agent: 0.5.3 → 0.6.0

All cross-package dependencies have been updated to use the new version ranges.

All tests passing (59/59) and CI checks complete.