### PR TITLE
Add --unstable-broadcast-channel flag to pyodide-runtime-agent shebang

### DIFF
--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-all
+#!/usr/bin/env -S deno run --allow-all --unstable-broadcast-channel
 /**
  * PyRunt - Python Runtime Agent
  *


### PR DESCRIPTION
Enables broadcast channel support when running directly via JSR: `deno run jsr:@runt/pyodide-runtime-agent`