### PR TITLE
Fix AI package publish excludes

### DIFF
--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -32,6 +32,8 @@
       "ollama-client.ts",
       "shared-types.ts",
       "tool-registry.ts",
+      "media-utils.ts",
+      "notebook-context.ts",
       "README.md"
     ],
     "exclude": ["**/*.test.ts", "**/test_*.ts", "examples/"]


### PR DESCRIPTION
Fixes JSR publish dry run failure by including media-utils.ts and notebook-context.ts in the AI package publish configuration. These files are imported by mod.ts but were excluded from the publish include list.