### PR TITLE
Big ol' refactor to make sure AI sees it all

### DIFF
--- a/packages/ai/media-utils.ts
+++ b/packages/ai/media-utils.ts
@@ -1,0 +1,205 @@
+/**
+ * AI-specific media utilities for converting rich output to LLM-friendly formats
+ *
+ * This module provides utilities for converting Jupyter-style rich output
+ * into formats that work well with Large Language Models, while preserving
+ * the flexibility to extend with custom AI-specific transformations.
+ */
+
+import { IMAGE_MIME_TYPES, type MediaContainer } from "@runt/schema";
+
+/**
+ * Media bundle interface for AI processing
+ * Maps MIME types to their content representations
+ */
+export interface AIMediaBundle {
+  [mimeType: string]: unknown;
+}
+
+/**
+ * Rich output data structure used in notebook outputs
+ */
+export interface RichOutputData {
+  [mimeType: string]: MediaContainer;
+}
+
+/**
+ * Convert rich notebook output to AI-friendly formats
+ *
+ * AI models work better with certain formats:
+ * - Markdown is more compact and structured than HTML
+ * - JSON preserves data structure for reasoning
+ * - Images work with vision-capable models
+ * - Plain text provides universal fallback
+ *
+ * @example
+ * ```typescript
+ * const richOutput = {
+ *   "text/html": { type: "inline", data: "<h1>Sales Report</h1>" },
+ *   "text/markdown": { type: "inline", data: "# Sales Report" },
+ *   "application/json": { type: "inline", data: { revenue: 10000 } }
+ * };
+ *
+ * const aiBundle = toAIMediaBundle(richOutput);
+ * // Prefers markdown over HTML, keeps JSON structure
+ * ```
+ */
+export function toAIMediaBundle(richOutput: RichOutputData): AIMediaBundle {
+  const result: AIMediaBundle = {};
+
+  // Always include text/plain if available
+  if (richOutput["text/plain"]) {
+    const container = richOutput["text/plain"];
+    if (container.type === "inline") {
+      result["text/plain"] = container.data;
+    }
+  }
+
+  // Prefer markdown over HTML for AI
+  if (richOutput["text/markdown"]) {
+    const container = richOutput["text/markdown"];
+    if (container.type === "inline") {
+      result["text/markdown"] = container.data;
+    }
+  } else if (richOutput["text/html"]) {
+    const container = richOutput["text/html"];
+    if (container.type === "inline" && typeof container.data === "string") {
+      // Convert HTML to plain text for AI if no markdown available
+      const plainFromHtml = container.data.replace(/<[^>]*>/g, "");
+      if (!result["text/plain"]) {
+        result["text/plain"] = plainFromHtml;
+      }
+    }
+  }
+
+  // Include JSON for structured data
+  if (richOutput["application/json"]) {
+    const container = richOutput["application/json"];
+    if (container.type === "inline") {
+      result["application/json"] = container.data;
+    }
+  }
+
+  // Include images that some AI providers support
+  for (const imageType of IMAGE_MIME_TYPES) {
+    if (richOutput[imageType]) {
+      const container = richOutput[imageType];
+      if (container.type === "inline") {
+        result[imageType] = container.data;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Ensure every media bundle has text/plain for maximum AI compatibility
+ *
+ * Some AI providers only support text, and text/plain ensures your output
+ * is never completely invisible to an AI system.
+ *
+ * @example
+ * ```typescript
+ * const bundle = { "text/html": "<b>Important data</b>" };
+ * const withFallback = ensureTextPlainFallback(bundle);
+ * // { "text/html": "<b>Important data</b>", "text/plain": "Important data" }
+ * ```
+ */
+export function ensureTextPlainFallback(bundle: AIMediaBundle): AIMediaBundle {
+  if (bundle["text/plain"]) {
+    return bundle;
+  }
+
+  const result = { ...bundle };
+
+  // Try to generate text/plain from other formats
+  if (typeof result["text/html"] === "string") {
+    // Strip HTML tags for plain text
+    result["text/plain"] = result["text/html"].replace(/<[^>]*>/g, "");
+  } else if (typeof result["text/markdown"] === "string") {
+    // Markdown is readable as plain text
+    result["text/plain"] = result["text/markdown"];
+  } else {
+    // Use first available string content
+    const firstStringValue = Object.values(result).find(
+      (value): value is string => typeof value === "string",
+    );
+    if (firstStringValue) {
+      result["text/plain"] = firstStringValue;
+    } else {
+      // Last resort: JSON stringify first available content
+      const firstEntry = Object.entries(result)[0];
+      if (firstEntry && firstEntry[1] != null) {
+        try {
+          result["text/plain"] = JSON.stringify(firstEntry[1], null, 2);
+        } catch {
+          result["text/plain"] = String(firstEntry[1]);
+        }
+      } else {
+        result["text/plain"] = "";
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert rich output data to a simplified format for AI context
+ *
+ * This function prioritizes content types that work well with LLMs:
+ * 1. Markdown over HTML (better structure, less noise)
+ * 2. Plain text as universal fallback
+ * 3. JSON for structured data
+ * 4. Images for vision-capable models
+ *
+ * Skips verbose formats like HTML with embedded CSS/JS.
+ */
+export function toAIContext(richOutput: RichOutputData): string {
+  const aiBundle = toAIMediaBundle(richOutput);
+  const withFallback = ensureTextPlainFallback(aiBundle);
+
+  // Prioritize markdown for AI readability
+  if (withFallback["text/markdown"]) {
+    return String(withFallback["text/markdown"]);
+  }
+
+  // Fall back to plain text
+  if (withFallback["text/plain"]) {
+    return String(withFallback["text/plain"]);
+  }
+
+  // Last resort: JSON representation
+  if (withFallback["application/json"]) {
+    try {
+      return JSON.stringify(withFallback["application/json"], null, 2);
+    } catch {
+      return String(withFallback["application/json"]);
+    }
+  }
+
+  return "";
+}
+
+/**
+ * Check if rich output contains visual content (images, plots, etc.)
+ */
+export function hasVisualContent(richOutput: RichOutputData): boolean {
+  return IMAGE_MIME_TYPES.some((mimeType) =>
+    richOutput[mimeType] && richOutput[mimeType].type === "inline"
+  );
+}
+
+/**
+ * Extract structured data from rich output for AI analysis
+ */
+export function extractStructuredData(richOutput: RichOutputData): unknown {
+  if (richOutput["application/json"]) {
+    const container = richOutput["application/json"];
+    if (container.type === "inline") {
+      return container.data;
+    }
+  }
+  return null;
+}

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -304,7 +304,7 @@ export async function executeAI(
       if (isOllamaReady) {
         const openaiMessages = buildConversationMessages(
           notebookContext,
-          "You are an AI assistant in a collaborative notebook environment. You can see all cell outputs (including terminal text, plots, tables, and errors) from code that has been executed. You cannot execute code yourself, but you can see the results when users run cells. Use the visible outputs to help analyze data and answer questions.",
+          "You are an AI assistant in a collaborative notebook environment. You can see all cell outputs (including terminal text, plots, tables, and errors) from code that has been executed. You can also execute code yourself using tool calls. Use the visible outputs and your execution capabilities to help analyze data and answer questions.",
           prompt,
         );
 
@@ -424,7 +424,7 @@ The system will automatically pull models if they're not available locally.`;
       // Use conversation-based approach for better AI interaction
       const conversationMessages = buildConversationMessages(
         notebookContext,
-        "You are an AI assistant in a collaborative notebook environment. You can see all cell outputs (including terminal text, plots, tables, and errors) from code that has been executed. You cannot execute code yourself, but you can see the results when users run cells. Use the visible outputs to help analyze data and answer questions.",
+        "You are an AI assistant in a collaborative notebook environment. You can see all cell outputs (including terminal text, plots, tables, and errors) from code that has been executed. You can also execute code yourself using tool calls. Use the visible outputs and your execution capabilities to help analyze data and answer questions.",
         prompt,
       );
 

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -304,7 +304,7 @@ export async function executeAI(
       if (isOllamaReady) {
         const openaiMessages = buildConversationMessages(
           notebookContext,
-          "This is a pyodide based notebook environment with assistant and user access to the same runtime. Users see and edit the same notebook as you. When you execute cells, the user sees the output as well",
+          "You are an AI assistant in a collaborative notebook environment. You can see all cell outputs (including terminal text, plots, tables, and errors) from code that has been executed. You cannot execute code yourself, but you can see the results when users run cells. Use the visible outputs to help analyze data and answer questions.",
           prompt,
         );
 
@@ -424,7 +424,7 @@ The system will automatically pull models if they're not available locally.`;
       // Use conversation-based approach for better AI interaction
       const conversationMessages = buildConversationMessages(
         notebookContext,
-        "This is a pyodide based notebook environment with assistant and user access to the same runtime. Users see and edit the same notebook as you. When you execute cells, the user sees the output as well",
+        "You are an AI assistant in a collaborative notebook environment. You can see all cell outputs (including terminal text, plots, tables, and errors) from code that has been executed. You cannot execute code yourself, but you can see the results when users run cells. Use the visible outputs to help analyze data and answer questions.",
         prompt,
       );
 

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -157,20 +157,45 @@ export function buildConversationMessages(
     );
     if (cell.cellType === "ai" && cell.outputs && cell.outputs.length > 0) {
       // Process AI cell outputs sequentially - each output becomes a message
-      cell.outputs.forEach((output) => {
+      cell.outputs.forEach((output, outputIndex) => {
         const metadata = output.metadata as { anode?: { role?: string } };
         const role = metadata?.anode?.role;
+
+        logger.debug(
+          `Processing AI cell output ${outputIndex + 1}/${cell.outputs.length}`,
+          {
+            cellId: cell.id,
+            outputType: output.outputType,
+            role: role,
+            hasMetadata: !!output.metadata,
+            metadataKeys: output.metadata ? Object.keys(output.metadata) : [],
+            anodeMetadata: metadata?.anode,
+            hasData: !!output.data,
+            dataKeys: output.data && typeof output.data === "object"
+              ? Object.keys(output.data as Record<string, unknown>)
+              : [],
+            hasMarkdown: output.data && typeof output.data === "object"
+              ? "text/markdown" in output.data
+              : false,
+          },
+        );
 
         if (
           role === "assistant" && output.data &&
           typeof output.data === "object" && "text/markdown" in output.data
         ) {
           // Assistant text response
+          const markdownContent = String(
+            (output.data as Record<string, unknown>)["text/markdown"],
+          );
+          logger.debug("Adding assistant message to conversation", {
+            cellId: cell.id,
+            contentLength: markdownContent.length,
+            contentPreview: markdownContent.substring(0, 100),
+          });
           messages.push({
             role: "assistant" as const,
-            content: String(
-              (output.data as Record<string, unknown>)["text/markdown"],
-            ),
+            content: markdownContent,
           });
         } else if (role === "function_call") {
           // Tool call - create assistant message with tool_calls

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -14,6 +14,17 @@ import type { Store } from "@runt/schema";
 import { OpenAIClient } from "./openai-client.ts";
 import { RuntOllamaClient } from "./ollama-client.ts";
 
+// Export AI-specific media utilities
+export {
+  type AIMediaBundle,
+  ensureTextPlainFallback,
+  extractStructuredData,
+  hasVisualContent,
+  type RichOutputData,
+  toAIContext,
+  toAIMediaBundle,
+} from "./media-utils.ts";
+
 type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
 
 // Helper types for accessing tool call properties

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -9,7 +9,7 @@ import type {
 } from "@runt/lib";
 
 import { handleToolCallWithResult } from "./tool-registry.ts";
-import type { Store } from "@runt/schema";
+import type { MediaContainer, OutputData, Store } from "@runt/schema";
 
 import { OpenAIClient } from "./openai-client.ts";
 import { RuntOllamaClient } from "./ollama-client.ts";
@@ -79,8 +79,9 @@ export interface CellContextData {
   position: number;
   outputs: Array<{
     outputType: string;
-    data: Record<string, unknown>;
+    data: unknown;
     metadata?: Record<string, unknown>;
+    representations?: Record<string, MediaContainer>;
   }>;
 }
 
@@ -107,37 +108,54 @@ export function buildConversationMessages(
         const metadata = output.metadata as { anode?: { role?: string } };
         const role = metadata?.anode?.role;
 
-        if (role === "assistant" && output.data["text/markdown"]) {
+        if (
+          role === "assistant" && output.data &&
+          typeof output.data === "object" && "text/markdown" in output.data
+        ) {
           // Assistant text response
           messages.push({
             role: "assistant" as const,
-            content: String(output.data["text/markdown"]),
+            content: String(
+              (output.data as Record<string, unknown>)["text/markdown"],
+            ),
           });
         } else if (role === "function_call") {
           // Tool call - create assistant message with tool_calls
-          const toolData = output
-            .data["application/vnd.anode.aitool+json"] as ToolCallData;
-          messages.push({
-            role: "assistant" as const,
-            content: "", // Empty content for pure tool call
-            tool_calls: [{
-              id: toolData.tool_call_id,
-              type: "function" as const,
-              function: {
-                name: toolData.tool_name,
-                arguments: JSON.stringify(toolData.arguments),
-              },
-            }],
-          });
+          const toolData = output.data && typeof output.data === "object" &&
+              "application/vnd.anode.aitool+json" in output.data
+            ? (output.data as Record<string, unknown>)[
+              "application/vnd.anode.aitool+json"
+            ] as ToolCallData
+            : null;
+          if (toolData) {
+            messages.push({
+              role: "assistant" as const,
+              content: "", // Empty content for pure tool call
+              tool_calls: [{
+                id: toolData.tool_call_id,
+                type: "function" as const,
+                function: {
+                  name: toolData.tool_name,
+                  arguments: JSON.stringify(toolData.arguments),
+                },
+              }],
+            });
+          }
         } else if (role === "tool") {
           // Tool result
-          const resultData = output
-            .data["application/vnd.anode.aitool.result+json"] as ToolResultData;
-          messages.push({
-            role: "tool" as const,
-            content: resultData.result || "Success",
-            tool_call_id: resultData.tool_call_id,
-          });
+          const resultData = output.data && typeof output.data === "object" &&
+              "application/vnd.anode.aitool.result+json" in output.data
+            ? (output.data as Record<string, unknown>)[
+              "application/vnd.anode.aitool.result+json"
+            ] as ToolResultData
+            : null;
+          if (resultData) {
+            messages.push({
+              role: "tool" as const,
+              content: resultData.result || "Success",
+              tool_call_id: resultData.tool_call_id,
+            });
+          }
         }
       });
     } else if (cell.cellType === "code" || cell.cellType === "sql") {
@@ -149,29 +167,73 @@ export function buildConversationMessages(
       if (cell.outputs && cell.outputs.length > 0) {
         cellMessage += `\n\nOutput:\n`;
         cell.outputs.forEach((output) => {
-          if (output.outputType === "terminal" && output.data.text) {
-            cellMessage += `\`\`\`\n${
-              stripAnsi(String(output.data.text))
-            }\`\`\`\n`;
-          } else if (
-            output.outputType === "error" && output.data.ename &&
-            output.data.evalue
-          ) {
-            cellMessage += `\`\`\`\nError: ${
-              stripAnsi(String(output.data.ename))
-            }: ${stripAnsi(String(output.data.evalue))}\n\`\`\`\n`;
+          if (output.outputType === "terminal" && output.data) {
+            // Handle both old format (data.text) and new format (data as string)
+            const terminalText = typeof output.data === "object" &&
+                output.data !== null && "text" in output.data
+              ? String((output.data as Record<string, unknown>).text)
+              : String(output.data);
+            cellMessage += `\`\`\`\n${stripAnsi(terminalText)}\`\`\`\n`;
           } else if (
             (output.outputType === "execute_result" ||
               output.outputType === "display_data") &&
-            output.data["text/plain"]
+            output.data && typeof output.data === "object"
           ) {
-            cellMessage += `\`\`\`\n${
-              stripAnsi(String(output.data["text/plain"]))
-            }\n\`\`\`\n`;
+            // Handle execute_result and display_data outputs
+            const outputData = output.data as Record<string, unknown>;
+            if (outputData["text/plain"]) {
+              cellMessage += `\`\`\`\n${
+                stripAnsi(String(outputData["text/plain"]))
+              }\n\`\`\`\n`;
+            }
+            if (outputData["text/markdown"]) {
+              cellMessage += `${outputData["text/markdown"]}\n`;
+            }
+          } else if (
+            output.outputType === "error" && output.data
+          ) {
+            try {
+              const errorData = typeof output.data === "string"
+                ? JSON.parse(output.data)
+                : output.data;
+              cellMessage += `\`\`\`\nError: ${
+                stripAnsi(String(errorData.ename || "Unknown"))
+              }: ${
+                stripAnsi(String(errorData.evalue || "Unknown error"))
+              }\n\`\`\`\n`;
+            } catch {
+              cellMessage += `\`\`\`\nError: ${
+                stripAnsi(String(output.data))
+              }\n\`\`\`\n`;
+            }
+          } else if (
+            output.outputType === "markdown" && output.data
+          ) {
+            cellMessage += `${output.data}\n`;
+          } else if (
+            (output.outputType === "multimedia_result" ||
+              output.outputType === "multimedia_display") &&
+            output.representations
+          ) {
+            // Handle MediaContainer representations (at top level, not in data)
+            const representations = output.representations;
+
+            // Prioritize markdown for AI context
+            if (
+              representations &&
+              representations["text/markdown"]?.type === "inline"
+            ) {
+              cellMessage += `${representations["text/markdown"].data}\n`;
+            } else if (
+              representations &&
+              representations["text/plain"]?.type === "inline"
+            ) {
+              cellMessage += `\`\`\`\n${
+                stripAnsi(String(representations["text/plain"].data))
+              }\n\`\`\`\n`;
+            }
           }
-          if (output.data["text/markdown"]) {
-            cellMessage += `${output.data["text/markdown"]}\n`;
-          }
+
           // Future: Add image/multimodal support here
           // if (output.data["image/png"]) {
           //   cellMessage += `[Image output displayed]\n`;

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -9,14 +9,20 @@ import type {
 } from "@runt/lib";
 
 import { handleToolCallWithResult } from "./tool-registry.ts";
-import type { MediaContainer, Store } from "@runt/schema";
+import type {
+  AiToolCallData,
+  AiToolResultData,
+  MediaContainer,
+  Store,
+} from "@runt/schema";
+import { AI_TOOL_CALL_MIME_TYPE, AI_TOOL_RESULT_MIME_TYPE } from "@runt/schema";
 import { createLogger } from "@runt/lib";
 
 import { OpenAIClient } from "./openai-client.ts";
 import { RuntOllamaClient } from "./ollama-client.ts";
 
-// Export AI-specific media utilities
-export {
+// Import and export AI-specific media utilities
+import {
   type AIMediaBundle,
   ensureTextPlainFallback,
   extractStructuredData,
@@ -26,6 +32,17 @@ export {
   toAIMediaBundle,
 } from "./media-utils.ts";
 
+// Re-export for external use
+export {
+  type AIMediaBundle,
+  ensureTextPlainFallback,
+  extractStructuredData,
+  hasVisualContent,
+  type RichOutputData,
+  toAIContext,
+  toAIMediaBundle,
+};
+
 // Export notebook context functions
 export { gatherNotebookContext } from "./notebook-context.ts";
 
@@ -33,6 +50,34 @@ export { gatherNotebookContext } from "./notebook-context.ts";
 const logger = createLogger("ai-conversation");
 
 type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+
+// Extended message type for rich multimedia content
+export interface RichChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content:
+    | string
+    | Array<{
+      type: "text" | "image_url";
+      text?: string;
+      image_url?: {
+        url: string;
+        detail?: "low" | "high" | "auto";
+      };
+    }>;
+  tool_calls?: Array<{
+    id: string;
+    type: "function";
+    function: {
+      name: string;
+      arguments: string;
+    };
+  }>;
+  tool_call_id?: string;
+  // Preserve original multimedia data for AI clients that can handle it
+  multimedia?: {
+    [mimeType: string]: unknown;
+  };
+}
 
 // Helper types for accessing tool call properties
 type ChatMessageWithToolCalls = ChatMessage & {
@@ -52,20 +97,9 @@ type ChatMessageWithToolCallId = ChatMessage & {
   tool_call_id: string;
 };
 
-interface ToolResultData {
-  tool_call_id: string;
-  result?: string;
-  status: string;
-}
-
-export interface ToolCallData {
-  tool_call_id: string;
-  tool_name: string;
-  arguments: Record<string, unknown>;
-  status: "success" | "error";
-  timestamp: string;
-  execution_time_ms?: number;
-}
+// Use schema types for tool data
+export type ToolResultData = AiToolResultData;
+export type ToolCallData = AiToolCallData;
 
 export interface NotebookContextData {
   previousCells: CellContextData[];
@@ -141,10 +175,10 @@ export function buildConversationMessages(
         } else if (role === "function_call") {
           // Tool call - create assistant message with tool_calls
           const toolData = output.data && typeof output.data === "object" &&
-              "application/vnd.anode.aitool+json" in output.data
+              AI_TOOL_CALL_MIME_TYPE in output.data
             ? (output.data as Record<string, unknown>)[
-              "application/vnd.anode.aitool+json"
-            ] as ToolCallData
+              AI_TOOL_CALL_MIME_TYPE
+            ] as AiToolCallData
             : null;
           if (toolData) {
             messages.push({
@@ -163,10 +197,10 @@ export function buildConversationMessages(
         } else if (role === "tool") {
           // Tool result
           const resultData = output.data && typeof output.data === "object" &&
-              "application/vnd.anode.aitool.result+json" in output.data
+              AI_TOOL_RESULT_MIME_TYPE in output.data
             ? (output.data as Record<string, unknown>)[
-              "application/vnd.anode.aitool.result+json"
-            ] as ToolResultData
+              AI_TOOL_RESULT_MIME_TYPE
+            ] as AiToolResultData
             : null;
           if (resultData) {
             messages.push({
@@ -247,30 +281,59 @@ export function buildConversationMessages(
               plainType: representations["text/plain"]?.type,
             });
 
-            // Prioritize markdown for AI context
-            if (
-              representations &&
-              representations["text/markdown"]?.type === "inline"
-            ) {
-              const markdownContent = representations["text/markdown"].data;
-              logger.debug("Adding markdown content to conversation", {
-                cellId: cell.id,
-                contentLength: String(markdownContent).length,
-                fullContent: String(markdownContent),
-              });
-              cellMessage += `${markdownContent}\n`;
-            } else if (
-              representations &&
-              representations["text/plain"]?.type === "inline"
-            ) {
-              const plainContent = stripAnsi(
-                String(representations["text/plain"].data),
+            // Preserve full multimedia data for AI providers that support it
+            const aiBundle = toAIMediaBundle(representations as RichOutputData);
+            const hasRichContent = Object.keys(aiBundle).length > 0;
+
+            if (hasRichContent) {
+              logger.debug(
+                "Adding multimedia content to conversation",
+                {
+                  cellId: cell.id,
+                  mimeTypes: Object.keys(aiBundle),
+                  hasMarkdown: !!aiBundle["text/markdown"],
+                  hasPlain: !!aiBundle["text/plain"],
+                  hasImages: Object.keys(aiBundle).some((type) =>
+                    type.startsWith("image/")
+                  ),
+                  hasJson: !!aiBundle["application/json"],
+                },
               );
-              logger.debug("Adding plain text content to conversation", {
-                cellId: cell.id,
-                contentLength: plainContent.length,
-              });
-              cellMessage += `\`\`\`\n${plainContent}\n\`\`\`\n`;
+
+              // Prioritize markdown for structured text, but preserve other formats
+              if (aiBundle["text/markdown"]) {
+                cellMessage += `${aiBundle["text/markdown"]}\n`;
+              } else if (aiBundle["text/plain"]) {
+                cellMessage += `${aiBundle["text/plain"]}\n`;
+              }
+
+              // Include structured data as formatted JSON
+              if (aiBundle["application/json"]) {
+                try {
+                  const jsonContent = JSON.stringify(
+                    aiBundle["application/json"],
+                    null,
+                    2,
+                  );
+                  cellMessage +=
+                    `\n**Structured Data:**\n\`\`\`json\n${jsonContent}\n\`\`\`\n`;
+                } catch {
+                  cellMessage += `\n**Structured Data:** ${
+                    String(aiBundle["application/json"])
+                  }\n`;
+                }
+              }
+
+              // Note presence of visual content for AI awareness
+              if (
+                Object.keys(aiBundle).some((type) => type.startsWith("image/"))
+              ) {
+                cellMessage += `\n**Visual Content:** ${
+                  Object.keys(aiBundle).filter((type) =>
+                    type.startsWith("image/")
+                  ).join(", ")
+                } (available for vision-capable models)\n`;
+              }
             }
           }
 

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -180,19 +180,40 @@ export function buildConversationMessages(
           },
         );
 
+        // Handle markdown outputs from AI cells (streaming text responses)
         if (
-          role === "assistant" && output.data &&
-          typeof output.data === "object" && "text/markdown" in output.data
+          output.outputType === "markdown" &&
+          output.data &&
+          typeof output.data === "string" &&
+          metadata?.anode?.role === "assistant"
         ) {
-          // Assistant text response
-          const markdownContent = String(
-            (output.data as Record<string, unknown>)["text/markdown"],
-          );
-          logger.debug("Adding assistant message to conversation", {
+          // Assistant markdown response
+          const markdownContent = String(output.data);
+          logger.debug("Adding assistant markdown message to conversation", {
             cellId: cell.id,
             contentLength: markdownContent.length,
             contentPreview: markdownContent.substring(0, 100),
           });
+          messages.push({
+            role: "assistant" as const,
+            content: markdownContent,
+          });
+        } else if (
+          role === "assistant" && output.data &&
+          typeof output.data === "object" && "text/markdown" in output.data
+        ) {
+          // Assistant text response from display_data
+          const markdownContent = String(
+            (output.data as Record<string, unknown>)["text/markdown"],
+          );
+          logger.debug(
+            "Adding assistant display_data message to conversation",
+            {
+              cellId: cell.id,
+              contentLength: markdownContent.length,
+              contentPreview: markdownContent.substring(0, 100),
+            },
+          );
           messages.push({
             role: "assistant" as const,
             content: markdownContent,

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -25,6 +25,9 @@ export {
   toAIMediaBundle,
 } from "./media-utils.ts";
 
+// Export notebook context functions
+export { gatherNotebookContext } from "./notebook-context.ts";
+
 type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
 
 // Helper types for accessing tool call properties

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -157,28 +157,9 @@ export function buildConversationMessages(
     );
     if (cell.cellType === "ai" && cell.outputs && cell.outputs.length > 0) {
       // Process AI cell outputs sequentially - each output becomes a message
-      cell.outputs.forEach((output, outputIndex) => {
+      cell.outputs.forEach((output) => {
         const metadata = output.metadata as { anode?: { role?: string } };
         const role = metadata?.anode?.role;
-
-        logger.debug(
-          `Processing AI cell output ${outputIndex + 1}/${cell.outputs.length}`,
-          {
-            cellId: cell.id,
-            outputType: output.outputType,
-            role: role,
-            hasMetadata: !!output.metadata,
-            metadataKeys: output.metadata ? Object.keys(output.metadata) : [],
-            anodeMetadata: metadata?.anode,
-            hasData: !!output.data,
-            dataKeys: output.data && typeof output.data === "object"
-              ? Object.keys(output.data as Record<string, unknown>)
-              : [],
-            hasMarkdown: output.data && typeof output.data === "object"
-              ? "text/markdown" in output.data
-              : false,
-          },
-        );
 
         // Handle markdown outputs from AI cells (streaming text responses)
         if (
@@ -189,11 +170,6 @@ export function buildConversationMessages(
         ) {
           // Assistant markdown response
           const markdownContent = String(output.data);
-          logger.debug("Adding assistant markdown message to conversation", {
-            cellId: cell.id,
-            contentLength: markdownContent.length,
-            contentPreview: markdownContent.substring(0, 100),
-          });
           messages.push({
             role: "assistant" as const,
             content: markdownContent,
@@ -205,14 +181,6 @@ export function buildConversationMessages(
           // Assistant text response from display_data
           const markdownContent = String(
             (output.data as Record<string, unknown>)["text/markdown"],
-          );
-          logger.debug(
-            "Adding assistant display_data message to conversation",
-            {
-              cellId: cell.id,
-              contentLength: markdownContent.length,
-              contentPreview: markdownContent.substring(0, 100),
-            },
           );
           messages.push({
             role: "assistant" as const,

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -9,7 +9,8 @@ import type {
 } from "@runt/lib";
 
 import { handleToolCallWithResult } from "./tool-registry.ts";
-import type { MediaContainer, OutputData, Store } from "@runt/schema";
+import type { MediaContainer, Store } from "@runt/schema";
+import { createLogger } from "@runt/lib";
 
 import { OpenAIClient } from "./openai-client.ts";
 import { RuntOllamaClient } from "./ollama-client.ts";
@@ -27,6 +28,9 @@ export {
 
 // Export notebook context functions
 export { gatherNotebookContext } from "./notebook-context.ts";
+
+// Create logger for AI conversation debugging
+const logger = createLogger("ai-conversation");
 
 type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
 
@@ -95,13 +99,28 @@ export function buildConversationMessages(
 ): ChatMessage[] {
   const messages: ChatMessage[] = [];
 
+  logger.debug("Building conversation messages", {
+    totalCells: context.totalCells,
+    previousCellsCount: context.previousCells.length,
+    currentPosition: context.currentCellPosition,
+  });
+
   messages.push({
     role: "system" as const,
     content: systemPrompt,
   });
 
   // Process each cell in order, building sequential conversation
-  context.previousCells.forEach((cell) => {
+  context.previousCells.forEach((cell, cellIndex) => {
+    logger.debug(
+      `Processing cell ${cellIndex + 1}/${context.previousCells.length}`,
+      {
+        cellId: cell.id,
+        cellType: cell.cellType,
+        outputCount: cell.outputs?.length || 0,
+        position: cell.position,
+      },
+    );
     if (cell.cellType === "ai" && cell.outputs && cell.outputs.length > 0) {
       // Process AI cell outputs sequentially - each output becomes a message
       cell.outputs.forEach((output) => {
@@ -218,19 +237,40 @@ export function buildConversationMessages(
             // Handle MediaContainer representations (at top level, not in data)
             const representations = output.representations;
 
+            logger.debug("Found multimedia representations", {
+              cellId: cell.id,
+              outputType: output.outputType,
+              mimeTypes: Object.keys(representations),
+              hasMarkdown: !!representations["text/markdown"],
+              hasPlain: !!representations["text/plain"],
+              markdownType: representations["text/markdown"]?.type,
+              plainType: representations["text/plain"]?.type,
+            });
+
             // Prioritize markdown for AI context
             if (
               representations &&
               representations["text/markdown"]?.type === "inline"
             ) {
-              cellMessage += `${representations["text/markdown"].data}\n`;
+              const markdownContent = representations["text/markdown"].data;
+              logger.debug("Adding markdown content to conversation", {
+                cellId: cell.id,
+                contentLength: String(markdownContent).length,
+                contentPreview: String(markdownContent).substring(0, 100),
+              });
+              cellMessage += `${markdownContent}\n`;
             } else if (
               representations &&
               representations["text/plain"]?.type === "inline"
             ) {
-              cellMessage += `\`\`\`\n${
-                stripAnsi(String(representations["text/plain"].data))
-              }\n\`\`\`\n`;
+              const plainContent = stripAnsi(
+                String(representations["text/plain"].data),
+              );
+              logger.debug("Adding plain text content to conversation", {
+                cellId: cell.id,
+                contentLength: plainContent.length,
+              });
+              cellMessage += `\`\`\`\n${plainContent}\n\`\`\`\n`;
             }
           }
 
@@ -258,6 +298,14 @@ export function buildConversationMessages(
   messages.push({
     role: "user" as const,
     content: userPrompt,
+  });
+
+  logger.debug("Conversation messages built successfully", {
+    totalMessages: messages.length,
+    systemMessages: messages.filter((m) => m.role === "system").length,
+    userMessages: messages.filter((m) => m.role === "user").length,
+    assistantMessages: messages.filter((m) => m.role === "assistant").length,
+    toolMessages: messages.filter((m) => m.role === "tool").length,
   });
 
   return messages;

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -256,7 +256,7 @@ export function buildConversationMessages(
               logger.debug("Adding markdown content to conversation", {
                 cellId: cell.id,
                 contentLength: String(markdownContent).length,
-                contentPreview: String(markdownContent).substring(0, 100),
+                fullContent: String(markdownContent),
               });
               cellMessage += `${markdownContent}\n`;
             } else if (
@@ -559,7 +559,7 @@ The system will automatically pull models if they're not available locally.`;
           index: idx,
           role: msg.role,
           contentLength: msg.content?.length || 0,
-          contentPreview: msg.content?.slice(0, 100) || "",
+          fullContent: msg.content || "",
           hasToolCalls: !!(msg as ChatMessageWithToolCalls).tool_calls,
           toolCallCount: (msg as ChatMessageWithToolCalls).tool_calls?.length ||
             0,

--- a/packages/ai/notebook-context.ts
+++ b/packages/ai/notebook-context.ts
@@ -1,0 +1,67 @@
+/**
+ * Notebook context utilities for AI execution
+ *
+ * This module provides functions for gathering and processing notebook context
+ * for AI execution, preserving conversation flow and tool call information.
+ */
+
+import type { Store } from "@runt/schema";
+import { type CellData, type OutputData, tables } from "@runt/schema";
+import type { CellContextData, NotebookContextData } from "./mod.ts";
+
+/**
+ * Gather notebook context for AI execution with proper conversation flow
+ *
+ * This function preserves the original output structure including metadata
+ * that contains conversation roles and tool call information, unlike the
+ * destructive string conversion in the runtime agent.
+ */
+export function gatherNotebookContext(
+  store: Store,
+  currentCell: { id: string; position: number },
+): NotebookContextData {
+  // Query all cells in order
+  const allCells = store.query(
+    tables.cells.select().orderBy("position", "asc"),
+  );
+
+  // Get cells before current cell that should be included in AI context
+  const previousCells = allCells
+    .filter((cell: CellData) =>
+      cell.position < currentCell.position &&
+      cell.aiContextVisible !== false
+    )
+    .map((cell: CellData): CellContextData => {
+      // Query outputs for this cell in order
+      const outputs = store.query(
+        tables.outputs
+          .select()
+          .where({ cellId: cell.id })
+          .orderBy("position", "asc"),
+      );
+
+      // Convert outputs to AI context format, preserving ALL metadata
+      // This is crucial for maintaining conversation flow with tool calls
+      const contextOutputs = outputs.map((output: OutputData) => {
+        return {
+          outputType: output.outputType,
+          data: output.data || {},
+          metadata: output.metadata || {},
+        };
+      });
+
+      return {
+        id: cell.id,
+        cellType: cell.cellType,
+        source: cell.source || "",
+        position: cell.position,
+        outputs: contextOutputs,
+      };
+    });
+
+  return {
+    previousCells,
+    totalCells: allCells.length,
+    currentCellPosition: currentCell.position,
+  };
+}

--- a/packages/ai/notebook-context.ts
+++ b/packages/ai/notebook-context.ts
@@ -6,7 +6,12 @@
  */
 
 import type { Store } from "@runt/schema";
-import { type CellData, type OutputData, tables } from "@runt/schema";
+import {
+  type CellData,
+  type MediaContainer,
+  type OutputData,
+  tables,
+} from "@runt/schema";
 import type { CellContextData, NotebookContextData } from "./mod.ts";
 
 /**
@@ -43,12 +48,23 @@ export function gatherNotebookContext(
       // Convert outputs to AI context format, preserving ALL metadata
       // This is crucial for maintaining conversation flow with tool calls
       const contextOutputs = outputs.map((output: OutputData) => {
-        return {
+        const result: {
+          outputType: string;
+          data: unknown;
+          metadata?: Record<string, unknown>;
+          representations?: Record<string, MediaContainer>;
+        } = {
           outputType: output.outputType,
           data: output.data || {},
           metadata: output.metadata || {},
-          representations: output.representations || undefined,
         };
+
+        // Only include representations if they exist
+        if (output.representations) {
+          result.representations = output.representations;
+        }
+
+        return result;
       });
 
       return {

--- a/packages/ai/notebook-context.ts
+++ b/packages/ai/notebook-context.ts
@@ -47,6 +47,7 @@ export function gatherNotebookContext(
           outputType: output.outputType,
           data: output.data || {},
           metadata: output.metadata || {},
+          representations: output.representations || undefined,
         };
       });
 

--- a/packages/ai/ollama-client.ts
+++ b/packages/ai/ollama-client.ts
@@ -3,6 +3,8 @@ import type { Message, Tool } from "npm:ollama";
 import type { AiModel, ModelCapability } from "@runt/lib";
 import { createLogger, type ExecutionContext } from "@runt/lib";
 
+import { AI_TOOL_CALL_MIME_TYPE, AI_TOOL_RESULT_MIME_TYPE } from "@runt/schema";
+
 import { NOTEBOOK_TOOLS } from "./tool-registry.ts";
 import {
   type AgenticOptions,
@@ -490,7 +492,7 @@ export class RuntOllamaClient {
               const successOutput: OutputData = {
                 type: "display_data",
                 data: {
-                  "application/vnd.anode.aitool+json": toolCallData,
+                  [AI_TOOL_CALL_MIME_TYPE]: toolCallData,
                   "text/markdown":
                     `🔧 **Tool executed**: \`${toolCall.function.name}\`\n\n${
                       formatToolCall(
@@ -526,7 +528,7 @@ export class RuntOllamaClient {
                 iteration: iteration + 1,
               };
               context.display({
-                "application/vnd.anode.aitool.result+json": {
+                [AI_TOOL_RESULT_MIME_TYPE]: {
                   tool_call_id: toolCall.id,
                   result: toolResult,
                   status: "success",
@@ -568,7 +570,7 @@ export class RuntOllamaClient {
               const errorOutput: OutputData = {
                 type: "display_data",
                 data: {
-                  "application/vnd.anode.aitool+json": errorToolCallData,
+                  [AI_TOOL_CALL_MIME_TYPE]: errorToolCallData,
                   "text/markdown":
                     `❌ **Tool failed**: \`${toolCall.function.name}\`\n\nError: ${errorMessage}`,
                   "text/plain":

--- a/packages/ai/openai-client.ts
+++ b/packages/ai/openai-client.ts
@@ -5,6 +5,7 @@ import {
   type ExecutionContext,
   type ModelCapability,
 } from "@runt/lib";
+import { AI_TOOL_CALL_MIME_TYPE, AI_TOOL_RESULT_MIME_TYPE } from "@runt/schema";
 
 import { NOTEBOOK_TOOLS } from "./tool-registry.ts";
 
@@ -525,7 +526,7 @@ export class RuntOpenAIClient {
                 const errorOutput: OutputData = {
                   type: "display_data",
                   data: {
-                    "application/vnd.anode.aitool+json": toolCallData,
+                    [AI_TOOL_CALL_MIME_TYPE]: toolCallData,
                     "text/markdown":
                       `❌ **Tool failed**: \`${toolCall.function.name}\`\n\nError parsing arguments: ${parseError.message}`,
                     "text/plain":
@@ -588,7 +589,7 @@ export class RuntOpenAIClient {
                 const successOutput: OutputData = {
                   type: "display_data",
                   data: {
-                    "application/vnd.anode.aitool+json": toolCallData,
+                    [AI_TOOL_CALL_MIME_TYPE]: toolCallData,
                     "text/markdown":
                       `🔧 **Tool executed**: \`${toolCall.function.name}\`\n\n${
                         this.formatToolCall(toolCall.function.name, args)
@@ -620,7 +621,7 @@ export class RuntOpenAIClient {
                   iteration: iteration + 1,
                 };
                 context.display({
-                  "application/vnd.anode.aitool.result+json": {
+                  [AI_TOOL_RESULT_MIME_TYPE]: {
                     tool_call_id: toolCall.id,
                     result: toolResult,
                     status: "success",
@@ -662,7 +663,7 @@ export class RuntOpenAIClient {
                 const errorOutput: OutputData = {
                   type: "display_data",
                   data: {
-                    "application/vnd.anode.aitool+json": errorToolCallData,
+                    [AI_TOOL_CALL_MIME_TYPE]: errorToolCallData,
                     "text/markdown":
                       `❌ **Tool failed**: \`${toolCall.function.name}\`\n\nError: ${errorMessage}`,
                     "text/plain":

--- a/packages/ai/test/conversation-snapshot.test.ts
+++ b/packages/ai/test/conversation-snapshot.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "jsr:@std/assert";
 import { buildConversationMessages, type NotebookContextData } from "../mod.ts";
+import { AI_TOOL_CALL_MIME_TYPE, AI_TOOL_RESULT_MIME_TYPE } from "@runt/schema";
 
 // Helper types for test assertions
 interface AssistantMessageWithToolCalls {
@@ -82,7 +83,7 @@ Deno.test("AI conversation rendering - flattened tool calls", () => {
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool+json": {
+              [AI_TOOL_CALL_MIME_TYPE]: {
                 tool_call_id: "call_123",
                 tool_name: "create_cell",
                 arguments: {
@@ -98,7 +99,7 @@ Deno.test("AI conversation rendering - flattened tool calls", () => {
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool.result+json": {
+              [AI_TOOL_RESULT_MIME_TYPE]: {
                 tool_call_id: "call_123",
                 result: "Created code cell: cell-abc123",
                 status: "success",
@@ -234,7 +235,7 @@ Deno.test("AI conversation rendering - sequential tool call flow", () => {
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool+json": {
+              [AI_TOOL_CALL_MIME_TYPE]: {
                 tool_call_id: "call_1",
                 tool_name: "create_cell",
                 arguments: {
@@ -250,7 +251,7 @@ Deno.test("AI conversation rendering - sequential tool call flow", () => {
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool.result+json": {
+              [AI_TOOL_RESULT_MIME_TYPE]: {
                 tool_call_id: "call_1",
                 result: "Created code cell: cell-abc",
                 status: "success",
@@ -262,7 +263,7 @@ Deno.test("AI conversation rendering - sequential tool call flow", () => {
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool+json": {
+              [AI_TOOL_CALL_MIME_TYPE]: {
                 tool_call_id: "call_2",
                 tool_name: "create_cell",
                 arguments: {
@@ -277,7 +278,7 @@ Deno.test("AI conversation rendering - sequential tool call flow", () => {
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool.result+json": {
+              [AI_TOOL_RESULT_MIME_TYPE]: {
                 tool_call_id: "call_2",
                 result: "Created code cell: cell-def",
                 status: "success",
@@ -439,7 +440,7 @@ Deno.test("AI conversation rendering - tool calls without text responses", () =>
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool+json": {
+              [AI_TOOL_CALL_MIME_TYPE]: {
                 tool_call_id: "call_only",
                 tool_name: "execute_cell",
                 arguments: { cellId: "some-cell" },
@@ -450,7 +451,7 @@ Deno.test("AI conversation rendering - tool calls without text responses", () =>
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool.result+json": {
+              [AI_TOOL_RESULT_MIME_TYPE]: {
                 tool_call_id: "call_only",
                 result: "Execution completed",
                 status: "success",
@@ -578,7 +579,7 @@ Deno.test("AI conversation rendering - complex interleaved conversation", () => 
           {
             outputType: "display_data",
             data: {
-              "application/vnd.anode.aitool+json": {
+              [AI_TOOL_CALL_MIME_TYPE]: {
                 tool_call_id: "improve_call",
                 tool_name: "create_cell",
                 arguments: {

--- a/packages/ai/test/conversation-snapshot.test.ts
+++ b/packages/ai/test/conversation-snapshot.test.ts
@@ -1055,6 +1055,88 @@ Deno.test("AI conversation rendering - debug UI scenario", () => {
   // The sequential tool call flow maintains perfect OpenAI compatibility
 });
 
+Deno.test("AI conversation rendering - markdown outputs as assistant messages", () => {
+  const context: NotebookContextData = {
+    previousCells: [
+      {
+        id: "cell-1",
+        cellType: "ai",
+        source: "What is 2 + 2?",
+        position: 1,
+        outputs: [
+          // AI response as markdown output (streaming response)
+          {
+            outputType: "markdown",
+            data: "2 + 2 equals 4. This is a basic arithmetic operation.",
+            metadata: {
+              anode: {
+                role: "assistant",
+                ai_provider: "openai",
+                ai_model: "gpt-4o-mini",
+                iteration: 1,
+              },
+            },
+          },
+        ],
+      },
+      {
+        id: "cell-2",
+        cellType: "ai",
+        source: "Create a simple example",
+        position: 2,
+        outputs: [
+          // AI response as display_data output
+          {
+            outputType: "display_data",
+            data: {
+              "text/markdown": "I'll create a simple example for you.",
+              "text/plain": "I'll create a simple example for you.",
+            },
+            metadata: {
+              anode: {
+                role: "assistant",
+                ai_provider: "openai",
+                ai_model: "gpt-4o-mini",
+                iteration: 1,
+              },
+            },
+          },
+        ],
+      },
+    ],
+    totalCells: 2,
+    currentCellPosition: 2,
+  };
+
+  const messages = buildConversationMessages(
+    context,
+    "You are a helpful assistant.",
+    "What else can you help with?",
+  );
+
+  // Should have: system, assistant (markdown), assistant (display_data), user (prompt)
+  assertEquals(messages.length, 4);
+  assertEquals(messages[0].role, "system");
+  assertEquals(messages[1].role, "assistant");
+  assertEquals(messages[2].role, "assistant");
+  assertEquals(messages[3].role, "user");
+
+  // Check first assistant message (from markdown output)
+  assertEquals(
+    messages[1].content,
+    "2 + 2 equals 4. This is a basic arithmetic operation.",
+  );
+
+  // Check second assistant message (from display_data output)
+  assertEquals(
+    messages[2].content,
+    "I'll create a simple example for you.",
+  );
+
+  // Check current prompt is last
+  assertEquals(messages[3].content, "What else can you help with?");
+});
+
 Deno.test("AI conversation rendering - integrated code cells in conversation", () => {
   const context: NotebookContextData = {
     previousCells: [

--- a/packages/ai/test/media-utils-integration.test.ts
+++ b/packages/ai/test/media-utils-integration.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for AI media utilities integration with conversation building
+ */
+
+import { assertEquals } from "jsr:@std/assert";
+import {
+  buildConversationMessages,
+  toAIContext,
+  toAIMediaBundle,
+} from "../mod.ts";
+import type { NotebookContextData } from "../mod.ts";
+
+Deno.test("AI Media Utils Integration", async (t) => {
+  await t.step("toAIMediaBundle should prioritize markdown over HTML", () => {
+    const richOutput = {
+      "text/html": {
+        type: "inline" as const,
+        data: "<h1>Sales Report</h1><p>Revenue: $10,000</p>",
+      },
+      "text/markdown": {
+        type: "inline" as const,
+        data: "# Sales Report\n\nRevenue: $10,000",
+      },
+      "text/plain": {
+        type: "inline" as const,
+        data: "Sales Report\nRevenue: $10,000",
+      },
+    };
+
+    const result = toAIMediaBundle(richOutput);
+
+    assertEquals(result["text/markdown"], "# Sales Report\n\nRevenue: $10,000");
+    assertEquals(result["text/plain"], "Sales Report\nRevenue: $10,000");
+    // HTML should not be included when markdown is available
+    assertEquals(result["text/html"], undefined);
+  });
+
+  await t.step("toAIContext should return markdown when available", () => {
+    const richOutput = {
+      "text/html": {
+        type: "inline" as const,
+        data: "<h1>Test</h1>",
+      },
+      "text/markdown": {
+        type: "inline" as const,
+        data: "# Test",
+      },
+      "text/plain": {
+        type: "inline" as const,
+        data: "Test",
+      },
+    };
+
+    const result = toAIContext(richOutput);
+    assertEquals(result, "# Test");
+  });
+
+  await t.step("toAIContext should fallback to plain text", () => {
+    const richOutput = {
+      "text/html": {
+        type: "inline" as const,
+        data: "<h1>Test</h1>",
+      },
+      "text/plain": {
+        type: "inline" as const,
+        data: "Test",
+      },
+    };
+
+    const result = toAIContext(richOutput);
+    assertEquals(result, "Test");
+  });
+
+  await t.step("conversation building should use AI media utilities", () => {
+    const context: NotebookContextData = {
+      previousCells: [
+        {
+          id: "cell-1",
+          cellType: "code",
+          source: "print('Hello')",
+          position: 1,
+          outputs: [
+            {
+              outputType: "multimedia_result",
+              data: {},
+              metadata: {},
+              representations: {
+                "text/markdown": {
+                  type: "inline" as const,
+                  data: "**Hello World**",
+                },
+                "text/plain": {
+                  type: "inline" as const,
+                  data: "Hello World",
+                },
+              },
+            },
+          ],
+        },
+      ],
+      totalCells: 2,
+      currentCellPosition: 2,
+    };
+
+    const messages = buildConversationMessages(
+      context,
+      "You are a helpful assistant.",
+      "What was the output?",
+    );
+
+    // Find the user message with the code cell
+    const codeMessage = messages.find(
+      (msg) =>
+        msg.role === "user" && typeof msg.content === "string" &&
+        msg.content.includes("cell-1"),
+    );
+
+    // Should include the markdown output processed by AI media utilities
+    assertEquals(codeMessage !== undefined, true);
+    assertEquals(
+      typeof codeMessage?.content === "string" &&
+        codeMessage.content.includes("**Hello World**"),
+      true,
+    );
+  });
+
+  await t.step(
+    "conversation building should handle missing representations",
+    () => {
+      const context: NotebookContextData = {
+        previousCells: [
+          {
+            id: "cell-1",
+            cellType: "code",
+            source: "print('Hello')",
+            position: 1,
+            outputs: [
+              {
+                outputType: "multimedia_result",
+                data: {},
+                metadata: {},
+                // No representations property
+              },
+            ],
+          },
+        ],
+        totalCells: 2,
+        currentCellPosition: 2,
+      };
+
+      const messages = buildConversationMessages(
+        context,
+        "You are a helpful assistant.",
+        "What was the output?",
+      );
+
+      // Should not crash and should create valid messages
+      assertEquals(messages.length, 3); // system, user (code cell), user (prompt)
+      assertEquals(messages[0].role, "system");
+      assertEquals(messages[1].role, "user");
+      assertEquals(messages[2].role, "user");
+    },
+  );
+
+  await t.step(
+    "conversation building should handle empty representations",
+    () => {
+      const context: NotebookContextData = {
+        previousCells: [
+          {
+            id: "cell-1",
+            cellType: "code",
+            source: "print('Hello')",
+            position: 1,
+            outputs: [
+              {
+                outputType: "multimedia_result",
+                data: {},
+                metadata: {},
+                representations: {}, // Empty representations
+              },
+            ],
+          },
+        ],
+        totalCells: 2,
+        currentCellPosition: 2,
+      };
+
+      const messages = buildConversationMessages(
+        context,
+        "You are a helpful assistant.",
+        "What was the output?",
+      );
+
+      // Should not crash and should create valid messages
+      assertEquals(messages.length, 3);
+      const codeMessage = messages.find(
+        (msg) =>
+          msg.role === "user" && typeof msg.content === "string" &&
+          msg.content.includes("cell-1"),
+      );
+      assertEquals(codeMessage !== undefined, true);
+    },
+  );
+});

--- a/packages/ai/test/media-utils.test.ts
+++ b/packages/ai/test/media-utils.test.ts
@@ -1,0 +1,475 @@
+/**
+ * Comprehensive tests for AI media utilities
+ */
+
+import { assertEquals, assertObjectMatch } from "jsr:@std/assert";
+import {
+  type AIMediaBundle,
+  ensureTextPlainFallback,
+  extractStructuredData,
+  hasVisualContent,
+  type RichOutputData,
+  toAIContext,
+  toAIMediaBundle,
+} from "../media-utils.ts";
+
+Deno.test("AI Media Utils - toAIMediaBundle", async (t) => {
+  await t.step("should prioritize markdown over HTML", () => {
+    const richOutput: RichOutputData = {
+      "text/html": {
+        type: "inline",
+        data: "<h1>Report</h1><p>Content</p>",
+      },
+      "text/markdown": {
+        type: "inline",
+        data: "# Report\n\nContent",
+      },
+      "text/plain": {
+        type: "inline",
+        data: "Report\n\nContent",
+      },
+    };
+
+    const result = toAIMediaBundle(richOutput);
+
+    assertEquals(result["text/markdown"], "# Report\n\nContent");
+    assertEquals(result["text/plain"], "Report\n\nContent");
+    assertEquals(result["text/html"], undefined);
+  });
+
+  await t.step("should include HTML when no markdown available", () => {
+    const richOutput: RichOutputData = {
+      "text/html": {
+        type: "inline",
+        data: "<h1>Test</h1>",
+      },
+      "text/plain": {
+        type: "inline",
+        data: "Test",
+      },
+    };
+
+    const result = toAIMediaBundle(richOutput);
+
+    assertEquals(result["text/plain"], "Test");
+    assertEquals(result["text/markdown"], undefined);
+    assertEquals(result["text/html"], undefined); // HTML gets converted to plain text
+  });
+
+  await t.step("should include JSON data", () => {
+    const richOutput: RichOutputData = {
+      "application/json": {
+        type: "inline",
+        data: { revenue: 10000, profit: 2000 },
+      },
+      "text/plain": {
+        type: "inline",
+        data: "Financial data",
+      },
+    };
+
+    const result = toAIMediaBundle(richOutput);
+
+    assertEquals(result["application/json"], { revenue: 10000, profit: 2000 });
+    assertEquals(result["text/plain"], "Financial data");
+  });
+
+  await t.step("should include image data", () => {
+    const richOutput: RichOutputData = {
+      "image/png": {
+        type: "inline",
+        data: "base64imagedata",
+      },
+      "text/plain": {
+        type: "inline",
+        data: "Chart image",
+      },
+    };
+
+    const result = toAIMediaBundle(richOutput);
+
+    assertEquals(result["image/png"], "base64imagedata");
+    assertEquals(result["text/plain"], "Chart image");
+  });
+
+  await t.step("should handle empty input", () => {
+    const richOutput: RichOutputData = {};
+    const result = toAIMediaBundle(richOutput);
+    assertEquals(result, {});
+  });
+
+  await t.step("should handle artifact containers", () => {
+    const richOutput: RichOutputData = {
+      "text/plain": {
+        type: "artifact",
+        artifactId: "test-artifact",
+      },
+    };
+
+    const result = toAIMediaBundle(richOutput);
+    assertEquals(result, {}); // Artifacts are not included in AI bundles
+  });
+});
+
+Deno.test("AI Media Utils - ensureTextPlainFallback", async (t) => {
+  await t.step("should preserve existing text/plain", () => {
+    const bundle: AIMediaBundle = {
+      "text/plain": "Original text",
+      "text/html": "<p>HTML text</p>",
+    };
+
+    const result = ensureTextPlainFallback(bundle);
+
+    assertEquals(result["text/plain"], "Original text");
+    assertEquals(result["text/html"], "<p>HTML text</p>");
+  });
+
+  await t.step("should generate text/plain from HTML", () => {
+    const bundle: AIMediaBundle = {
+      "text/html": "<h1>Title</h1><p>Content</p>",
+    };
+
+    const result = ensureTextPlainFallback(bundle);
+
+    assertEquals(result["text/plain"], "TitleContent");
+    assertEquals(result["text/html"], "<h1>Title</h1><p>Content</p>");
+  });
+
+  await t.step("should use markdown as text/plain", () => {
+    const bundle: AIMediaBundle = {
+      "text/markdown": "# Title\n\nContent",
+    };
+
+    const result = ensureTextPlainFallback(bundle);
+
+    assertEquals(result["text/plain"], "# Title\n\nContent");
+    assertEquals(result["text/markdown"], "# Title\n\nContent");
+  });
+
+  await t.step("should use first string value as fallback", () => {
+    const bundle: AIMediaBundle = {
+      "custom/format": "Some text content",
+      "application/json": { data: "object" },
+    };
+
+    const result = ensureTextPlainFallback(bundle);
+
+    assertEquals(result["text/plain"], "Some text content");
+  });
+
+  await t.step("should JSON stringify non-string content", () => {
+    const bundle: AIMediaBundle = {
+      "application/json": { revenue: 1000 },
+    };
+
+    const result = ensureTextPlainFallback(bundle);
+
+    assertEquals(result["text/plain"], '{\n  "revenue": 1000\n}');
+  });
+
+  await t.step("should handle empty bundle", () => {
+    const bundle: AIMediaBundle = {};
+    const result = ensureTextPlainFallback(bundle);
+    assertEquals(result["text/plain"], "");
+  });
+});
+
+Deno.test("AI Media Utils - toAIContext", async (t) => {
+  await t.step("should return markdown when available", () => {
+    const richOutput: RichOutputData = {
+      "text/markdown": {
+        type: "inline",
+        data: "# Test\n\nContent",
+      },
+      "text/plain": {
+        type: "inline",
+        data: "Test Content",
+      },
+    };
+
+    const result = toAIContext(richOutput);
+    assertEquals(result, "# Test\n\nContent");
+  });
+
+  await t.step("should fallback to plain text", () => {
+    const richOutput: RichOutputData = {
+      "text/plain": {
+        type: "inline",
+        data: "Plain text content",
+      },
+      "text/html": {
+        type: "inline",
+        data: "<p>HTML content</p>",
+      },
+    };
+
+    const result = toAIContext(richOutput);
+    assertEquals(result, "Plain text content");
+  });
+
+  await t.step("should return JSON as string", () => {
+    const richOutput: RichOutputData = {
+      "application/json": {
+        type: "inline",
+        data: { message: "Hello" },
+      },
+    };
+
+    const result = toAIContext(richOutput);
+    assertEquals(result, '{\n  "message": "Hello"\n}');
+  });
+
+  await t.step("should return empty string for no content", () => {
+    const richOutput: RichOutputData = {};
+    const result = toAIContext(richOutput);
+    assertEquals(result, "");
+  });
+
+  await t.step("should handle complex mixed content", () => {
+    const richOutput: RichOutputData = {
+      "text/markdown": {
+        type: "inline",
+        data: "# Analysis Results\n\n- Revenue: $10,000\n- Profit: $2,000",
+      },
+      "application/json": {
+        type: "inline",
+        data: { revenue: 10000, profit: 2000 },
+      },
+      "image/png": {
+        type: "inline",
+        data: "base64data",
+      },
+    };
+
+    const result = toAIContext(richOutput);
+    assertEquals(
+      result,
+      "# Analysis Results\n\n- Revenue: $10,000\n- Profit: $2,000",
+    );
+  });
+});
+
+Deno.test("AI Media Utils - hasVisualContent", async (t) => {
+  await t.step("should detect PNG images", () => {
+    const richOutput: RichOutputData = {
+      "image/png": {
+        type: "inline",
+        data: "base64data",
+      },
+    };
+
+    const result = hasVisualContent(richOutput);
+    assertEquals(result, true);
+  });
+
+  await t.step("should detect JPEG images", () => {
+    const richOutput: RichOutputData = {
+      "image/jpeg": {
+        type: "inline",
+        data: "base64data",
+      },
+    };
+
+    const result = hasVisualContent(richOutput);
+    assertEquals(result, true);
+  });
+
+  await t.step("should detect SVG images", () => {
+    const richOutput: RichOutputData = {
+      "image/svg+xml": {
+        type: "inline",
+        data: "<svg>...</svg>",
+      },
+    };
+
+    const result = hasVisualContent(richOutput);
+    assertEquals(result, true);
+  });
+
+  await t.step("should return false for text-only content", () => {
+    const richOutput: RichOutputData = {
+      "text/plain": {
+        type: "inline",
+        data: "Just text",
+      },
+      "text/markdown": {
+        type: "inline",
+        data: "# Just markdown",
+      },
+    };
+
+    const result = hasVisualContent(richOutput);
+    assertEquals(result, false);
+  });
+
+  await t.step("should return false for artifact images", () => {
+    const richOutput: RichOutputData = {
+      "image/png": {
+        type: "artifact",
+        artifactId: "test-artifact",
+      },
+    };
+
+    const result = hasVisualContent(richOutput);
+    assertEquals(result, false);
+  });
+
+  await t.step("should return false for empty content", () => {
+    const richOutput: RichOutputData = {};
+    const result = hasVisualContent(richOutput);
+    assertEquals(result, false);
+  });
+});
+
+Deno.test("AI Media Utils - extractStructuredData", async (t) => {
+  await t.step("should extract JSON data", () => {
+    const richOutput: RichOutputData = {
+      "application/json": {
+        type: "inline",
+        data: { revenue: 10000, expenses: 8000 },
+      },
+    };
+
+    const result = extractStructuredData(richOutput);
+    assertObjectMatch(result as Record<string, unknown>, {
+      revenue: 10000,
+      expenses: 8000,
+    });
+  });
+
+  await t.step("should return null for non-JSON content", () => {
+    const richOutput: RichOutputData = {
+      "text/plain": {
+        type: "inline",
+        data: "Plain text",
+      },
+    };
+
+    const result = extractStructuredData(richOutput);
+    assertEquals(result, null);
+  });
+
+  await t.step("should return null for artifact JSON", () => {
+    const richOutput: RichOutputData = {
+      "application/json": {
+        type: "artifact",
+        artifactId: "test-artifact",
+      },
+    };
+
+    const result = extractStructuredData(richOutput);
+    assertEquals(result, null);
+  });
+
+  await t.step("should return null for empty content", () => {
+    const richOutput: RichOutputData = {};
+    const result = extractStructuredData(richOutput);
+    assertEquals(result, null);
+  });
+});
+
+Deno.test("AI Media Utils - Real-world scenarios", async (t) => {
+  await t.step("should handle pandas DataFrame output", () => {
+    const richOutput: RichOutputData = {
+      "text/html": {
+        type: "inline",
+        data:
+          "<table><tr><th>Name</th><th>Value</th></tr><tr><td>A</td><td>1</td></tr></table>",
+      },
+      "text/plain": {
+        type: "inline",
+        data: "   Name  Value\n0     A      1",
+      },
+    };
+
+    const context = toAIContext(richOutput);
+    assertEquals(context, "   Name  Value\n0     A      1");
+
+    const bundle = toAIMediaBundle(richOutput);
+    assertEquals(bundle["text/plain"], "   Name  Value\n0     A      1");
+    assertEquals(bundle["text/html"], undefined);
+  });
+
+  await t.step("should handle matplotlib plot output", () => {
+    const richOutput: RichOutputData = {
+      "image/png": {
+        type: "inline",
+        data:
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+      },
+      "text/plain": {
+        type: "inline",
+        data: "<matplotlib.figure.Figure at 0x7f8b8c0b5f40>",
+      },
+    };
+
+    const hasVisual = hasVisualContent(richOutput);
+    assertEquals(hasVisual, true);
+
+    const context = toAIContext(richOutput);
+    assertEquals(context, "<matplotlib.figure.Figure at 0x7f8b8c0b5f40>");
+
+    const bundle = toAIMediaBundle(richOutput);
+    assertEquals(
+      bundle["image/png"],
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+    );
+  });
+
+  await t.step("should handle IPython rich display output", () => {
+    const richOutput: RichOutputData = {
+      "text/markdown": {
+        type: "inline",
+        data:
+          "**Analysis Complete**\n\n- Processed 1,000 records\n- Found 42 anomalies\n- Confidence: 95%",
+      },
+      "application/json": {
+        type: "inline",
+        data: {
+          records_processed: 1000,
+          anomalies_found: 42,
+          confidence: 0.95,
+        },
+      },
+      "text/plain": {
+        type: "inline",
+        data:
+          "Analysis Complete\nProcessed 1,000 records\nFound 42 anomalies\nConfidence: 95%",
+      },
+    };
+
+    const context = toAIContext(richOutput);
+    assertEquals(
+      context,
+      "**Analysis Complete**\n\n- Processed 1,000 records\n- Found 42 anomalies\n- Confidence: 95%",
+    );
+
+    const structuredData = extractStructuredData(richOutput);
+    assertObjectMatch(structuredData as Record<string, unknown>, {
+      records_processed: 1000,
+      anomalies_found: 42,
+      confidence: 0.95,
+    });
+  });
+
+  await t.step("should handle error output gracefully", () => {
+    const richOutput: RichOutputData = {
+      "text/plain": {
+        type: "inline",
+        data: "ValueError: invalid literal for int() with base 10: 'abc'",
+      },
+    };
+
+    const context = toAIContext(richOutput);
+    assertEquals(
+      context,
+      "ValueError: invalid literal for int() with base 10: 'abc'",
+    );
+
+    const bundle = ensureTextPlainFallback(toAIMediaBundle(richOutput));
+    assertEquals(
+      bundle["text/plain"],
+      "ValueError: invalid literal for int() with base 10: 'abc'",
+    );
+  });
+});

--- a/packages/ai/test/schema-integration.test.ts
+++ b/packages/ai/test/schema-integration.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for schema constants integration in AI package
+ */
+
+import { assertEquals } from "jsr:@std/assert";
+import {
+  AI_TOOL_CALL_MIME_TYPE,
+  AI_TOOL_RESULT_MIME_TYPE,
+  type AiToolCallData,
+  type AiToolResultData,
+  isAiToolCallData,
+  isAiToolMimeType,
+  isAiToolResultData,
+} from "@runt/schema";
+import { buildConversationMessages, type NotebookContextData } from "../mod.ts";
+
+Deno.test("Schema Integration - AI Tool Constants", async (t) => {
+  await t.step("should have correct AI tool MIME types", () => {
+    assertEquals(AI_TOOL_CALL_MIME_TYPE, "application/vnd.anode.aitool+json");
+    assertEquals(
+      AI_TOOL_RESULT_MIME_TYPE,
+      "application/vnd.anode.aitool.result+json",
+    );
+  });
+
+  await t.step("should identify AI tool MIME types", () => {
+    assertEquals(isAiToolMimeType(AI_TOOL_CALL_MIME_TYPE), true);
+    assertEquals(isAiToolMimeType(AI_TOOL_RESULT_MIME_TYPE), true);
+    assertEquals(isAiToolMimeType("application/json"), false);
+    assertEquals(isAiToolMimeType("text/plain"), false);
+  });
+
+  await t.step("should validate AI tool call data", () => {
+    const validToolCall: AiToolCallData = {
+      tool_call_id: "call_123",
+      tool_name: "create_cell",
+      arguments: { cellType: "code", content: "print('hello')" },
+    };
+
+    assertEquals(isAiToolCallData(validToolCall), true);
+    assertEquals(isAiToolCallData({}), false);
+    assertEquals(isAiToolCallData({ tool_call_id: "123" }), false);
+    assertEquals(isAiToolCallData(null), false);
+  });
+
+  await t.step("should validate AI tool result data", () => {
+    const validToolResult: AiToolResultData = {
+      tool_call_id: "call_123",
+      tool_name: "create_cell",
+      arguments: { cellType: "code", content: "print('hello')" },
+      status: "success",
+      timestamp: "2025-01-11T00:00:00Z",
+      result: "Created cell successfully",
+    };
+
+    assertEquals(isAiToolResultData(validToolResult), true);
+    assertEquals(isAiToolResultData({}), false);
+    assertEquals(isAiToolResultData({ status: "invalid" }), false);
+    assertEquals(isAiToolResultData(null), false);
+  });
+});
+
+Deno.test("Schema Integration - Conversation Building", async (t) => {
+  await t.step("should use schema constants in conversation building", () => {
+    const context: NotebookContextData = {
+      previousCells: [
+        {
+          id: "cell-1",
+          cellType: "ai",
+          source: "Create a code cell",
+          position: 1,
+          outputs: [
+            {
+              outputType: "display_data",
+              data: {
+                [AI_TOOL_CALL_MIME_TYPE]: {
+                  tool_call_id: "call_456",
+                  tool_name: "create_cell",
+                  arguments: {
+                    cellType: "code",
+                    content: "import numpy as np",
+                  },
+                } as AiToolCallData,
+              },
+              metadata: { anode: { role: "function_call" } },
+            },
+            {
+              outputType: "display_data",
+              data: {
+                [AI_TOOL_RESULT_MIME_TYPE]: {
+                  tool_call_id: "call_456",
+                  tool_name: "create_cell",
+                  arguments: {
+                    cellType: "code",
+                    content: "import numpy as np",
+                  },
+                  status: "success",
+                  timestamp: "2025-01-11T00:00:00Z",
+                  result: "Created code cell: cell-789",
+                } as AiToolResultData,
+              },
+              metadata: { anode: { role: "tool" } },
+            },
+          ],
+        },
+      ],
+      totalCells: 1,
+      currentCellPosition: 1,
+    };
+
+    const messages = buildConversationMessages(
+      context,
+      "You are a helpful assistant.",
+      "What did you create?",
+    );
+
+    // Should have: system, assistant (tool call), tool (result), user (prompt)
+    assertEquals(messages.length, 4);
+    assertEquals(messages[0].role, "system");
+    assertEquals(messages[1].role, "assistant");
+    assertEquals(messages[2].role, "tool");
+    assertEquals(messages[3].role, "user");
+
+    // Check tool call message
+    const toolCallMessage = messages[1] as {
+      role: string;
+      content: string;
+      tool_calls?: Array<{
+        id: string;
+        function: { name: string; arguments: string };
+      }>;
+    };
+    assertEquals(toolCallMessage.tool_calls?.length, 1);
+    assertEquals(toolCallMessage.tool_calls?.[0].function.name, "create_cell");
+    assertEquals(toolCallMessage.tool_calls?.[0].id, "call_456");
+
+    // Check tool result message
+    const toolResultMessage = messages[2] as {
+      role: string;
+      content: string;
+      tool_call_id: string;
+    };
+    assertEquals(toolResultMessage.tool_call_id, "call_456");
+    assertEquals(toolResultMessage.content, "Created code cell: cell-789");
+  });
+
+  await t.step("should handle malformed tool data gracefully", () => {
+    const context: NotebookContextData = {
+      previousCells: [
+        {
+          id: "cell-1",
+          cellType: "ai",
+          source: "Create a code cell",
+          position: 1,
+          outputs: [
+            {
+              outputType: "display_data",
+              data: {
+                [AI_TOOL_CALL_MIME_TYPE]: {
+                  // Missing required fields
+                  tool_call_id: "call_invalid",
+                },
+              },
+              metadata: { anode: { role: "function_call" } },
+            },
+          ],
+        },
+      ],
+      totalCells: 1,
+      currentCellPosition: 1,
+    };
+
+    const messages = buildConversationMessages(
+      context,
+      "You are a helpful assistant.",
+      "What happened?",
+    );
+
+    // Should have system, assistant (with malformed tool call), and user messages
+    assertEquals(messages.length, 3);
+    assertEquals(messages[0].role, "system");
+    assertEquals(messages[1].role, "assistant");
+    assertEquals(messages[2].role, "user");
+
+    // The malformed tool call should still create a message but with undefined values
+    const toolCallMessage = messages[1] as {
+      role: string;
+      content: string;
+      tool_calls?: Array<{
+        id: string;
+        function: { name: string; arguments: string };
+      }>;
+    };
+    assertEquals(toolCallMessage.tool_calls?.length, 1);
+    assertEquals(toolCallMessage.tool_calls?.[0].id, "call_invalid");
+    assertEquals(toolCallMessage.tool_calls?.[0].function.name, undefined);
+  });
+});
+
+Deno.test("Schema Integration - Type Safety", async (t) => {
+  await t.step("should enforce type safety for tool call data", () => {
+    // This should compile without errors
+    const toolCallData: AiToolCallData = {
+      tool_call_id: "call_123",
+      tool_name: "execute_cell",
+      arguments: { cellId: "cell-456" },
+    };
+
+    // Verify the data structure
+    assertEquals(typeof toolCallData.tool_call_id, "string");
+    assertEquals(typeof toolCallData.tool_name, "string");
+    assertEquals(typeof toolCallData.arguments, "object");
+  });
+
+  await t.step("should enforce type safety for tool result data", () => {
+    // This should compile without errors
+    const toolResultData: AiToolResultData = {
+      tool_call_id: "call_123",
+      tool_name: "execute_cell",
+      arguments: { cellId: "cell-456" },
+      status: "success",
+      timestamp: "2025-01-11T00:00:00Z",
+      result: "Execution completed successfully",
+    };
+
+    // Verify the data structure
+    assertEquals(typeof toolResultData.tool_call_id, "string");
+    assertEquals(typeof toolResultData.tool_name, "string");
+    assertEquals(typeof toolResultData.arguments, "object");
+    assertEquals(
+      toolResultData.status === "success" || toolResultData.status === "error",
+      true,
+    );
+    assertEquals(typeof toolResultData.timestamp, "string");
+    assertEquals(typeof toolResultData.result, "string");
+  });
+
+  await t.step("should provide consistent MIME type constants", () => {
+    // These constants should be available and consistent
+    const toolCallMimeType = AI_TOOL_CALL_MIME_TYPE;
+    const toolResultMimeType = AI_TOOL_RESULT_MIME_TYPE;
+
+    assertEquals(typeof toolCallMimeType, "string");
+    assertEquals(typeof toolResultMimeType, "string");
+    assertEquals(toolCallMimeType.includes("aitool"), true);
+    assertEquals(toolResultMimeType.includes("aitool.result"), true);
+  });
+});

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -328,9 +328,10 @@ export async function handleToolCallWithResult(
                       output.representations &&
                       output.representations["text/plain"]
                     ) {
-                      resultText = String(
-                        output.representations["text/plain"].data || "",
-                      );
+                      const container = output.representations["text/plain"];
+                      if (container.type === "inline") {
+                        resultText = String(container.data || "");
+                      }
                     } else if (output.data) {
                       resultText = String(output.data);
                     }

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -323,18 +323,52 @@ export async function handleToolCallWithResult(
                     output.outputType === "multimedia_result"
                   ) {
                     // Try to get text representation from representations or fallback to data
+                    // Prioritize markdown for AI context, then plain text
                     let resultText = "";
+                    let usedFormat = "";
+
+                    toolLogger.debug(
+                      "Processing multimedia_result for tool response",
+                      {
+                        cellId,
+                        hasRepresentations: !!output.representations,
+                        representationKeys: output.representations
+                          ? Object.keys(output.representations)
+                          : [],
+                        hasData: !!output.data,
+                      },
+                    );
+
                     if (
+                      output.representations &&
+                      output.representations["text/markdown"]
+                    ) {
+                      const container = output.representations["text/markdown"];
+                      if (container.type === "inline") {
+                        resultText = String(container.data || "");
+                        usedFormat = "text/markdown";
+                      }
+                    } else if (
                       output.representations &&
                       output.representations["text/plain"]
                     ) {
                       const container = output.representations["text/plain"];
                       if (container.type === "inline") {
                         resultText = String(container.data || "");
+                        usedFormat = "text/plain";
                       }
                     } else if (output.data) {
                       resultText = String(output.data);
+                      usedFormat = "raw_data";
                     }
+
+                    toolLogger.debug("Tool result content extracted", {
+                      cellId,
+                      usedFormat,
+                      contentLength: resultText.length,
+                      contentPreview: resultText.substring(0, 100),
+                    });
+
                     if (resultText) {
                       outputTexts.push(`Result: ${resultText.trim()}`);
                     }

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -1,5 +1,9 @@
 import { type CellData, events, type Store, tables } from "@runt/schema";
 import type { Logger } from "@runt/lib";
+import { createLogger } from "@runt/lib";
+
+// Create logger for tool execution debugging
+const toolLogger = createLogger("ai-tools");
 
 interface NotebookTool {
   name: string;

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -370,7 +370,7 @@ export async function handleToolCallWithResult(
                       cellId,
                       usedFormat,
                       contentLength: resultText.length,
-                      contentPreview: resultText.substring(0, 100),
+                      fullContent: resultText,
                     });
 
                     if (resultText) {

--- a/packages/lib/src/media/mod.ts
+++ b/packages/lib/src/media/mod.ts
@@ -1,17 +1,16 @@
 /**
- * # Media Types for AI-Aware Runtime Agents
+ * # Media Types for Runtime Agents
  *
- * When your Python code outputs tables, plots, or rich data, it creates multiple
- * representations - HTML for humans, JSON for data, plain text for accessibility.
- * But which format should we send to AI models?
+ * This module provides runtime-specific utilities for working with media bundles
+ * and validating content from Python execution environments.
  *
- * This module helps runtime agents convert Jupyter-style rich output into formats
- * that work well with Large Language Models.
+ * Core MIME type definitions and type guards are now in `@runt/schema` for
+ * consistent use across frontend and backend.
  *
  * ## Quick Start
  *
  * ```typescript
- * import { toAIMediaBundle, validateMediaBundle } from "@runt/lib/media";
+ * import { validateMediaBundle } from "@runt/lib/media";
  *
  * // Raw output from Python execution
  * const rawOutput = {
@@ -20,21 +19,19 @@
  *   "application/json": { revenue: 50000, currency: "USD" }
  * };
  *
- * // Convert for AI consumption (prefers markdown, keeps structured data)
- * const aiBundle = toAIMediaBundle(rawOutput);
- * // Send this to your AI model for better understanding
+ * // Validate and normalize the bundle
+ * const validated = validateMediaBundle(rawOutput);
  * ```
  */
 
-// Core types and constants
+// Core types and constants (re-exported from schema for consistency)
 export type {
   ApplicationMimeType,
   ImageMimeType,
   JupyterMimeType,
   KnownMimeType,
-  MediaBundle,
   TextMimeType,
-} from "./types.ts";
+} from "@runt/schema";
 
 export {
   APPLICATION_MIME_TYPES,
@@ -42,9 +39,9 @@ export {
   JUPYTER_MIME_TYPES,
   KNOWN_MIME_TYPES,
   TEXT_MIME_TYPES,
-} from "./types.ts";
+} from "@runt/schema";
 
-// Type guards
+// Type guards (re-exported from schema)
 export {
   isApplicationMimeType,
   isImageMimeType,
@@ -53,11 +50,9 @@ export {
   isKnownMimeType,
   isTextBasedMimeType,
   isTextMimeType,
-} from "./types.ts";
+} from "@runt/schema";
 
-// Utility functions
-export {
-  ensureTextPlainFallback,
-  toAIMediaBundle,
-  validateMediaBundle,
-} from "./types.ts";
+// Runtime-specific types and utilities
+export type { MediaBundle } from "./types.ts";
+
+export { validateMediaBundle } from "./types.ts";

--- a/packages/lib/src/media/types.ts
+++ b/packages/lib/src/media/types.ts
@@ -1,102 +1,36 @@
 /**
- * # Media Types for AI-Aware Notebooks
+ * # Media Types for Runtime Agents
  *
- * When Python objects are displayed in Jupyter notebooks, they can provide multiple
- * representations - HTML for rich display, plain text for accessibility, JSON for
- * data interchange. But what format works best for AI?
+ * This module provides runtime-specific utilities for working with media bundles
+ * and validating content from Python execution environments.
  *
- * This module helps convert rich Jupyter output into formats that work well with
- * Large Language Models while preserving the flexibility to extend with custom types.
- *
- * ## Example: Converting Rich Output for AI
- *
- * ```typescript
- * const richOutput = {
- *   "text/html": "<table><tr><td>Data</td></tr></table>",
- *   "text/markdown": "| Data |\n|------|",
- *   "application/json": { rows: [{ data: "Data" }] },
- *   "image/png": "base64-encoded-chart"
- * };
- *
- * // Convert to AI-friendly formats
- * const aiOutput = toAIMediaBundle(richOutput);
- * // Result: markdown (better for LLMs than HTML), JSON, and images
- * // { "text/markdown": "| Data |\n|------|", "application/json": {...}, "image/png": "..." }
- * ```
- *
- * ## Custom Media Types
- *
- * Any `application/*+json` media type is automatically recognized:
- *
- * ```typescript
- * isJsonMimeType("application/vnd.anode.aitool+json") // true
- * isJsonMimeType("application/vnd.plotly.v1+json")    // true
- * ```
+ * Core MIME type definitions and type guards are now in `@runt/schema` for
+ * consistent use across frontend and backend.
  */
 
-/**
- * Core text-based media types
- */
-export const TEXT_MIME_TYPES = [
-  "text/plain",
-  "text/html",
-  "text/markdown",
-  "text/latex",
-] as const;
+// Re-export core types from schema for backwards compatibility
+export {
+  APPLICATION_MIME_TYPES,
+  type ApplicationMimeType,
+  IMAGE_MIME_TYPES,
+  type ImageMimeType,
+  isApplicationMimeType,
+  isImageMimeType,
+  isJsonMimeType,
+  isJupyterMimeType,
+  isKnownMimeType,
+  isTextBasedMimeType,
+  isTextMimeType,
+  JUPYTER_MIME_TYPES,
+  type JupyterMimeType,
+  KNOWN_MIME_TYPES,
+  type KnownMimeType,
+  TEXT_MIME_TYPES,
+  type TextMimeType,
+} from "@runt/schema";
 
-/**
- * Application media types
- */
-export const APPLICATION_MIME_TYPES = [
-  "application/json",
-  "application/javascript",
-] as const;
-
-/**
- * Image media types (base64 encoded content)
- */
-export const IMAGE_MIME_TYPES = [
-  "image/png",
-  "image/jpeg",
-  "image/svg+xml",
-  "image/gif",
-] as const;
-
-/**
- * Jupyter-specific vendor media types
- */
-export const JUPYTER_MIME_TYPES = [
-  "application/vnd.jupyter.widget-state+json",
-  "application/vnd.jupyter.widget-view+json",
-  "application/vnd.plotly.v1+json",
-  "application/vnd.dataresource+json",
-  "application/vnd.vegalite.v2+json",
-  "application/vnd.vegalite.v3+json",
-  "application/vnd.vegalite.v4+json",
-  "application/vnd.vegalite.v5+json",
-  "application/vnd.vegalite.v6+json",
-  "application/vnd.vega.v3+json",
-  "application/vnd.vega.v4+json",
-  "application/vnd.vega.v5+json",
-  "application/geo+json",
-  "application/vdom.v1+json",
-] as const;
-
-/**
- * All known/standard media types
- */
-export const KNOWN_MIME_TYPES = [
-  ...TEXT_MIME_TYPES,
-  ...APPLICATION_MIME_TYPES,
-  ...IMAGE_MIME_TYPES,
-  ...JUPYTER_MIME_TYPES,
-] as const;
-
-export type TextMimeType = typeof TEXT_MIME_TYPES[number];
-export type ApplicationMimeType = typeof APPLICATION_MIME_TYPES[number];
-export type ImageMimeType = typeof IMAGE_MIME_TYPES[number];
-export type JupyterMimeType = typeof JUPYTER_MIME_TYPES[number];
-export type KnownMimeType = typeof KNOWN_MIME_TYPES[number];
+// Import type guards needed by validateMediaBundle
+import { isJsonMimeType, isTextBasedMimeType } from "@runt/schema";
 
 /**
  * A media bundle represents rich content that can be displayed in multiple formats.
@@ -104,172 +38,6 @@ export type KnownMimeType = typeof KNOWN_MIME_TYPES[number];
  */
 export interface MediaBundle {
   [mimeType: string]: unknown;
-}
-
-/**
- * Type guard to check if a MIME type is a known text format
- */
-export function isTextMimeType(mimeType: string): mimeType is TextMimeType {
-  return (TEXT_MIME_TYPES as readonly string[]).includes(mimeType);
-}
-
-/**
- * Type guard to check if a MIME type is a known application format
- */
-export function isApplicationMimeType(
-  mimeType: string,
-): mimeType is ApplicationMimeType {
-  return (APPLICATION_MIME_TYPES as readonly string[]).includes(mimeType);
-}
-
-/**
- * Type guard to check if a MIME type is a known image format
- */
-export function isImageMimeType(mimeType: string): mimeType is ImageMimeType {
-  return (IMAGE_MIME_TYPES as readonly string[]).includes(mimeType);
-}
-
-/**
- * Type guard to check if a MIME type is a Jupyter vendor format
- */
-export function isJupyterMimeType(
-  mimeType: string,
-): mimeType is JupyterMimeType {
-  return (JUPYTER_MIME_TYPES as readonly string[]).includes(mimeType);
-}
-
-/**
- * Type guard to check if a MIME type is any known format
- */
-export function isKnownMimeType(mimeType: string): mimeType is KnownMimeType {
-  return (KNOWN_MIME_TYPES as readonly string[]).includes(mimeType);
-}
-
-/**
- * Check if a MIME type is a JSON-based format (ends with +json)
- * This includes both known types and custom extensions
- */
-export function isJsonMimeType(mimeType: string): boolean {
-  return mimeType.endsWith("+json") || mimeType === "application/json";
-}
-
-/**
- * Check if a MIME type appears to be text-based and should be treated as a string
- */
-export function isTextBasedMimeType(mimeType: string): boolean {
-  return (
-    mimeType.startsWith("text/") ||
-    mimeType === "application/javascript" ||
-    mimeType === "image/svg+xml"
-  );
-}
-
-/**
- * Convert rich Jupyter output to AI-friendly formats
- *
- * AI models work better with certain formats:
- * - Markdown is more compact and structured than HTML
- * - JSON preserves data structure for reasoning
- * - Images work with vision-capable models
- * - Plain text provides universal fallback
- *
- * @example
- * ```typescript
- * const bundle = {
- *   "text/html": "<h1>Sales Report</h1><p>Revenue: $10,000</p>",
- *   "text/markdown": "# Sales Report\n\nRevenue: $10,000",
- *   "application/json": { revenue: 10000, currency: "USD" }
- * };
- *
- * const aiBundle = toAIMediaBundle(bundle);
- * // Prefers markdown over HTML, keeps JSON structure
- * // { "text/markdown": "# Sales Report\n\nRevenue: $10,000", "application/json": {...} }
- * ```
- */
-export function toAIMediaBundle(bundle: MediaBundle): MediaBundle {
-  const result: MediaBundle = {};
-
-  // Always include text/plain if available
-  if (bundle["text/plain"]) {
-    result["text/plain"] = bundle["text/plain"];
-  }
-
-  // Prefer markdown over HTML for AI
-  if (bundle["text/markdown"]) {
-    result["text/markdown"] = bundle["text/markdown"];
-  } else if (bundle["text/html"] && typeof bundle["text/html"] === "string") {
-    // Convert HTML to markdown-ish plain text for AI
-    const plainFromHtml = bundle["text/html"].replace(/<[^>]*>/g, "");
-    if (!result["text/plain"]) {
-      result["text/plain"] = plainFromHtml;
-    }
-  }
-
-  // Include JSON for structured data
-  if (bundle["application/json"]) {
-    result["application/json"] = bundle["application/json"];
-  }
-
-  // Include images that some AI providers support
-  for (const imageType of IMAGE_MIME_TYPES) {
-    if (bundle[imageType]) {
-      result[imageType] = bundle[imageType];
-    }
-  }
-
-  return result;
-}
-
-/**
- * Every media bundle should have text/plain for maximum compatibility
- *
- * Some AI providers only support text, and text/plain ensures your output
- * is never completely invisible to an AI system.
- *
- * @example
- * ```typescript
- * const bundle = { "text/html": "<b>Important data</b>" };
- * const withFallback = ensureTextPlainFallback(bundle);
- * // { "text/html": "<b>Important data</b>", "text/plain": "Important data" }
- * ```
- */
-export function ensureTextPlainFallback(bundle: MediaBundle): MediaBundle {
-  if (bundle["text/plain"]) {
-    return bundle;
-  }
-
-  const result = { ...bundle };
-
-  // Try to generate text/plain from other formats
-  if (typeof result["text/html"] === "string") {
-    // Strip HTML tags for plain text
-    result["text/plain"] = result["text/html"].replace(/<[^>]*>/g, "");
-  } else if (typeof result["text/markdown"] === "string") {
-    // Markdown is readable as plain text
-    result["text/plain"] = result["text/markdown"];
-  } else {
-    // Use first available string content
-    const firstStringValue = Object.values(result).find(
-      (value): value is string => typeof value === "string",
-    );
-    if (firstStringValue) {
-      result["text/plain"] = firstStringValue;
-    } else {
-      // Last resort: JSON stringify first available content
-      const firstEntry = Object.entries(result)[0];
-      if (firstEntry && firstEntry[1] != null) {
-        try {
-          result["text/plain"] = JSON.stringify(firstEntry[1], null, 2);
-        } catch {
-          result["text/plain"] = String(firstEntry[1]);
-        }
-      } else {
-        result["text/plain"] = "";
-      }
-    }
-  }
-
-  return result;
 }
 
 /**

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -14,7 +14,6 @@ import {
   KNOWN_MIME_TYPES,
   type KnownMimeType,
   type MediaBundle,
-  toAIMediaBundle,
   validateMediaBundle,
 } from "@runt/lib";
 import { getEssentialPackages } from "./cache-utils.ts";
@@ -22,7 +21,6 @@ import type { Store } from "npm:@livestore/livestore";
 import {
   type CellData,
   type MediaContainer,
-  type OutputData as SchemaOutputData,
   schema,
   tables,
 } from "@runt/schema";

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -735,42 +735,25 @@ export class PyodideRuntimeAgent {
             .orderBy("position", "asc"),
         ) as SchemaOutputData[];
 
-        // Convert outputs to AI-friendly formats
+        // Convert outputs to AI-friendly formats using type-safe pattern matching
         const filteredOutputs = outputs.map((output: SchemaOutputData) => {
-          const outputData = output.data;
-
-          // Handle terminal outputs first (data is a string, not object)
-          if (output.outputType === "terminal") {
-            return {
-              outputType: output.outputType,
-              data: {
-                text: output.data || "",
-                name: output.streamName || "stdout",
-              },
-            };
-          }
-
-          if (outputData && typeof outputData === "object") {
-            // For rich media outputs, convert to AI-friendly bundle
-            if (
-              outputData["text/plain"] || outputData["text/html"] ||
-              outputData["text/markdown"] || outputData["application/json"]
-            ) {
-              const aiBundle = toAIMediaBundle(outputData as MediaBundle);
+          switch (output.outputType) {
+            case "terminal":
               return {
-                outputType: output.outputType,
-                data: aiBundle,
+                outputType: "terminal" as const,
+                data: {
+                  text: String(output.data || ""),
+                  name: output.streamName || "stdout",
+                },
               };
-            }
 
-            // For error outputs, parse JSON data
-            if (output.outputType === "error") {
+            case "error":
               try {
                 const errorData = typeof output.data === "string"
                   ? JSON.parse(output.data)
                   : output.data;
                 return {
-                  outputType: output.outputType,
+                  outputType: "error" as const,
                   data: {
                     ename: errorData?.ename || "Error",
                     evalue: errorData?.evalue || "Unknown error",
@@ -779,7 +762,7 @@ export class PyodideRuntimeAgent {
                 };
               } catch {
                 return {
-                  outputType: output.outputType,
+                  outputType: "error" as const,
                   data: {
                     ename: "Error",
                     evalue: String(output.data || "Unknown error"),
@@ -787,24 +770,48 @@ export class PyodideRuntimeAgent {
                   },
                 };
               }
-            }
 
-            // For multimedia outputs, use representations if available
-            if (output.representations) {
+            case "multimedia_display":
+            case "multimedia_result":
+              // For multimedia outputs, use representations if available
+              if (output.representations) {
+                const aiBundle = toAIMediaBundle(
+                  output.representations as MediaBundle,
+                );
+                return {
+                  outputType: output.outputType,
+                  data: aiBundle,
+                };
+              }
+              // Fallback to data field for legacy outputs
+              if (output.data && typeof output.data === "object") {
+                const aiBundle = toAIMediaBundle(output.data as MediaBundle);
+                return {
+                  outputType: output.outputType,
+                  data: aiBundle,
+                };
+              }
+              // Final fallback to plain text
               return {
                 outputType: output.outputType,
-                data: output.representations,
+                data: { "text/plain": String(output.data || "") },
               };
-            }
-          }
 
-          // Fallback to data field
-          return {
-            outputType: output.outputType,
-            data: typeof output.data === "string"
-              ? { "text/plain": output.data }
-              : (output.data || {}),
-          };
+            case "markdown":
+              return {
+                outputType: "markdown" as const,
+                data: { "text/markdown": String(output.data || "") },
+              };
+
+            default:
+              // Fallback for any unknown output types
+              return {
+                outputType: output.outputType,
+                data: typeof output.data === "string"
+                  ? { "text/plain": output.data }
+                  : (output.data || {}),
+              };
+          }
         });
 
         return {

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -735,11 +735,11 @@ export class PyodideRuntimeAgent {
             .select()
             .where({ cellId: cell.id })
             .orderBy("position", "asc"),
-        ) as SchemaOutputData[];
+        );
 
         // Convert each output to simple string representation
         const outputStrings = outputs.map(
-          (output: SchemaOutputData): string => {
+          (output): string => {
             switch (output.outputType) {
               case "terminal":
                 return String(output.data || "");

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -7,15 +7,13 @@
 import { createRuntimeConfig, RuntimeAgent } from "@runt/lib";
 import type { ExecutionContext } from "@runt/lib";
 import { createLogger } from "@runt/lib";
+import { type MediaBundle, validateMediaBundle } from "@runt/lib";
 import {
-  ensureTextPlainFallback,
   isJsonMimeType,
   isTextBasedMimeType,
   KNOWN_MIME_TYPES,
   type KnownMimeType,
-  type MediaBundle,
-  validateMediaBundle,
-} from "@runt/lib";
+} from "@runt/schema";
 import { getEssentialPackages } from "./cache-utils.ts";
 import type { Store } from "npm:@livestore/livestore";
 import {
@@ -26,6 +24,7 @@ import {
 } from "@runt/schema";
 import {
   discoverAvailableAiModels,
+  ensureTextPlainFallback,
   executeAI,
   NotebookContextData,
 } from "@runt/ai";
@@ -579,7 +578,7 @@ export class PyodideRuntimeAgent {
       }
 
       if (hasMimeType) {
-        // Validate and ensure text/plain fallback
+        // Validate and ensure text/plain fallback for display
         const validated = validateMediaBundle(rawBundle);
         return ensureTextPlainFallback(validated);
       }
@@ -769,11 +768,11 @@ export class PyodideRuntimeAgent {
                   const mimeTypes = Object.keys(mediaContainers);
 
                   // Try to get text representation from inline containers
+                  // Prioritize markdown for AI context, then plain text, then HTML
                   for (
                     const mimeType of [
-                      "text/plain",
-                      "text/html",
                       "text/markdown",
+                      "text/plain",
                     ]
                   ) {
                     const container = mediaContainers[mimeType];

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -739,6 +739,17 @@ export class PyodideRuntimeAgent {
         const filteredOutputs = outputs.map((output: SchemaOutputData) => {
           const outputData = output.data;
 
+          // Handle terminal outputs first (data is a string, not object)
+          if (output.outputType === "terminal") {
+            return {
+              outputType: output.outputType,
+              data: {
+                text: output.data || "",
+                name: output.streamName || "stdout",
+              },
+            };
+          }
+
           if (outputData && typeof outputData === "object") {
             // For rich media outputs, convert to AI-friendly bundle
             if (
@@ -749,17 +760,6 @@ export class PyodideRuntimeAgent {
               return {
                 outputType: output.outputType,
                 data: aiBundle,
-              };
-            }
-
-            // With new schema, data is flattened - check output type and handle accordingly
-            if (output.outputType === "terminal") {
-              return {
-                outputType: output.outputType,
-                data: {
-                  text: output.data || "",
-                  name: output.streamName || "stdout",
-                },
               };
             }
 

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -16,17 +16,12 @@ import {
 } from "@runt/schema";
 import { getEssentialPackages } from "./cache-utils.ts";
 import type { Store } from "npm:@livestore/livestore";
-import {
-  type CellData,
-  type MediaContainer,
-  schema,
-  tables,
-} from "@runt/schema";
+import { schema } from "@runt/schema";
 import {
   discoverAvailableAiModels,
   ensureTextPlainFallback,
   executeAI,
-  NotebookContextData,
+  gatherNotebookContext,
 } from "@runt/ai";
 
 /**
@@ -339,7 +334,7 @@ export class PyodideRuntimeAgent {
 
     // When an AI cell, hand it off to `@runt/ai` to handle, providing it notebook context
     if (cell.cellType === "ai") {
-      const notebookContext = this.gatherNotebookContext(cell);
+      const notebookContext = gatherNotebookContext(this.store, cell);
 
       // Track AI execution for cancellation
       const aiAbortController = new AbortController();
@@ -708,115 +703,5 @@ export class PyodideRuntimeAgent {
     }
 
     this.logger.info("Pyodide worker cleanup completed");
-  }
-
-  /**
-   * Gather context from previous cells for AI execution
-   */
-  public gatherNotebookContext(currentCell: CellData): NotebookContextData {
-    // Query all cells in order
-    const allCells = this.store.query(
-      tables.cells.select().orderBy("position", "asc"),
-    );
-
-    // Build clean intermediate format
-    const previousCells = allCells
-      .filter((cell: CellData) =>
-        cell.position < currentCell.position &&
-        cell.aiContextVisible !== false
-      )
-      .map((cell: CellData) => {
-        // Query outputs for this cell in order
-        const outputs = this.store.query(
-          tables.outputs
-            .select()
-            .where({ cellId: cell.id })
-            .orderBy("position", "asc"),
-        );
-
-        // Convert each output to simple string representation
-        const outputStrings = outputs.map(
-          (output): string => {
-            switch (output.outputType) {
-              case "terminal":
-                return String(output.data || "");
-
-              case "error":
-                try {
-                  const errorData = typeof output.data === "string"
-                    ? JSON.parse(output.data)
-                    : output.data;
-                  const traceback = errorData?.traceback?.join("\n") || "";
-                  return `${errorData?.ename || "Error"}: ${
-                    errorData?.evalue || "Unknown error"
-                  }\n${traceback}`;
-                } catch {
-                  return `Error: ${String(output.data || "Unknown error")}`;
-                }
-
-              case "markdown":
-                return String(output.data || "");
-
-              case "multimedia_display":
-              case "multimedia_result":
-                // For multimedia, extract from MediaContainer representations
-                if (output.representations) {
-                  const mediaContainers = output.representations as Record<
-                    string,
-                    MediaContainer
-                  >;
-                  const mimeTypes = Object.keys(mediaContainers);
-
-                  // Try to get text representation from inline containers
-                  // Prioritize markdown for AI context, then plain text, then HTML
-                  for (
-                    const mimeType of [
-                      "text/markdown",
-                      "text/plain",
-                    ]
-                  ) {
-                    const container = mediaContainers[mimeType];
-                    if (container?.type === "inline") {
-                      return String(container.data || "");
-                    }
-                  }
-
-                  // Show available media types
-                  return `[${mimeTypes.join(", ")}]`;
-                }
-                return String(output.data || "[No representations]");
-
-              default:
-                return String(output.data || "");
-            }
-          },
-        );
-
-        // Build clean intermediate cell format
-        return {
-          cellType: cell.cellType,
-          cellId: cell.id,
-          source: cell.source,
-          outputs: outputStrings,
-        };
-      });
-
-    // Convert to AI message format
-    const aiFormattedCells = previousCells.map((cell) => ({
-      id: cell.cellId,
-      cellType: cell.cellType,
-      source: cell.source,
-      position: allCells.find((c) => c.id === cell.cellId)?.position || 0,
-      outputs: cell.outputs.map((outputStr) => ({
-        outputType: "terminal" as const,
-        data: { text: outputStr },
-      })),
-    }));
-
-    return {
-      previousCells: aiFormattedCells,
-      totalCells: allCells.length,
-      currentCellPosition: currentCell.position,
-    };
   }
 }

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -21,6 +21,7 @@ import { getEssentialPackages } from "./cache-utils.ts";
 import type { Store } from "npm:@livestore/livestore";
 import {
   type CellData,
+  type MediaContainer,
   type OutputData as SchemaOutputData,
   schema,
   tables,
@@ -716,18 +717,19 @@ export class PyodideRuntimeAgent {
    * Gather context from previous cells for AI execution
    */
   public gatherNotebookContext(currentCell: CellData): NotebookContextData {
-    // Query all cells that come before the current cell AND are visible to AI
+    // Query all cells in order
     const allCells = this.store.query(
       tables.cells.select().orderBy("position", "asc"),
     );
 
+    // Build clean intermediate format
     const previousCells = allCells
       .filter((cell: CellData) =>
         cell.position < currentCell.position &&
         cell.aiContextVisible !== false
       )
       .map((cell: CellData) => {
-        // Get outputs for each cell
+        // Query outputs for this cell in order
         const outputs = this.store.query(
           tables.outputs
             .select()
@@ -735,96 +737,87 @@ export class PyodideRuntimeAgent {
             .orderBy("position", "asc"),
         ) as SchemaOutputData[];
 
-        // Convert outputs to AI-friendly formats using type-safe pattern matching
-        const filteredOutputs = outputs.map((output: SchemaOutputData) => {
-          switch (output.outputType) {
-            case "terminal":
-              return {
-                outputType: "terminal" as const,
-                data: {
-                  text: String(output.data || ""),
-                  name: output.streamName || "stdout",
-                },
-              };
+        // Convert each output to simple string representation
+        const outputStrings = outputs.map(
+          (output: SchemaOutputData): string => {
+            switch (output.outputType) {
+              case "terminal":
+                return String(output.data || "");
 
-            case "error":
-              try {
-                const errorData = typeof output.data === "string"
-                  ? JSON.parse(output.data)
-                  : output.data;
-                return {
-                  outputType: "error" as const,
-                  data: {
-                    ename: errorData?.ename || "Error",
-                    evalue: errorData?.evalue || "Unknown error",
-                    traceback: errorData?.traceback || [],
-                  },
-                };
-              } catch {
-                return {
-                  outputType: "error" as const,
-                  data: {
-                    ename: "Error",
-                    evalue: String(output.data || "Unknown error"),
-                    traceback: [],
-                  },
-                };
-              }
+              case "error":
+                try {
+                  const errorData = typeof output.data === "string"
+                    ? JSON.parse(output.data)
+                    : output.data;
+                  const traceback = errorData?.traceback?.join("\n") || "";
+                  return `${errorData?.ename || "Error"}: ${
+                    errorData?.evalue || "Unknown error"
+                  }\n${traceback}`;
+                } catch {
+                  return `Error: ${String(output.data || "Unknown error")}`;
+                }
 
-            case "multimedia_display":
-            case "multimedia_result":
-              // For multimedia outputs, use representations if available
-              if (output.representations) {
-                const aiBundle = toAIMediaBundle(
-                  output.representations as MediaBundle,
-                );
-                return {
-                  outputType: output.outputType,
-                  data: aiBundle,
-                };
-              }
-              // Fallback to data field for legacy outputs
-              if (output.data && typeof output.data === "object") {
-                const aiBundle = toAIMediaBundle(output.data as MediaBundle);
-                return {
-                  outputType: output.outputType,
-                  data: aiBundle,
-                };
-              }
-              // Final fallback to plain text
-              return {
-                outputType: output.outputType,
-                data: { "text/plain": String(output.data || "") },
-              };
+              case "markdown":
+                return String(output.data || "");
 
-            case "markdown":
-              return {
-                outputType: "markdown" as const,
-                data: { "text/markdown": String(output.data || "") },
-              };
+              case "multimedia_display":
+              case "multimedia_result":
+                // For multimedia, extract from MediaContainer representations
+                if (output.representations) {
+                  const mediaContainers = output.representations as Record<
+                    string,
+                    MediaContainer
+                  >;
+                  const mimeTypes = Object.keys(mediaContainers);
 
-            default:
-              // Fallback for any unknown output types
-              return {
-                outputType: output.outputType,
-                data: typeof output.data === "string"
-                  ? { "text/plain": output.data }
-                  : (output.data || {}),
-              };
-          }
-        });
+                  // Try to get text representation from inline containers
+                  for (
+                    const mimeType of [
+                      "text/plain",
+                      "text/html",
+                      "text/markdown",
+                    ]
+                  ) {
+                    const container = mediaContainers[mimeType];
+                    if (container?.type === "inline") {
+                      return String(container.data || "");
+                    }
+                  }
 
+                  // Show available media types
+                  return `[${mimeTypes.join(", ")}]`;
+                }
+                return String(output.data || "[No representations]");
+
+              default:
+                return String(output.data || "");
+            }
+          },
+        );
+
+        // Build clean intermediate cell format
         return {
-          id: cell.id,
           cellType: cell.cellType,
-          source: cell.source || "",
-          position: cell.position,
-          outputs: filteredOutputs,
+          cellId: cell.id,
+          source: cell.source,
+          outputs: outputStrings,
         };
       });
 
+    // Convert to AI message format
+    const aiFormattedCells = previousCells.map((cell) => ({
+      id: cell.cellId,
+      cellType: cell.cellType,
+      source: cell.source,
+      position: allCells.find((c) => c.id === cell.cellId)?.position || 0,
+      outputs: cell.outputs.map((outputStr) => ({
+        outputType: "terminal" as const,
+        data: { text: outputStr },
+      })),
+    }));
+
     return {
-      previousCells,
+      previousCells: aiFormattedCells,
       totalCells: allCells.length,
       currentCellPosition: currentCell.position,
     };

--- a/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
@@ -145,7 +145,7 @@ Deno.test({
 
       // Verify the arithmetic result - check representations for multimedia output
       const outputData = outputs[0]?.representations as {
-        "text/plain": { data: string };
+        "text/plain": { type: "inline"; data: string };
       };
       assertEquals(
         outputData?.["text/plain"]?.data,

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -128,8 +128,11 @@ export const tables = {
       // Multi-media support
       representations: State.SQLite.json({
         nullable: true,
-        schema: Schema.Any,
-      }), // Full representation map for multimedia outputs
+        schema: Schema.Record({
+          key: Schema.String,
+          value: MediaRepresentationSchema,
+        }),
+      }),
     },
   }),
 

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -7,8 +7,6 @@ import {
   type Store as LiveStore,
 } from "@livestore/livestore";
 
-console.log("633 PM July 10");
-
 // Base generic types for MediaContainer system
 export type InlineContainer<T = unknown> = {
   type: "inline";

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -7,7 +7,7 @@ import {
   type Store as LiveStore,
 } from "@livestore/livestore";
 
-console.log("551 PM July 10");
+console.log("633 PM July 10");
 
 // Base generic types for MediaContainer system
 export type InlineContainer<T = unknown> = {
@@ -39,6 +39,11 @@ export const APPLICATION_MIME_TYPES = [
   "application/javascript",
 ] as const;
 
+export const AI_TOOL_MIME_TYPES = [
+  "application/vnd.anode.aitool+json",
+  "application/vnd.anode.aitool.result+json",
+] as const;
+
 export const IMAGE_MIME_TYPES = [
   "image/png",
   "image/jpeg",
@@ -68,12 +73,14 @@ export const KNOWN_MIME_TYPES = [
   ...APPLICATION_MIME_TYPES,
   ...IMAGE_MIME_TYPES,
   ...JUPYTER_MIME_TYPES,
+  ...AI_TOOL_MIME_TYPES,
 ] as const;
 
 export type TextMimeType = typeof TEXT_MIME_TYPES[number];
 export type ApplicationMimeType = typeof APPLICATION_MIME_TYPES[number];
 export type ImageMimeType = typeof IMAGE_MIME_TYPES[number];
 export type JupyterMimeType = typeof JUPYTER_MIME_TYPES[number];
+export type AiToolMimeType = typeof AI_TOOL_MIME_TYPES[number];
 export type KnownMimeType = typeof KNOWN_MIME_TYPES[number];
 
 /**
@@ -106,6 +113,15 @@ export function isJupyterMimeType(
   mimeType: string,
 ): mimeType is JupyterMimeType {
   return (JUPYTER_MIME_TYPES as readonly string[]).includes(mimeType);
+}
+
+/**
+ * Type guard to check if a MIME type is an AI tool format
+ */
+export function isAiToolMimeType(
+  mimeType: string,
+): mimeType is AiToolMimeType {
+  return (AI_TOOL_MIME_TYPES as readonly string[]).includes(mimeType);
 }
 
 /**
@@ -1256,3 +1272,73 @@ export function isRichOutput(data: unknown): data is RichOutputData {
     !isErrorOutput(data)
   );
 }
+
+/**
+ * AI tool call data structure for notebook outputs
+ */
+export interface AiToolCallData {
+  tool_call_id: string;
+  tool_name: string;
+  arguments: Record<string, unknown>;
+}
+
+/**
+ * AI tool result data structure for notebook outputs
+ */
+export interface AiToolResultData {
+  tool_call_id: string;
+  tool_name: string;
+  arguments: Record<string, unknown>;
+  status: "success" | "error";
+  timestamp: string;
+  result?: string;
+}
+
+/**
+ * Type guard to check if data is an AI tool call
+ */
+export function isAiToolCallData(data: unknown): data is AiToolCallData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "tool_call_id" in data &&
+    "tool_name" in data &&
+    "arguments" in data &&
+    typeof (data as AiToolCallData).tool_call_id === "string" &&
+    typeof (data as AiToolCallData).tool_name === "string" &&
+    typeof (data as AiToolCallData).arguments === "object"
+  );
+}
+
+/**
+ * Type guard to check if data is an AI tool result
+ */
+export function isAiToolResultData(data: unknown): data is AiToolResultData {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "tool_call_id" in data &&
+    "tool_name" in data &&
+    "arguments" in data &&
+    "status" in data &&
+    "timestamp" in data &&
+    typeof (data as AiToolResultData).tool_call_id === "string" &&
+    typeof (data as AiToolResultData).tool_name === "string" &&
+    typeof (data as AiToolResultData).arguments === "object" &&
+    (typeof (data as AiToolResultData).status === "string") &&
+    ["success", "error"].includes((data as AiToolResultData).status) &&
+    typeof (data as AiToolResultData).timestamp === "string"
+  );
+}
+
+/**
+ * AI tool call MIME type constant
+ */
+export const AI_TOOL_CALL_MIME_TYPE =
+  "application/vnd.anode.aitool+json" as const;
+
+/**
+ * AI tool result MIME type constant
+ */
+export const AI_TOOL_RESULT_MIME_TYPE =
+  "application/vnd.anode.aitool.result+json" as const;

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -7,7 +7,7 @@ import {
   type Store as LiveStore,
 } from "@livestore/livestore";
 
-console.log("419 PM July 10");
+console.log("551 PM July 10");
 
 // Base generic types for MediaContainer system
 export type InlineContainer<T = unknown> = {

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -7,7 +7,7 @@ import {
   type Store as LiveStore,
 } from "@livestore/livestore";
 
-console.log("344 PM July 10");
+console.log("419 PM July 10");
 
 // Base generic types for MediaContainer system
 export type InlineContainer<T = unknown> = {
@@ -25,6 +25,113 @@ export type ArtifactContainer = {
 export type MediaContainer<T = unknown> =
   | InlineContainer<T>
   | ArtifactContainer;
+
+// MIME type constants - core definitions used across frontend and backend
+export const TEXT_MIME_TYPES = [
+  "text/plain",
+  "text/html",
+  "text/markdown",
+  "text/latex",
+] as const;
+
+export const APPLICATION_MIME_TYPES = [
+  "application/json",
+  "application/javascript",
+] as const;
+
+export const IMAGE_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/svg+xml",
+  "image/gif",
+] as const;
+
+export const JUPYTER_MIME_TYPES = [
+  "application/vnd.jupyter.widget-state+json",
+  "application/vnd.jupyter.widget-view+json",
+  "application/vnd.plotly.v1+json",
+  "application/vnd.dataresource+json",
+  "application/vnd.vegalite.v2+json",
+  "application/vnd.vegalite.v3+json",
+  "application/vnd.vegalite.v4+json",
+  "application/vnd.vegalite.v5+json",
+  "application/vnd.vegalite.v6+json",
+  "application/vnd.vega.v3+json",
+  "application/vnd.vega.v4+json",
+  "application/vnd.vega.v5+json",
+  "application/geo+json",
+  "application/vdom.v1+json",
+] as const;
+
+export const KNOWN_MIME_TYPES = [
+  ...TEXT_MIME_TYPES,
+  ...APPLICATION_MIME_TYPES,
+  ...IMAGE_MIME_TYPES,
+  ...JUPYTER_MIME_TYPES,
+] as const;
+
+export type TextMimeType = typeof TEXT_MIME_TYPES[number];
+export type ApplicationMimeType = typeof APPLICATION_MIME_TYPES[number];
+export type ImageMimeType = typeof IMAGE_MIME_TYPES[number];
+export type JupyterMimeType = typeof JUPYTER_MIME_TYPES[number];
+export type KnownMimeType = typeof KNOWN_MIME_TYPES[number];
+
+/**
+ * Type guard to check if a MIME type is a known text format
+ */
+export function isTextMimeType(mimeType: string): mimeType is TextMimeType {
+  return (TEXT_MIME_TYPES as readonly string[]).includes(mimeType);
+}
+
+/**
+ * Type guard to check if a MIME type is a known application format
+ */
+export function isApplicationMimeType(
+  mimeType: string,
+): mimeType is ApplicationMimeType {
+  return (APPLICATION_MIME_TYPES as readonly string[]).includes(mimeType);
+}
+
+/**
+ * Type guard to check if a MIME type is a known image format
+ */
+export function isImageMimeType(mimeType: string): mimeType is ImageMimeType {
+  return (IMAGE_MIME_TYPES as readonly string[]).includes(mimeType);
+}
+
+/**
+ * Type guard to check if a MIME type is a Jupyter vendor format
+ */
+export function isJupyterMimeType(
+  mimeType: string,
+): mimeType is JupyterMimeType {
+  return (JUPYTER_MIME_TYPES as readonly string[]).includes(mimeType);
+}
+
+/**
+ * Type guard to check if a MIME type is any known format
+ */
+export function isKnownMimeType(mimeType: string): mimeType is KnownMimeType {
+  return (KNOWN_MIME_TYPES as readonly string[]).includes(mimeType);
+}
+
+/**
+ * Check if a MIME type is a JSON-based format (ends with +json)
+ */
+export function isJsonMimeType(mimeType: string): boolean {
+  return mimeType.endsWith("+json") || mimeType === "application/json";
+}
+
+/**
+ * Check if a MIME type appears to be text-based
+ */
+export function isTextBasedMimeType(mimeType: string): boolean {
+  return (
+    mimeType.startsWith("text/") ||
+    mimeType === "application/javascript" ||
+    mimeType === "image/svg+xml"
+  );
+}
 
 // Media representation schema for unified output system - defined first for use in events
 const MediaRepresentationSchema = Schema.Union(
@@ -537,11 +644,34 @@ export const events = {
 function selectPrimaryRepresentation(
   representations: Record<string, MediaContainer>,
   preferredMimeTypes: string[] = [
+    // JSON-based formats first (highest priority for rich data)
+    "application/vnd.plotly.v1+json",
+    "application/vnd.vegalite.v6+json",
+    "application/vnd.vegalite.v5+json",
+    "application/vnd.vegalite.v4+json",
+    "application/vnd.vegalite.v3+json",
+    "application/vnd.vegalite.v2+json",
+    "application/vnd.vega.v5+json",
+    "application/vnd.vega.v4+json",
+    "application/vnd.vega.v3+json",
+    "application/vnd.jupyter.widget-view+json",
+    "application/vnd.jupyter.widget-state+json",
+    "application/vnd.dataresource+json",
+    "application/vdom.v1+json",
+    "application/geo+json",
+    "application/json",
+    // Interactive content
+    "application/javascript",
+    // Rich display formats
     "text/html",
+    "image/svg+xml",
+    // Binary images
     "image/png",
     "image/jpeg",
-    "image/svg+xml",
-    "application/json",
+    "image/gif",
+    // Text formats
+    "text/latex",
+    "text/markdown",
     "text/plain",
   ],
 ): { mimeType: string; container: MediaContainer } | null {

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -7,6 +7,8 @@ import {
   type Store as LiveStore,
 } from "@livestore/livestore";
 
+console.log("344 PM July 10");
+
 // Base generic types for MediaContainer system
 export type InlineContainer<T = unknown> = {
   type: "inline";


### PR DESCRIPTION
## Schema Integration
- Add AI tool MIME types and data structures to `@runt/schema`
- Replace magic strings with typed constants across packages
- Add validation functions for tool call/result data

## Conversation Building Fix
- Fix AI assistant responses missing from conversation context
- Handle both `markdown` outputs (streaming) and `display_data` outputs (structured)
- AI responses now properly appear as assistant messages in conversation

## Media Utilities
- Add AI media utilities for consistent rich content processing
- Preserve multimedia data structure (images, JSON, markdown)
- Convert to text for current AI conversation building
- Foundation for future multimodal AI support