### PR TITLE
Fix IPython display updates

### DIFF
--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -7,7 +7,7 @@ import {
   type Store,
 } from "npm:@livestore/livestore";
 import { makeCfSync } from "npm:@livestore/sync-cf";
-import { events, schema, tables } from "@runt/schema";
+import { events, type MediaRepresentation, schema, tables } from "@runt/schema";
 import { createLogger } from "./logging.ts";
 import type {
   CancellationHandler,
@@ -581,9 +581,24 @@ export class RuntimeAgent {
         data: RichOutputData,
         metadata?: Record<string, unknown>,
       ) => {
-        // For updated displays, we need to find the output and replace it
-        // This is a simplified implementation - could be enhanced
-        context.display(data, metadata, displayId);
+        // For updated displays, use the dedicated update event (no new output created)
+        const representations: Record<
+          string,
+          MediaRepresentation
+        > = {};
+
+        for (const [mimeType, content] of Object.entries(data)) {
+          representations[mimeType] = {
+            type: "inline",
+            data: content, // Keep JSON objects as-is, don't stringify
+            metadata: metadata?.[mimeType] as Record<string, unknown>,
+          };
+        }
+
+        this.store.commit(events.multimediaDisplayOutputUpdated({
+          displayId,
+          representations,
+        }));
       },
 
       result: (

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -392,6 +392,17 @@ export const events = {
     }),
   }),
 
+  multimediaDisplayOutputUpdated: Events.synced({
+    name: "v1.MultimediaDisplayOutputUpdated",
+    schema: Schema.Struct({
+      displayId: Schema.String,
+      representations: Schema.Record({
+        key: Schema.String,
+        value: MediaRepresentationSchema,
+      }),
+    }),
+  }),
+
   multimediaResultOutputAdded: Events.synced({
     name: "v1.MultimediaResultOutputAdded",
     schema: Schema.Struct({
@@ -499,6 +510,62 @@ export const events = {
   // UI state
   uiStateSet: tables.uiState.set,
 };
+
+// Helper function to select primary representation from multimedia data
+function selectPrimaryRepresentation(representations: Record<string, any>) {
+  const preferenceOrder = [
+    "text/html",
+    "image/png",
+    "image/jpeg",
+    "image/svg+xml",
+    "application/json",
+    "text/plain",
+  ];
+
+  for (const mimeType of preferenceOrder) {
+    if (representations[mimeType]) {
+      const rep = representations[mimeType];
+      return {
+        data: rep.type === "inline" ? String(rep.data || "") : "",
+        mimeType,
+      };
+    }
+  }
+
+  return { data: "", mimeType: "text/plain" };
+}
+
+// Helper function to update existing displays with same displayId
+function updateExistingDisplays(
+  displayId: string,
+  representations: Record<string, any>,
+  ctx: any,
+) {
+  const existingOutputs = ctx.query(
+    tables.outputs.select().where({
+      displayId,
+      outputType: "multimedia_display",
+    }),
+  );
+
+  if (existingOutputs.length === 0) {
+    return [];
+  }
+
+  const { data: primaryData, mimeType: primaryMimeType } =
+    selectPrimaryRepresentation(representations);
+
+  return [
+    tables.outputs.update({
+      data: primaryData,
+      mimeType: primaryMimeType,
+      representations,
+    }).where({
+      displayId,
+      outputType: "multimedia_display",
+    }),
+  ];
+}
 
 // Materializers map events to state changes
 const materializers = State.SQLite.materializers(events, {
@@ -676,26 +743,20 @@ const materializers = State.SQLite.materializers(events, {
       ops.push(tables.pendingClears.delete().where({ cellId }));
     }
 
-    // Choose primary representation
-    const preferenceOrder = [
-      "text/html",
-      "image/png",
-      "image/jpeg",
-      "image/svg+xml",
-      "application/json",
-      "text/plain",
-    ];
-    let primaryData = "";
-    let primaryMimeType = "text/plain";
-
-    for (const mimeType of preferenceOrder) {
-      if (representations[mimeType]) {
-        const rep = representations[mimeType];
-        primaryData = rep.type === "inline" ? String(rep.data || "") : "";
-        primaryMimeType = mimeType;
-        break;
-      }
+    // If displayId provided, update all existing displays with same ID first
+    if (displayId) {
+      ops.push(
+        ...updateExistingDisplays(
+          displayId,
+          representations,
+          ctx,
+        ),
+      );
     }
+
+    // Always create new output (core behavior of "Added" event)
+    const { data: primaryData, mimeType: primaryMimeType } =
+      selectPrimaryRepresentation(representations);
 
     ops.push(
       tables.outputs.insert({
@@ -712,6 +773,18 @@ const materializers = State.SQLite.materializers(events, {
       }),
     );
     return ops;
+  },
+
+  "v1.MultimediaDisplayOutputUpdated": (
+    { displayId, representations },
+    ctx,
+  ) => {
+    // Only update existing displays - no new output creation
+    return updateExistingDisplays(
+      displayId,
+      representations,
+      ctx,
+    );
   },
 
   "v1.MultimediaResultOutputAdded": (


### PR DESCRIPTION
- Add multimediaDisplayOutputUpdated event for update-only operations
- Materializer now looks up displayId globally, not per-cell
- display() updates existing displays AND creates new output
- update() only updates existing displays (no new output)
- Both same-cell and cross-cell updates now working correctly
- Extract helper functions for representation selection and display updates
- Reduce code duplication between materializers
- Clearer separation: Added always creates, Updated only updates
- Maintain same behavior but with better maintainability