### PR TITLE
Fix AiToolResultData interface to match actual runtime behavior

### DIFF
--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -1285,11 +1285,12 @@ export interface AiToolCallData {
  */
 export interface AiToolResultData {
   tool_call_id: string;
-  tool_name: string;
-  arguments: Record<string, unknown>;
   status: "success" | "error";
-  timestamp: string;
   result?: string;
+  // Optional fields for backward compatibility
+  tool_name?: string;
+  arguments?: Record<string, unknown>;
+  timestamp?: string;
 }
 
 /**
@@ -1316,16 +1317,10 @@ export function isAiToolResultData(data: unknown): data is AiToolResultData {
     typeof data === "object" &&
     data !== null &&
     "tool_call_id" in data &&
-    "tool_name" in data &&
-    "arguments" in data &&
     "status" in data &&
-    "timestamp" in data &&
     typeof (data as AiToolResultData).tool_call_id === "string" &&
-    typeof (data as AiToolResultData).tool_name === "string" &&
-    typeof (data as AiToolResultData).arguments === "object" &&
     (typeof (data as AiToolResultData).status === "string") &&
-    ["success", "error"].includes((data as AiToolResultData).status) &&
-    typeof (data as AiToolResultData).timestamp === "string"
+    ["success", "error"].includes((data as AiToolResultData).status)
   );
 }
 


### PR DESCRIPTION
Fixes the AiToolResultData interface to match the actual data structure generated by the AI runtime.

## Problem
The schema defined AiToolResultData with required fields that the actual AI runtime doesn't provide:
- tool_name (missing)
- arguments (missing) 
- timestamp (missing)

This caused type validation failures in frontends, showing "Invalid tool result data" errors.

## Solution
- Made tool_name, arguments, and timestamp optional fields for backward compatibility
- Updated isAiToolResultData type guard to only require tool_call_id and status
- Now matches actual runtime behavior: {tool_call_id, result, status}

## Testing
- All 76 tests passing
- Maintains backward compatibility
- Fixes validation errors in Anode frontend