### PR TITLE
Refactor to MediaContainer system with per-mimetype artifact support

### DIFF
--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -135,7 +135,7 @@ export function buildConversationMessages(
       if (cell.outputs && cell.outputs.length > 0) {
         cellMessage += `\n\nOutput:\n`;
         cell.outputs.forEach((output) => {
-          if (output.outputType === "stream" && output.data.text) {
+          if (output.outputType === "terminal" && output.data.text) {
             cellMessage += `\`\`\`\n${
               stripAnsi(String(output.data.text))
             }\`\`\`\n`;

--- a/packages/ai/test/conversation-snapshot.test.ts
+++ b/packages/ai/test/conversation-snapshot.test.ts
@@ -32,7 +32,7 @@ Deno.test("AI conversation rendering - code cell context", () => {
         position: 1,
         outputs: [
           {
-            outputType: "stream",
+            outputType: "terminal",
             data: { "text": "   A\n0  1\n1  2\n2  3" },
           },
         ],
@@ -539,7 +539,7 @@ Deno.test("AI conversation rendering - complex interleaved conversation", () => 
         position: 1,
         outputs: [
           {
-            outputType: "stream",
+            outputType: "terminal",
             data: { text: "hello" },
           },
         ],
@@ -712,7 +712,7 @@ Deno.test("AI conversation rendering - complete integration flow", () => {
         position: 1,
         outputs: [
           {
-            outputType: "stream",
+            outputType: "terminal",
             data: { text: "Data: [1, 2, 3, 4, 5]" },
           },
         ],
@@ -1066,7 +1066,7 @@ Deno.test("AI conversation rendering - integrated code cells in conversation", (
         position: 1,
         outputs: [
           {
-            outputType: "stream",
+            outputType: "terminal",
             data: { text: "   A\n0  1\n1  2\n2  3" },
           },
         ],
@@ -1093,7 +1093,7 @@ Deno.test("AI conversation rendering - integrated code cells in conversation", (
         position: 3,
         outputs: [
           {
-            outputType: "stream",
+            outputType: "terminal",
             data: { text: "Mean: 2.0" },
           },
         ],

--- a/packages/lib/mod.ts
+++ b/packages/lib/mod.ts
@@ -24,7 +24,7 @@ export type {
   ExecutionResult,
   ModelCapability,
   OutputType,
-  RichOutputData,
+  RawOutputData,
   RuntimeAgentEventHandlers,
   RuntimeAgentOptions,
   RuntimeCapabilities,

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -7,7 +7,7 @@ import {
   type Store,
 } from "npm:@livestore/livestore";
 import { makeCfSync } from "npm:@livestore/sync-cf";
-import { events, schema, tables } from "@runt/schema";
+import { events, type MediaRepresentation, schema, tables } from "@runt/schema";
 import { createLogger } from "./logging.ts";
 import type {
   CancellationHandler,
@@ -581,9 +581,24 @@ export class RuntimeAgent {
         data: RichOutputData,
         metadata?: Record<string, unknown>,
       ) => {
-        // For updated displays, we need to find the output and replace it
-        // This is a simplified implementation - could be enhanced
-        context.display(data, metadata, displayId);
+        // For updated displays, use the dedicated update event (no new output created)
+        const representations: Record<
+          string,
+          MediaRepresentation
+        > = {};
+
+        for (const [mimeType, content] of Object.entries(data)) {
+          representations[mimeType] = {
+            type: "inline",
+            data: content, // Keep JSON objects as-is, don't stringify
+            metadata: metadata?.[mimeType] as Record<string, unknown>,
+          };
+        }
+
+        this.store.commit(events.multimediaDisplayOutputUpdated({
+          displayId,
+          representations,
+        }));
       },
 
       result: (

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -7,7 +7,7 @@ import {
   type Store,
 } from "npm:@livestore/livestore";
 import { makeCfSync } from "npm:@livestore/sync-cf";
-import { events, type MediaRepresentation, schema, tables } from "@runt/schema";
+import { events, type MediaContainer, schema, tables } from "@runt/schema";
 import { createLogger } from "./logging.ts";
 import type {
   CancellationHandler,
@@ -16,7 +16,7 @@ import type {
   ExecutionHandler,
   ExecutionQueueData,
   ExecutionResult,
-  RichOutputData,
+  RawOutputData,
   RuntimeAgentEventHandlers,
   RuntimeCapabilities,
   RuntimeSessionData,
@@ -549,14 +549,14 @@ export class RuntimeAgent {
       },
 
       display: (
-        data: RichOutputData,
+        data: RawOutputData,
         metadata?: Record<string, unknown>,
         displayId?: string,
       ) => {
-        // Convert MediaBundle to representations
+        // Convert raw data to MediaContainer representations
         const representations: Record<
           string,
-          { type: "inline"; data: unknown; metadata?: Record<string, unknown> }
+          MediaContainer
         > = {};
 
         for (const [mimeType, content] of Object.entries(data)) {
@@ -578,13 +578,13 @@ export class RuntimeAgent {
 
       updateDisplay: (
         displayId: string,
-        data: RichOutputData,
+        data: RawOutputData,
         metadata?: Record<string, unknown>,
       ) => {
         // For updated displays, use the dedicated update event (no new output created)
         const representations: Record<
           string,
-          MediaRepresentation
+          MediaContainer
         > = {};
 
         for (const [mimeType, content] of Object.entries(data)) {
@@ -602,13 +602,13 @@ export class RuntimeAgent {
       },
 
       result: (
-        data: RichOutputData,
+        data: RawOutputData,
         metadata?: Record<string, unknown>,
       ) => {
-        // Convert MediaBundle to representations
+        // Convert raw data to MediaContainer representations
         const representations: Record<
           string,
-          { type: "inline"; data: unknown; metadata?: Record<string, unknown> }
+          MediaContainer
         > = {};
 
         for (const [mimeType, content] of Object.entries(data)) {

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -9,9 +9,16 @@ import type {
   CellData,
   ExecutionQueueData,
   OutputType,
-  RichOutputData,
   schema,
 } from "@runt/schema";
+
+/**
+ * Raw output data format accepted by context.display() methods
+ * This is converted internally to MediaContainer format
+ */
+export interface RawOutputData {
+  [mimeType: string]: unknown;
+}
 
 /**
  * Configuration options for runtime agents
@@ -100,19 +107,19 @@ export interface ExecutionContext {
   stderr: (text: string) => void;
   /** Emit rich display data (plots, HTML, etc.) */
   display: (
-    data: RichOutputData,
+    data: RawOutputData,
     metadata?: Record<string, unknown>,
     displayId?: string,
   ) => void;
   /** Update existing display data by display ID */
   updateDisplay: (
     displayId: string,
-    data: RichOutputData,
+    data: RawOutputData,
     metadata?: Record<string, unknown>,
   ) => void;
   /** Emit execution result (final output) */
   result: (
-    data: RichOutputData,
+    data: RawOutputData,
     metadata?: Record<string, unknown>,
   ) => void;
   /** Emit error output */
@@ -138,7 +145,7 @@ export interface ExecutionResult {
   /** Whether execution succeeded */
   success: boolean;
   /** Optional final output data (for simple cases) */
-  data?: RichOutputData;
+  data?: RawOutputData;
   /** Optional metadata for final output */
   metadata?: Record<string, unknown>;
   /** Error message if execution failed */
@@ -220,7 +227,5 @@ export type {
   ErrorOutputData,
   ExecutionQueueData,
   OutputType,
-  RichOutputData,
   RuntimeSessionData,
-  StreamOutputData,
 } from "@runt/schema";

--- a/packages/pyodide-runtime-agent/test/real-execution.test.ts
+++ b/packages/pyodide-runtime-agent/test/real-execution.test.ts
@@ -6,8 +6,11 @@ import {
   assertStringIncludes,
 } from "jsr:@std/assert";
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
-import type { ExecutionContext, ExecutionResult } from "@runt/lib/types";
-import type { RichOutputData } from "@runt/schema";
+import type {
+  ExecutionContext,
+  ExecutionResult,
+  RawOutputData,
+} from "@runt/lib/types";
 
 // Create test agent with minimal packages for speed
 function createTestAgent(packages?: string[]): PyodideRuntimeAgent {
@@ -93,16 +96,16 @@ function createTestExecutionContext(code: string): {
     },
     stdout: (text: string) => outputs.push({ type: "stdout", data: text }),
     stderr: (text: string) => outputs.push({ type: "stderr", data: text }),
-    result: (data: RichOutputData, metadata?: Record<string, unknown>) =>
+    result: (data: RawOutputData, metadata?: Record<string, unknown>) =>
       outputs.push({ type: "result", data, metadata: metadata || undefined }),
     display: (
-      data: RichOutputData,
+      data: RawOutputData,
       metadata?: Record<string, unknown>,
     ) =>
       outputs.push({ type: "display", data, metadata: metadata || undefined }),
     updateDisplay: (
       _displayId: string,
-      data: RichOutputData,
+      data: RawOutputData,
       metadata?: Record<string, unknown>,
     ) =>
       outputs.push({ type: "display", data, metadata: metadata || undefined }),

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -392,6 +392,17 @@ export const events = {
     }),
   }),
 
+  multimediaDisplayOutputUpdated: Events.synced({
+    name: "v1.MultimediaDisplayOutputUpdated",
+    schema: Schema.Struct({
+      displayId: Schema.String,
+      representations: Schema.Record({
+        key: Schema.String,
+        value: MediaRepresentationSchema,
+      }),
+    }),
+  }),
+
   multimediaResultOutputAdded: Events.synced({
     name: "v1.MultimediaResultOutputAdded",
     schema: Schema.Struct({
@@ -499,6 +510,62 @@ export const events = {
   // UI state
   uiStateSet: tables.uiState.set,
 };
+
+// Helper function to select primary representation from multimedia data
+function selectPrimaryRepresentation(representations: Record<string, any>) {
+  const preferenceOrder = [
+    "text/html",
+    "image/png",
+    "image/jpeg",
+    "image/svg+xml",
+    "application/json",
+    "text/plain",
+  ];
+
+  for (const mimeType of preferenceOrder) {
+    if (representations[mimeType]) {
+      const rep = representations[mimeType];
+      return {
+        data: rep.type === "inline" ? String(rep.data || "") : "",
+        mimeType,
+      };
+    }
+  }
+
+  return { data: "", mimeType: "text/plain" };
+}
+
+// Helper function to update existing displays with same displayId
+function updateExistingDisplays(
+  displayId: string,
+  representations: Record<string, any>,
+  ctx: any,
+) {
+  const existingOutputs = ctx.query(
+    tables.outputs.select().where({
+      displayId,
+      outputType: "multimedia_display",
+    }),
+  );
+
+  if (existingOutputs.length === 0) {
+    return [];
+  }
+
+  const { data: primaryData, mimeType: primaryMimeType } =
+    selectPrimaryRepresentation(representations);
+
+  return [
+    tables.outputs.update({
+      data: primaryData,
+      mimeType: primaryMimeType,
+      representations,
+    }).where({
+      displayId,
+      outputType: "multimedia_display",
+    }),
+  ];
+}
 
 // Materializers map events to state changes
 const materializers = State.SQLite.materializers(events, {
@@ -676,26 +743,20 @@ const materializers = State.SQLite.materializers(events, {
       ops.push(tables.pendingClears.delete().where({ cellId }));
     }
 
-    // Choose primary representation
-    const preferenceOrder = [
-      "text/html",
-      "image/png",
-      "image/jpeg",
-      "image/svg+xml",
-      "application/json",
-      "text/plain",
-    ];
-    let primaryData = "";
-    let primaryMimeType = "text/plain";
-
-    for (const mimeType of preferenceOrder) {
-      if (representations[mimeType]) {
-        const rep = representations[mimeType];
-        primaryData = rep.type === "inline" ? String(rep.data || "") : "";
-        primaryMimeType = mimeType;
-        break;
-      }
+    // If displayId provided, update all existing displays with same ID first
+    if (displayId) {
+      ops.push(
+        ...updateExistingDisplays(
+          displayId,
+          representations,
+          ctx,
+        ),
+      );
     }
+
+    // Always create new output (core behavior of "Added" event)
+    const { data: primaryData, mimeType: primaryMimeType } =
+      selectPrimaryRepresentation(representations);
 
     ops.push(
       tables.outputs.insert({
@@ -712,6 +773,18 @@ const materializers = State.SQLite.materializers(events, {
       }),
     );
     return ops;
+  },
+
+  "v1.MultimediaDisplayOutputUpdated": (
+    { displayId, representations },
+    ctx,
+  ) => {
+    // Only update existing displays - no new output creation
+    return updateExistingDisplays(
+      displayId,
+      representations,
+      ctx,
+    );
   },
 
   "v1.MultimediaResultOutputAdded": (

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -7,6 +7,23 @@ import {
   type Store as LiveStore,
 } from "@livestore/livestore";
 
+// Base generic types for MediaContainer system
+export type InlineContainer<T = unknown> = {
+  type: "inline";
+  data: T;
+  metadata?: Record<string, unknown> | undefined;
+};
+
+export type ArtifactContainer = {
+  type: "artifact";
+  artifactId: string;
+  metadata?: Record<string, unknown> | undefined;
+};
+
+export type MediaContainer<T = unknown> =
+  | InlineContainer<T>
+  | ArtifactContainer;
+
 // Media representation schema for unified output system - defined first for use in events
 const MediaRepresentationSchema = Schema.Union(
   Schema.Struct({
@@ -512,33 +529,34 @@ export const events = {
 };
 
 // Helper function to select primary representation from multimedia data
-function selectPrimaryRepresentation(representations: Record<string, any>) {
-  const preferenceOrder = [
+function selectPrimaryRepresentation(
+  representations: Record<string, MediaContainer>,
+  preferredMimeTypes: string[] = [
     "text/html",
     "image/png",
     "image/jpeg",
     "image/svg+xml",
     "application/json",
     "text/plain",
-  ];
-
-  for (const mimeType of preferenceOrder) {
+  ],
+): { mimeType: string; container: MediaContainer } | null {
+  for (const mimeType of preferredMimeTypes) {
     if (representations[mimeType]) {
-      const rep = representations[mimeType];
       return {
-        data: rep.type === "inline" ? String(rep.data || "") : "",
         mimeType,
+        container: representations[mimeType],
       };
     }
   }
 
-  return { data: "", mimeType: "text/plain" };
+  return null;
 }
 
 // Helper function to update existing displays with same displayId
 function updateExistingDisplays(
   displayId: string,
-  representations: Record<string, any>,
+  representations: Record<string, MediaContainer>,
+  // deno-lint-ignore no-explicit-any
   ctx: any,
 ) {
   const existingOutputs = ctx.query(
@@ -552,13 +570,18 @@ function updateExistingDisplays(
     return [];
   }
 
-  const { data: primaryData, mimeType: primaryMimeType } =
-    selectPrimaryRepresentation(representations);
+  const primaryRep = selectPrimaryRepresentation(representations);
+  if (!primaryRep) {
+    return [];
+  }
+
+  const { mimeType, container } = primaryRep;
+  const data = container.type === "inline" ? String(container.data || "") : "";
 
   return [
     tables.outputs.update({
-      data: primaryData,
-      mimeType: primaryMimeType,
+      data,
+      mimeType,
       representations,
     }).where({
       displayId,
@@ -755,8 +778,13 @@ const materializers = State.SQLite.materializers(events, {
     }
 
     // Always create new output (core behavior of "Added" event)
-    const { data: primaryData, mimeType: primaryMimeType } =
-      selectPrimaryRepresentation(representations);
+    const primaryRep = selectPrimaryRepresentation(representations);
+    const primaryData = primaryRep
+      ? (primaryRep.container.type === "inline"
+        ? String(primaryRep.container.data || "")
+        : "")
+      : "";
+    const primaryMimeType = primaryRep ? primaryRep.mimeType : "text/plain";
 
     ops.push(
       tables.outputs.insert({
@@ -1042,28 +1070,28 @@ export type QueueStatus =
   | "cancelled";
 
 // Output types
-export type OutputType = "display_data" | "execute_result" | "stream" | "error";
+export type OutputType =
+  | "display_data"
+  | "execute_result"
+  | "terminal"
+  | "error";
 
-// TypeScript type derived from schema
-export type MediaRepresentation = {
-  type: "inline";
-  data: unknown;
-  metadata?: Record<string, unknown>;
-} | {
-  type: "artifact";
-  artifactId: string;
-  metadata?: Record<string, unknown>;
-};
+// Type guards for MediaContainer
+export function isInlineContainer<T>(
+  container: MediaContainer,
+): container is InlineContainer<T> {
+  return container.type === "inline";
+}
+
+export function isArtifactContainer(
+  container: MediaContainer,
+): container is ArtifactContainer {
+  return container.type === "artifact";
+}
 
 // Output data types for different output formats
 export interface RichOutputData {
-  "text/plain"?: string;
-  "text/markdown"?: string;
-  "text/html"?: string;
-  "image/svg+xml"?: string;
-  "image/svg"?: string;
-  "application/json"?: unknown;
-  [key: string]: unknown;
+  [mimeType: string]: MediaContainer;
 }
 
 // Error output structure
@@ -1072,12 +1100,6 @@ export interface ErrorOutputData {
   ename: string;
   evalue: string;
   traceback: string[];
-}
-
-// Stream output structure
-export interface StreamOutputData {
-  name: "stdout" | "stderr";
-  text: string;
 }
 
 // Type guards for output data
@@ -1092,22 +1114,10 @@ export function isErrorOutput(data: unknown): data is ErrorOutputData {
   );
 }
 
-export function isStreamOutput(data: unknown): data is StreamOutputData {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "name" in data &&
-    "text" in data &&
-    ["stdout", "stderr"].includes((data as StreamOutputData).name) &&
-    typeof (data as StreamOutputData).text === "string"
-  );
-}
-
 export function isRichOutput(data: unknown): data is RichOutputData {
   return (
     typeof data === "object" &&
     data !== null &&
-    !isErrorOutput(data) &&
-    !isStreamOutput(data)
+    !isErrorOutput(data)
   );
 }


### PR DESCRIPTION
Implements the foundation for per-mimetype artifact storage as outlined in #64.

## Changes

**New MediaContainer Types**
- `InlineContainer<T>` - for inline data with optional metadata
- `ArtifactContainer` - for artifact references with artifactId  
- `MediaContainer<T>` - discriminated union enabling mixed storage strategies

**Output Type Standardization**
- Remove `stream` output type, standardize on `terminal`
- Update AI package references throughout

**Clean API Boundary**
- `RawOutputData` type for developer-facing `context.display()` calls
- `RichOutputData` uses `MediaContainer` internally
- `context.display()` converts raw data to MediaContainer format

**Per-Mimetype Flexibility**
- Each representation can independently be inline or artifact
- Enables `{"image/png": {artifactId: "..."}, "text/plain": {data: "..."}}`
- Sets up size-based thresholding for artifact service

## Benefits

- **Artifact-ready**: Framework in place for #64
- **Memory efficient**: Large outputs can reference external storage
- **Type safe**: Generic system allows typed containers
- **Developer friendly**: Existing code works, conversion internal
- **Performance**: Reduces SQLite memory pressure for large outputs