### PR TITLE
Release 0.6.2

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1256,8 +1256,8 @@
       "packages/ai": {
         "dependencies": [
           "jsr:@openai/openai@^4.98.0",
-          "jsr:@runt/lib@~0.6.1",
-          "jsr:@runt/schema@~0.6.1",
+          "jsr:@runt/lib@~0.6.2",
+          "jsr:@runt/schema@~0.6.2",
           "jsr:@std/async@1",
           "npm:@livestore/livestore@~0.3.1",
           "npm:ollama@~0.5.16",
@@ -1267,7 +1267,7 @@
       },
       "packages/lib": {
         "dependencies": [
-          "jsr:@runt/schema@~0.6.1",
+          "jsr:@runt/schema@~0.6.2",
           "jsr:@std/cli@1",
           "npm:@livestore/adapter-node@~0.3.1",
           "npm:@livestore/livestore@~0.3.1",
@@ -1277,9 +1277,9 @@
       },
       "packages/pyodide-runtime-agent": {
         "dependencies": [
-          "jsr:@runt/ai@~0.6.1",
-          "jsr:@runt/lib@~0.6.1",
-          "jsr:@runt/schema@~0.6.1",
+          "jsr:@runt/ai@~0.6.2",
+          "jsr:@runt/lib@~0.6.2",
+          "jsr:@runt/schema@~0.6.2",
           "jsr:@std/async@1",
           "npm:@livestore/livestore@~0.3.1",
           "npm:pyodide@~0.27.7",

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/ai",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Runtime AI Clients",
   "license": "MIT",
   "repository": {
@@ -11,8 +11,8 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.6.1",
-    "@runt/schema": "jsr:@runt/schema@^0.6.1",
+    "@runt/lib": "jsr:@runt/lib@^0.6.2",
+    "@runt/schema": "jsr:@runt/schema@^0.6.2",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Runtime agent library for building Anode runtime agents",
   "license": "MIT",
   "repository": {
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.6.1",
+    "@runt/schema": "jsr:@runt/schema@^0.6.2",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "MIT",
   "repository": {
@@ -14,9 +14,9 @@
     "pyrunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/ai": "jsr:@runt/ai@^0.6.1",
-    "@runt/lib": "jsr:@runt/lib@^0.6.1",
-    "@runt/schema": "jsr:@runt/schema@^0.6.1",
+    "@runt/ai": "jsr:@runt/ai@^0.6.2",
+    "@runt/lib": "jsr:@runt/lib@^0.6.2",
+    "@runt/schema": "jsr:@runt/schema@^0.6.2",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {


### PR DESCRIPTION
Version bump for 0.6.2 release

Updates all package versions and cross-package dependencies:
- @runt/schema: 0.6.1 → 0.6.2
- @runt/lib: 0.6.1 → 0.6.2
- @runt/ai: 0.6.1 → 0.6.2  
- @runt/pyodide-runtime-agent: 0.6.1 → 0.6.2

Ready for OIDC deployment to JSR.