### PR TITLE
Fix OpenAI model compatibility for o1/o3/o4 models

### DIFF
--- a/packages/ai/test/model-compatibility.test.ts
+++ b/packages/ai/test/model-compatibility.test.ts
@@ -1,0 +1,102 @@
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { RuntOpenAIClient } from "../openai-client.ts";
+
+Deno.test("OpenAI Model Compatibility", async (t) => {
+  const client = new RuntOpenAIClient();
+
+  await t.step("should identify models that use max_completion_tokens", () => {
+    // Test private method via reflection
+    const usesMaxCompletionTokens = (client as any).usesMaxCompletionTokens;
+
+    // Models that should use max_completion_tokens
+    assertEquals(usesMaxCompletionTokens("o1-preview"), true);
+    assertEquals(usesMaxCompletionTokens("o1-mini"), true);
+    assertEquals(usesMaxCompletionTokens("o3-mini"), true);
+    assertEquals(usesMaxCompletionTokens("o4-mini"), true);
+
+    // Models that should use max_tokens
+    assertEquals(usesMaxCompletionTokens("gpt-4o"), false);
+    assertEquals(usesMaxCompletionTokens("gpt-4o-mini"), false);
+    assertEquals(usesMaxCompletionTokens("gpt-4.1"), false);
+    assertEquals(usesMaxCompletionTokens("gpt-3.5-turbo"), false);
+  });
+
+  await t.step("should identify models that support system messages", () => {
+    // Test private method via reflection
+    const supportsSystemMessages = (client as any).supportsSystemMessages;
+
+    // Models that don't support system messages
+    assertEquals(supportsSystemMessages("o1-preview"), false);
+    assertEquals(supportsSystemMessages("o1-mini"), false);
+    assertEquals(supportsSystemMessages("o1-pro"), false);
+
+    // Models that support system messages
+    assertEquals(supportsSystemMessages("gpt-4o"), true);
+    assertEquals(supportsSystemMessages("gpt-4o-mini"), true);
+    assertEquals(supportsSystemMessages("gpt-4.1"), true);
+    assertEquals(supportsSystemMessages("o3-mini"), true);
+    assertEquals(supportsSystemMessages("o4-mini"), true);
+  });
+
+  await t.step(
+    "should filter messages for models without system support",
+    () => {
+      // Test private method via reflection with proper binding
+      const filterMessagesForModel = (client as any).filterMessagesForModel
+        .bind(client);
+
+      const messages = [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello!" },
+        { role: "assistant", content: "Hi there!" },
+      ];
+
+      // For models that support system messages, should return unchanged
+      const gpt4oMessages = filterMessagesForModel(messages, "gpt-4o");
+      assertEquals(gpt4oMessages.length, 3);
+      assertEquals(gpt4oMessages[0].role, "system");
+      assertEquals(gpt4oMessages[0].content, "You are a helpful assistant.");
+
+      // For models that don't support system messages, should convert system to user
+      const o1Messages = filterMessagesForModel(messages, "o1-preview");
+      assertEquals(o1Messages.length, 3);
+      assertEquals(o1Messages[0].role, "user");
+      assertEquals(
+        o1Messages[0].content,
+        "System instructions: You are a helpful assistant.",
+      );
+      assertEquals(o1Messages[1].role, "user");
+      assertEquals(o1Messages[1].content, "Hello!");
+      assertEquals(o1Messages[2].role, "assistant");
+      assertEquals(o1Messages[2].content, "Hi there!");
+    },
+  );
+
+  await t.step("should handle empty messages array", () => {
+    const filterMessagesForModel = (client as any).filterMessagesForModel.bind(
+      client,
+    );
+
+    const emptyMessages: any[] = [];
+    const result = filterMessagesForModel(emptyMessages, "o1-preview");
+    assertEquals(result.length, 0);
+  });
+
+  await t.step("should handle messages without system role", () => {
+    const filterMessagesForModel = (client as any).filterMessagesForModel.bind(
+      client,
+    );
+
+    const messages = [
+      { role: "user", content: "Hello!" },
+      { role: "assistant", content: "Hi there!" },
+    ];
+
+    const result = filterMessagesForModel(messages, "o1-preview");
+    assertEquals(result.length, 2);
+    assertEquals(result[0].role, "user");
+    assertEquals(result[0].content, "Hello!");
+    assertEquals(result[1].role, "assistant");
+    assertEquals(result[1].content, "Hi there!");
+  });
+});

--- a/packages/ai/test/model-compatibility.test.ts
+++ b/packages/ai/test/model-compatibility.test.ts
@@ -6,7 +6,9 @@ Deno.test("OpenAI Model Compatibility", async (t) => {
 
   await t.step("should identify models that use max_completion_tokens", () => {
     // Test private method via reflection
-    const usesMaxCompletionTokens = (client as any).usesMaxCompletionTokens;
+    const usesMaxCompletionTokens = (client as unknown as {
+      usesMaxCompletionTokens: (model: string) => boolean;
+    }).usesMaxCompletionTokens;
 
     // Models that should use max_completion_tokens
     assertEquals(usesMaxCompletionTokens("o1-preview"), true);
@@ -23,7 +25,9 @@ Deno.test("OpenAI Model Compatibility", async (t) => {
 
   await t.step("should identify models that support system messages", () => {
     // Test private method via reflection
-    const supportsSystemMessages = (client as any).supportsSystemMessages;
+    const supportsSystemMessages = (client as unknown as {
+      supportsSystemMessages: (model: string) => boolean;
+    }).supportsSystemMessages;
 
     // Models that don't support system messages
     assertEquals(supportsSystemMessages("o1-preview"), false);
@@ -42,7 +46,12 @@ Deno.test("OpenAI Model Compatibility", async (t) => {
     "should filter messages for models without system support",
     () => {
       // Test private method via reflection with proper binding
-      const filterMessagesForModel = (client as any).filterMessagesForModel
+      const filterMessagesForModel = (client as unknown as {
+        filterMessagesForModel: (
+          messages: { role: string; content: string }[],
+          model: string,
+        ) => { role: string; content: string }[];
+      }).filterMessagesForModel
         .bind(client);
 
       const messages = [
@@ -73,17 +82,27 @@ Deno.test("OpenAI Model Compatibility", async (t) => {
   );
 
   await t.step("should handle empty messages array", () => {
-    const filterMessagesForModel = (client as any).filterMessagesForModel.bind(
+    const filterMessagesForModel = (client as unknown as {
+      filterMessagesForModel: (
+        messages: { role: string; content: string }[],
+        model: string,
+      ) => { role: string; content: string }[];
+    }).filterMessagesForModel.bind(
       client,
     );
 
-    const emptyMessages: any[] = [];
+    const emptyMessages: { role: string; content: string }[] = [];
     const result = filterMessagesForModel(emptyMessages, "o1-preview");
     assertEquals(result.length, 0);
   });
 
   await t.step("should handle messages without system role", () => {
-    const filterMessagesForModel = (client as any).filterMessagesForModel.bind(
+    const filterMessagesForModel = (client as unknown as {
+      filterMessagesForModel: (
+        messages: { role: string; content: string }[],
+        model: string,
+      ) => { role: string; content: string }[];
+    }).filterMessagesForModel.bind(
       client,
     );
 


### PR DESCRIPTION
Fixes OpenAI API compatibility issues with newer models that have different parameter requirements and restrictions.

## Changes

### Model Parameter Compatibility
- Added support for max_completion_tokens parameter for o1, o3, and o4-mini models
- Existing models continue to use max_tokens parameter
- Added helper method to detect which parameter to use based on model name

### System Message Handling
- o1 family models don't support system messages
- Added automatic conversion of system messages to user messages with System instructions prefix
- Other models continue to use system messages normally

### TypeScript Fixes
- Fixed streaming response typing issues with proper casting
- All type checks now pass cleanly

### Test Coverage
- Added comprehensive test suite for model compatibility features
- Tests cover parameter selection, message filtering, and edge cases
- All existing tests continue to pass

## Fixes

This resolves the following API errors:
- 400 Unsupported parameter: max_tokens is not supported with this model. Use max_completion_tokens instead.
- 400 Unsupported value: messages[0].role does not support system with this model.

## Models Affected

### Use max_completion_tokens
- o1-preview, o1-mini, o1-pro
- o3-mini  
- o4-mini

### No system message support
- o1-preview, o1-mini, o1-pro (o3/o4 models do support system messages)

All other OpenAI models continue to work as before.