### PR TITLE
Add schema linking documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,25 +86,34 @@ When making changes:
 
 ## Schema Linking for Development
 
-The `@runt/schema` package provides the shared types and events between Anode and Runt. The linking method depends on your development phase:
+The `@runt/schema` package provides the shared types and events between Anode
+and Runt. The linking method depends on your development phase:
 
 ### Production (JSR Package)
+
 ```json
 "@runt/schema": "jsr:^0.6.0"
 ```
+
 Use this for stable releases and production deployments.
 
 ### Testing PR Changes (GitHub Reference)
+
 ```json
 "@runt/schema": "github:runtimed/runt#1d52f9e51b9f28e81e366a7053d1e5fa6164c390&path:/packages/schema"
 ```
-Use this when testing changes from a merged PR in the Runt repository. Replace the commit hash with the specific commit you want to test.
+
+Use this when testing changes from a merged PR in the Runt repository. Replace
+the commit hash with the specific commit you want to test.
 
 ### Local Development (File Link)
+
 ```json
 "@runt/schema": "file:../runt/packages/schema"
 ```
-Use this when developing locally with both Anode and Runt repositories side-by-side.
+
+Use this when developing locally with both Anode and Runt repositories
+side-by-side.
 
 ### Switching Between Modes
 
@@ -112,7 +121,8 @@ Use this when developing locally with both Anode and Runt repositories side-by-s
 2. **Run `pnpm install`** to update dependencies
 3. **Restart your development servers** (both `pnpm dev` and `pnpm dev:sync`)
 
-**Important**: Always ensure both repositories are using compatible schema versions. Type errors usually indicate schema mismatches.
+**Important**: Always ensure both repositories are using compatible schema
+versions. Type errors usually indicate schema mismatches.
 
 ## Key Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,36 @@ When making changes:
 - Push branch and create PR
 - GitHub Actions runs the same checks
 
+## Schema Linking for Development
+
+The `@runt/schema` package provides the shared types and events between Anode and Runt. The linking method depends on your development phase:
+
+### Production (JSR Package)
+```json
+"@runt/schema": "jsr:^0.6.0"
+```
+Use this for stable releases and production deployments.
+
+### Testing PR Changes (GitHub Reference)
+```json
+"@runt/schema": "github:runtimed/runt#1d52f9e51b9f28e81e366a7053d1e5fa6164c390&path:/packages/schema"
+```
+Use this when testing changes from a merged PR in the Runt repository. Replace the commit hash with the specific commit you want to test.
+
+### Local Development (File Link)
+```json
+"@runt/schema": "file:../runt/packages/schema"
+```
+Use this when developing locally with both Anode and Runt repositories side-by-side.
+
+### Switching Between Modes
+
+1. **Update `package.json`** with the appropriate schema reference
+2. **Run `pnpm install`** to update dependencies
+3. **Restart your development servers** (both `pnpm dev` and `pnpm dev:sync`)
+
+**Important**: Always ensure both repositories are using compatible schema versions. Type errors usually indicate schema mismatches.
+
 ## Key Constraints
 
 - **LiveStore Materializers**: Must be pure functions. Avoid non-deterministic

--- a/README.md
+++ b/README.md
@@ -34,3 +34,31 @@ packages/
 - Publishing requires `--allow-slow-types` flag (Deno limitation)
 
 Examples in `packages/lib/examples/`.
+
+## Development
+
+### Schema Linking
+
+The `@runt/schema` package can be linked in different ways depending on your development phase:
+
+**Production (JSR Package)**:
+```json
+"@runt/schema": "jsr:^0.6.0"
+```
+
+**Testing PR Changes (GitHub Reference)**:
+```json
+"@runt/schema": "github:runtimed/runt#1d52f9e51b9f28e81e366a7053d1e5fa6164c390&path:/packages/schema"
+```
+
+**Local Development (File Link)**:
+```json
+"@runt/schema": "file:../runt/packages/schema"
+```
+
+**To switch between modes:**
+1. Update `package.json` with the appropriate schema reference
+2. Run `pnpm install` (for Node.js projects) or restart Deno
+3. Restart development servers
+
+**Important**: Ensure all consuming projects use compatible schema versions.

--- a/README.md
+++ b/README.md
@@ -39,24 +39,29 @@ Examples in `packages/lib/examples/`.
 
 ### Schema Linking
 
-The `@runt/schema` package can be linked in different ways depending on your development phase:
+The `@runt/schema` package can be linked in different ways depending on your
+development phase:
 
 **Production (JSR Package)**:
+
 ```json
 "@runt/schema": "jsr:^0.6.0"
 ```
 
 **Testing PR Changes (GitHub Reference)**:
+
 ```json
 "@runt/schema": "github:runtimed/runt#1d52f9e51b9f28e81e366a7053d1e5fa6164c390&path:/packages/schema"
 ```
 
 **Local Development (File Link)**:
+
 ```json
 "@runt/schema": "file:../runt/packages/schema"
 ```
 
 **To switch between modes:**
+
 1. Update `package.json` with the appropriate schema reference
 2. Run `pnpm install` (for Node.js projects) or restart Deno
 3. Restart development servers


### PR DESCRIPTION
Documents the three schema linking modes for cross-repository development workflow. Includes production JSR, GitHub testing, and local file linking methods with switching instructions.