### PR TITLE
Add config options for cpython

### DIFF
--- a/packages/lib/lib.test.ts
+++ b/packages/lib/lib.test.ts
@@ -35,6 +35,7 @@ Deno.test("RuntimeConfig validation works", () => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
+      environmentOptions: {},
     });
     config.validate();
     throw new Error("Should have thrown validation error");
@@ -57,6 +58,7 @@ Deno.test("RuntimeConfig validation works", () => {
       canExecuteSql: false,
       canExecuteAi: false,
     },
+    environmentOptions: {},
   });
 
   // Should not throw

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -25,6 +25,7 @@ export class RuntimeConfig {
   public readonly notebookId: string;
   public readonly capabilities: RuntimeCapabilities;
   public readonly sessionId: string;
+  public readonly environmentOptions?: RuntimeAgentOptions["environmentOptions"];
 
   constructor(options: RuntimeAgentOptions) {
     this.runtimeId = options.runtimeId;
@@ -33,6 +34,7 @@ export class RuntimeConfig {
     this.authToken = options.authToken;
     this.notebookId = options.notebookId;
     this.capabilities = options.capabilities;
+    this.environmentOptions = options.environmentOptions;
 
     // Generate unique session ID
     this.sessionId = `${this.runtimeType}-${this.runtimeId}-${Date.now()}-${
@@ -81,6 +83,27 @@ export class RuntimeConfig {
         }\n\nUse --help for more information.`,
       );
     }
+
+    if (this.environmentOptions) {
+      const invalid: string[] = [];
+      const { runtimePackageManager, runtimePythonPath, runtimeEnvPath } = this.environmentOptions;
+      if (runtimePackageManager && runtimePackageManager !== "pip") {
+        invalid.push(`--runtime-package-manager`);
+      }
+
+      if (runtimePythonPath !== undefined && !runtimePythonPath) {
+        invalid.push(`--runtime-python-path`);
+      }
+      if (runtimeEnvPath !== undefined && !runtimeEnvPath) {
+        invalid.push(`--runtime-env-path`);
+      }
+
+      if (invalid.length > 0) {
+        throw new Error(
+          `Invalid value for:\n\n${invalid.join("\n")}\n\nUse --help for more information.`
+        );
+      }
+    }
   }
 }
 
@@ -96,8 +119,11 @@ export function parseRuntimeArgs(args: string[]): Partial<RuntimeAgentOptions> {
       "runtime-id",
       "runtime-type",
       "heartbeat-interval",
+      "runtime-python-path",
+      "runtime-env-path",
+      "runtime-package-manager",
     ],
-    boolean: ["help"],
+    boolean: ["help", "runtime-env-externally-managed"],
     alias: {
       n: "notebook",
       t: "auth-token",
@@ -162,6 +188,34 @@ Logging Configuration:
   const runtimeId = parsed["runtime-id"] || Deno.env.get("RUNTIME_ID");
   if (runtimeId && typeof runtimeId === "string") result.runtimeId = runtimeId;
 
+  // Environment options
+  const environmentOptions: Record<string, unknown> = {};
+  // runtimePythonPath
+  environmentOptions.runtimePythonPath =
+    parsed["runtime-python-path"] ||
+    Deno.env.get("RUNTIME_PYTHON_PATH") ||
+    "python3";
+  // runtimeEnvPath
+  if (parsed["runtime-env-path"] || Deno.env.get("RUNTIME_ENV_PATH")) {
+    environmentOptions.runtimeEnvPath =
+      parsed["runtime-env-path"] || Deno.env.get("RUNTIME_ENV_PATH");
+  }
+  // runtimePackageManager
+  environmentOptions.runtimePackageManager =
+    parsed["runtime-package-manager"] ||
+    Deno.env.get("RUNTIME_PACKAGE_MANAGER") ||
+    "pip";
+  // runtimeEnvExternallyManaged: true if CLI or env sets it, else false
+  const cliExternallyManaged = Boolean(
+    parsed["runtime-env-externally-managed"]
+  );
+  const envExternallyManaged =
+    Deno.env.get("RUNTIME_ENV_EXTERNALLY_MANAGED") === "1" ||
+    Deno.env.get("RUNTIME_ENV_EXTERNALLY_MANAGED") === "true";
+  environmentOptions.runtimeEnvExternallyManaged =
+    cliExternallyManaged || envExternallyManaged;
+  result.environmentOptions = environmentOptions;
+
   return result;
 }
 
@@ -170,7 +224,7 @@ Logging Configuration:
  */
 export function createRuntimeConfig(
   args: string[],
-  defaults: Partial<RuntimeAgentOptions> = {},
+  defaults: Partial<RuntimeAgentOptions> = {}
 ): RuntimeConfig {
   const cliConfig = parseRuntimeArgs(args);
 
@@ -183,17 +237,27 @@ export function createRuntimeConfig(
       canExecuteSql: false,
       canExecuteAi: false,
     },
+    environmentOptions: {
+      runtimePythonPath: "python3",
+      runtimePackageManager: "pip",
+      runtimeEnvExternallyManaged: false,
+      ...(defaults.environmentOptions ?? {}),
+    },
     ...defaults,
   };
 
   // Only include non-undefined values from CLI config
-  const cleanCliConfig = Object.fromEntries(
-    Object.entries(cliConfig).filter(([_, value]) => value !== undefined),
+  const cleanCliConfig: Partial<RuntimeAgentOptions> = Object.fromEntries(
+    Object.entries(cliConfig).filter(([_, value]) => value !== undefined)
   );
 
   const config: RuntimeAgentOptions = {
     ...mergedDefaults,
     ...cleanCliConfig,
+    environmentOptions: {
+      ...mergedDefaults.environmentOptions,
+      ...(cleanCliConfig.environmentOptions ?? {}),
+    },
   } as RuntimeAgentOptions;
 
   // Generate runtimeId after merging to use correct runtimeType
@@ -213,6 +277,7 @@ export function createRuntimeConfig(
     syncUrl: runtimeConfig.syncUrl,
     notebookId: runtimeConfig.notebookId,
     sessionId: runtimeConfig.sessionId,
+    environmentOptions: config.environmentOptions,
   });
 
   return runtimeConfig;

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -25,8 +25,7 @@ export class RuntimeConfig {
   public readonly notebookId: string;
   public readonly capabilities: RuntimeCapabilities;
   public readonly sessionId: string;
-  public readonly environmentOptions?:
-    RuntimeAgentOptions["environmentOptions"];
+  public readonly environmentOptions: RuntimeAgentOptions["environmentOptions"];
 
   constructor(options: RuntimeAgentOptions) {
     this.runtimeId = options.runtimeId;
@@ -192,23 +191,18 @@ Logging Configuration:
   const runtimeId = parsed["runtime-id"] || Deno.env.get("RUNTIME_ID");
   if (runtimeId && typeof runtimeId === "string") result.runtimeId = runtimeId;
 
-  // Environment options
   const environmentOptions: Record<string, unknown> = {};
-  // runtimePythonPath
   environmentOptions.runtimePythonPath = parsed["runtime-python-path"] ||
     Deno.env.get("RUNTIME_PYTHON_PATH") ||
     "python3";
-  // runtimeEnvPath
   if (parsed["runtime-env-path"] || Deno.env.get("RUNTIME_ENV_PATH")) {
     environmentOptions.runtimeEnvPath = parsed["runtime-env-path"] ||
       Deno.env.get("RUNTIME_ENV_PATH");
   }
-  // runtimePackageManager
   environmentOptions.runtimePackageManager =
     parsed["runtime-package-manager"] ||
     Deno.env.get("RUNTIME_PACKAGE_MANAGER") ||
     "pip";
-  // runtimeEnvExternallyManaged: true if CLI or env sets it, else false
   const cliExternallyManaged = Boolean(
     parsed["runtime-env-externally-managed"],
   );

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -25,7 +25,8 @@ export class RuntimeConfig {
   public readonly notebookId: string;
   public readonly capabilities: RuntimeCapabilities;
   public readonly sessionId: string;
-  public readonly environmentOptions?: RuntimeAgentOptions["environmentOptions"];
+  public readonly environmentOptions?:
+    RuntimeAgentOptions["environmentOptions"];
 
   constructor(options: RuntimeAgentOptions) {
     this.runtimeId = options.runtimeId;
@@ -86,7 +87,8 @@ export class RuntimeConfig {
 
     if (this.environmentOptions) {
       const invalid: string[] = [];
-      const { runtimePackageManager, runtimePythonPath, runtimeEnvPath } = this.environmentOptions;
+      const { runtimePackageManager, runtimePythonPath, runtimeEnvPath } =
+        this.environmentOptions;
       if (runtimePackageManager && runtimePackageManager !== "pip") {
         invalid.push(`--runtime-package-manager`);
       }
@@ -100,7 +102,9 @@ export class RuntimeConfig {
 
       if (invalid.length > 0) {
         throw new Error(
-          `Invalid value for:\n\n${invalid.join("\n")}\n\nUse --help for more information.`
+          `Invalid value for:\n\n${
+            invalid.join("\n")
+          }\n\nUse --help for more information.`,
         );
       }
     }
@@ -191,14 +195,13 @@ Logging Configuration:
   // Environment options
   const environmentOptions: Record<string, unknown> = {};
   // runtimePythonPath
-  environmentOptions.runtimePythonPath =
-    parsed["runtime-python-path"] ||
+  environmentOptions.runtimePythonPath = parsed["runtime-python-path"] ||
     Deno.env.get("RUNTIME_PYTHON_PATH") ||
     "python3";
   // runtimeEnvPath
   if (parsed["runtime-env-path"] || Deno.env.get("RUNTIME_ENV_PATH")) {
-    environmentOptions.runtimeEnvPath =
-      parsed["runtime-env-path"] || Deno.env.get("RUNTIME_ENV_PATH");
+    environmentOptions.runtimeEnvPath = parsed["runtime-env-path"] ||
+      Deno.env.get("RUNTIME_ENV_PATH");
   }
   // runtimePackageManager
   environmentOptions.runtimePackageManager =
@@ -207,13 +210,13 @@ Logging Configuration:
     "pip";
   // runtimeEnvExternallyManaged: true if CLI or env sets it, else false
   const cliExternallyManaged = Boolean(
-    parsed["runtime-env-externally-managed"]
+    parsed["runtime-env-externally-managed"],
   );
   const envExternallyManaged =
     Deno.env.get("RUNTIME_ENV_EXTERNALLY_MANAGED") === "1" ||
     Deno.env.get("RUNTIME_ENV_EXTERNALLY_MANAGED") === "true";
-  environmentOptions.runtimeEnvExternallyManaged =
-    cliExternallyManaged || envExternallyManaged;
+  environmentOptions.runtimeEnvExternallyManaged = cliExternallyManaged ||
+    envExternallyManaged;
   result.environmentOptions = environmentOptions;
 
   return result;
@@ -224,7 +227,7 @@ Logging Configuration:
  */
 export function createRuntimeConfig(
   args: string[],
-  defaults: Partial<RuntimeAgentOptions> = {}
+  defaults: Partial<RuntimeAgentOptions> = {},
 ): RuntimeConfig {
   const cliConfig = parseRuntimeArgs(args);
 
@@ -248,7 +251,7 @@ export function createRuntimeConfig(
 
   // Only include non-undefined values from CLI config
   const cleanCliConfig: Partial<RuntimeAgentOptions> = Object.fromEntries(
-    Object.entries(cliConfig).filter(([_, value]) => value !== undefined)
+    Object.entries(cliConfig).filter(([_, value]) => value !== undefined),
   );
 
   const config: RuntimeAgentOptions = {

--- a/packages/lib/src/runtime-agent.test.ts
+++ b/packages/lib/src/runtime-agent.test.ts
@@ -57,6 +57,7 @@ Deno.test("RuntimeAgent", async (t) => {
       syncUrl: "ws://localhost:8787",
       authToken: "test-token",
       capabilities,
+      environmentOptions: {},
     });
   };
 
@@ -173,6 +174,7 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: true,
       },
+      environmentOptions: {},
     });
 
     assertEquals(config.runtimeId, "test-runtime");
@@ -195,6 +197,7 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
+      environmentOptions: {},
     });
 
     const config2 = new RuntimeConfig({
@@ -208,6 +211,7 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
+      environmentOptions: {},
     });
 
     // Session IDs should be different
@@ -227,6 +231,7 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
+      environmentOptions: {},
     });
   });
 });

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -47,7 +47,7 @@ export class RuntimeAgent {
    */
   async start(): Promise<void> {
     try {
-      await this.handlers.onStartup?.();
+      await this.handlers.onStartup?.(this.config.environmentOptions);
 
       const logger = createLogger(`${this.config.runtimeType}-agent`, {
         context: {

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -187,7 +187,9 @@ export type ExecutionHandler = (
  */
 export interface RuntimeAgentEventHandlers {
   /** Called when agent starts up */
-  onStartup?: () => void | Promise<void>;
+  onStartup?: (
+    environmentOptions?: RuntimeAgentOptions["environmentOptions"],
+  ) => void | Promise<void>;
   /** Called when agent shuts down */
   onShutdown?: () => void | Promise<void>;
   /** Called when connection to LiveStore is established */

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -36,8 +36,8 @@ export interface RuntimeAgentOptions {
   authToken: string;
   /** Notebook ID to connect to */
   notebookId: string;
-  /** Optional: Environment-related options for the runtime */
-  environmentOptions?: {
+  /** Environment-related options for the runtime */
+  environmentOptions: {
     /** Path to the python executable to use (default: "python3") */
     runtimePythonPath?: string;
     /** Path to the environment/venv to use (default: unset) */
@@ -188,7 +188,7 @@ export type ExecutionHandler = (
 export interface RuntimeAgentEventHandlers {
   /** Called when agent starts up */
   onStartup?: (
-    environmentOptions?: RuntimeAgentOptions["environmentOptions"],
+    environmentOptions: RuntimeAgentOptions["environmentOptions"],
   ) => void | Promise<void>;
   /** Called when agent shuts down */
   onShutdown?: () => void | Promise<void>;

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -36,6 +36,17 @@ export interface RuntimeAgentOptions {
   authToken: string;
   /** Notebook ID to connect to */
   notebookId: string;
+  /** Optional: Environment-related options for the runtime */
+  environmentOptions?: {
+    /** Path to the python executable to use (default: "python3") */
+    runtimePythonPath?: string;
+    /** Path to the environment/venv to use (default: unset) */
+    runtimeEnvPath?: string;
+    /** Package manager to use (default: "pip") */
+    runtimePackageManager?: string;
+    /** If true, treat the environment as externally managed (default: false) */
+    runtimeEnvExternallyManaged?: boolean;
+  };
 }
 
 /**
@@ -118,10 +129,7 @@ export interface ExecutionContext {
     metadata?: Record<string, unknown>,
   ) => void;
   /** Emit execution result (final output) */
-  result: (
-    data: RawOutputData,
-    metadata?: Record<string, unknown>,
-  ) => void;
+  result: (data: RawOutputData, metadata?: Record<string, unknown>) => void;
   /** Emit error output */
   error: (ename: string, evalue: string, traceback: string[]) => void;
   /** Clear all previous outputs for this cell */

--- a/packages/lib/test/config.test.ts
+++ b/packages/lib/test/config.test.ts
@@ -19,7 +19,11 @@ function makeBaseConfig(overrides: Partial<Record<string, unknown>> = {}) {
     syncUrl: "url",
     authToken: "token",
     notebookId: "nb",
-    capabilities: { canExecuteCode: true, canExecuteSql: false, canExecuteAi: false },
+    capabilities: {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: false,
+    },
     environmentOptions: {
       runtimePackageManager: "pip",
       runtimePythonPath: "/usr/bin/python3",
@@ -31,14 +35,22 @@ function makeBaseConfig(overrides: Partial<Record<string, unknown>> = {}) {
 
 Deno.test("parseRuntimeArgs: parses required CLI args", () => {
   const args = [
-    "--notebook", "nb1",
-    "--auth-token", "tok",
-    "--runtime-id", "rid",
-    "--runtime-type", "python",
-    "--sync-url", "ws://foo",
-    "--runtime-python-path", "/usr/bin/python3",
-    "--runtime-env-path", "/tmp/venv",
-    "--runtime-package-manager", "pipx",
+    "--notebook",
+    "nb1",
+    "--auth-token",
+    "tok",
+    "--runtime-id",
+    "rid",
+    "--runtime-type",
+    "python",
+    "--sync-url",
+    "ws://foo",
+    "--runtime-python-path",
+    "/usr/bin/python3",
+    "--runtime-env-path",
+    "/tmp/venv",
+    "--runtime-package-manager",
+    "pipx",
     "--runtime-env-externally-managed",
   ];
   const result = parseRuntimeArgs(args);
@@ -48,14 +60,22 @@ Deno.test("parseRuntimeArgs: parses required CLI args", () => {
   assertEquals(result.runtimeType, "python");
   assertEquals(result.syncUrl, "ws://foo");
   assert(result.environmentOptions);
-  assertEquals(result.environmentOptions?.runtimePythonPath, "/usr/bin/python3");
+  assertEquals(
+    result.environmentOptions?.runtimePythonPath,
+    "/usr/bin/python3",
+  );
   assertEquals(result.environmentOptions?.runtimeEnvPath, "/tmp/venv");
   assertEquals(result.environmentOptions?.runtimePackageManager, "pipx");
   assertEquals(result.environmentOptions?.runtimeEnvExternallyManaged, true);
 });
 
 Deno.test("parseRuntimeArgs: uses defaults for missing environmentOptions", () => {
-  const result = parseRuntimeArgs(["--notebook", "nb2", "--auth-token", "tok2"]);
+  const result = parseRuntimeArgs([
+    "--notebook",
+    "nb2",
+    "--auth-token",
+    "tok2",
+  ]);
   assert(result.environmentOptions);
   assertEquals(result.environmentOptions?.runtimePythonPath, "python3");
   assertEquals(result.environmentOptions?.runtimePackageManager, "pip");
@@ -80,17 +100,22 @@ Deno.test("createRuntimeConfig - deep merges environmentOptions from CLI, env, a
   using _getStub = stub(Deno.env, "get", (key: string) => envMap[key]);
   const args = addRequiredParams(["--runtime-python-path", "/cli/python"]);
   assertThrows(
-    () => createRuntimeConfig(args, {
-      runtimeType: "python",
-      capabilities: { canExecuteCode: true, canExecuteSql: false, canExecuteAi: false },
-      environmentOptions: {
-        runtimePythonPath: "/default/python",
-        runtimePackageManager: "pip",
-        runtimeEnvExternallyManaged: false,
-      },
-    }),
+    () =>
+      createRuntimeConfig(args, {
+        runtimeType: "python",
+        capabilities: {
+          canExecuteCode: true,
+          canExecuteSql: false,
+          canExecuteAi: false,
+        },
+        environmentOptions: {
+          runtimePythonPath: "/default/python",
+          runtimePackageManager: "pip",
+          runtimeEnvExternallyManaged: false,
+        },
+      }),
     Error,
-    "--runtime-package-manager"
+    "--runtime-package-manager",
   );
 });
 
@@ -102,7 +127,9 @@ Deno.test("createRuntimeConfig - runtimeEnvExternallyManaged is true if set in C
 });
 
 Deno.test("createRuntimeConfig - runtimeEnvExternallyManaged is true if set in env", () => {
-  const envMap: Record<string, string | undefined> = { RUNTIME_ENV_EXTERNALLY_MANAGED: "true" };
+  const envMap: Record<string, string | undefined> = {
+    RUNTIME_ENV_EXTERNALLY_MANAGED: "true",
+  };
   using _getStub = stub(Deno.env, "get", (key: string) => envMap[key]);
   const config = createRuntimeConfig(addRequiredParams([]));
   assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, true);
@@ -121,17 +148,20 @@ Deno.test("RuntimeConfig.validate - passes with valid environmentOptions", () =>
 
 Deno.test("RuntimeConfig.validate - throws for invalid manager", () => {
   assertThrows(
-    () => new RuntimeConfig(makeBaseConfig({ runtimePackageManager: "conda" })).validate(),
+    () =>
+      new RuntimeConfig(makeBaseConfig({ runtimePackageManager: "conda" }))
+        .validate(),
     Error,
-    "--runtime-package-manager"
+    "--runtime-package-manager",
   );
 });
 
 Deno.test("RuntimeConfig.validate - throws for empty python path", () => {
   assertThrows(
-    () => new RuntimeConfig(makeBaseConfig({ runtimePythonPath: "" })).validate(),
+    () =>
+      new RuntimeConfig(makeBaseConfig({ runtimePythonPath: "" })).validate(),
     Error,
-    "--runtime-python-path"
+    "--runtime-python-path",
   );
 });
 
@@ -139,6 +169,6 @@ Deno.test("RuntimeConfig.validate - throws for empty env path", () => {
   assertThrows(
     () => new RuntimeConfig(makeBaseConfig({ runtimeEnvPath: "" })).validate(),
     Error,
-    "--runtime-env-path"
+    "--runtime-env-path",
   );
 });

--- a/packages/lib/test/config.test.ts
+++ b/packages/lib/test/config.test.ts
@@ -1,0 +1,144 @@
+import { assert, assertEquals, assertThrows } from "jsr:@std/assert";
+import { stub } from "jsr:@std/testing/mock";
+import {
+  createRuntimeConfig,
+  DEFAULT_CONFIG,
+  parseRuntimeArgs,
+  RuntimeConfig,
+} from "../src/config.ts";
+
+const REQUIRED_PARAMS = ["--notebook", "nb", "--auth-token", "tok"];
+function addRequiredParams(args: string[]): string[] {
+  return [...REQUIRED_PARAMS, ...args];
+}
+
+function makeBaseConfig(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    runtimeId: "id",
+    runtimeType: "type",
+    syncUrl: "url",
+    authToken: "token",
+    notebookId: "nb",
+    capabilities: { canExecuteCode: true, canExecuteSql: false, canExecuteAi: false },
+    environmentOptions: {
+      runtimePackageManager: "pip",
+      runtimePythonPath: "/usr/bin/python3",
+      runtimeEnvPath: "/tmp/venv",
+      ...overrides,
+    },
+  };
+}
+
+Deno.test("parseRuntimeArgs: parses required CLI args", () => {
+  const args = [
+    "--notebook", "nb1",
+    "--auth-token", "tok",
+    "--runtime-id", "rid",
+    "--runtime-type", "python",
+    "--sync-url", "ws://foo",
+    "--runtime-python-path", "/usr/bin/python3",
+    "--runtime-env-path", "/tmp/venv",
+    "--runtime-package-manager", "pipx",
+    "--runtime-env-externally-managed",
+  ];
+  const result = parseRuntimeArgs(args);
+  assertEquals(result.notebookId, "nb1");
+  assertEquals(result.authToken, "tok");
+  assertEquals(result.runtimeId, "rid");
+  assertEquals(result.runtimeType, "python");
+  assertEquals(result.syncUrl, "ws://foo");
+  assert(result.environmentOptions);
+  assertEquals(result.environmentOptions?.runtimePythonPath, "/usr/bin/python3");
+  assertEquals(result.environmentOptions?.runtimeEnvPath, "/tmp/venv");
+  assertEquals(result.environmentOptions?.runtimePackageManager, "pipx");
+  assertEquals(result.environmentOptions?.runtimeEnvExternallyManaged, true);
+});
+
+Deno.test("parseRuntimeArgs: uses defaults for missing environmentOptions", () => {
+  const result = parseRuntimeArgs(["--notebook", "nb2", "--auth-token", "tok2"]);
+  assert(result.environmentOptions);
+  assertEquals(result.environmentOptions?.runtimePythonPath, "python3");
+  assertEquals(result.environmentOptions?.runtimePackageManager, "pip");
+  assertEquals(result.environmentOptions?.runtimeEnvExternallyManaged, false);
+});
+
+Deno.test("createRuntimeConfig - sets defaults for missing options", () => {
+  using _getStub = stub(Deno.env, "get", () => undefined);
+  const config = createRuntimeConfig(addRequiredParams([]));
+  assertEquals(config.syncUrl, DEFAULT_CONFIG.syncUrl);
+  assertEquals(config.environmentOptions?.runtimePythonPath, "python3");
+  assertEquals(config.environmentOptions?.runtimePackageManager, "pip");
+  assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, false);
+});
+
+Deno.test("createRuntimeConfig - deep merges environmentOptions from CLI, env, and defaults", () => {
+  const envMap: Record<string, string | undefined> = {
+    RUNTIME_PYTHON_PATH: "/env/python",
+    RUNTIME_PACKAGE_MANAGER: "conda",
+    RUNTIME_ENV_EXTERNALLY_MANAGED: "true",
+  };
+  using _getStub = stub(Deno.env, "get", (key: string) => envMap[key]);
+  const args = addRequiredParams(["--runtime-python-path", "/cli/python"]);
+  assertThrows(
+    () => createRuntimeConfig(args, {
+      runtimeType: "python",
+      capabilities: { canExecuteCode: true, canExecuteSql: false, canExecuteAi: false },
+      environmentOptions: {
+        runtimePythonPath: "/default/python",
+        runtimePackageManager: "pip",
+        runtimeEnvExternallyManaged: false,
+      },
+    }),
+    Error,
+    "--runtime-package-manager"
+  );
+});
+
+Deno.test("createRuntimeConfig - runtimeEnvExternallyManaged is true if set in CLI", () => {
+  using _getStub = stub(Deno.env, "get", () => undefined);
+  const args = addRequiredParams(["--runtime-env-externally-managed"]);
+  const config = createRuntimeConfig(args);
+  assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, true);
+});
+
+Deno.test("createRuntimeConfig - runtimeEnvExternallyManaged is true if set in env", () => {
+  const envMap: Record<string, string | undefined> = { RUNTIME_ENV_EXTERNALLY_MANAGED: "true" };
+  using _getStub = stub(Deno.env, "get", (key: string) => envMap[key]);
+  const config = createRuntimeConfig(addRequiredParams([]));
+  assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, true);
+});
+
+Deno.test("createRuntimeConfig - runtimeEnvExternallyManaged is false if not set", () => {
+  using _getStub = stub(Deno.env, "get", () => undefined);
+  const config = createRuntimeConfig(addRequiredParams([]));
+  assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, false);
+});
+
+Deno.test("RuntimeConfig.validate - passes with valid environmentOptions", () => {
+  const config = new RuntimeConfig(makeBaseConfig());
+  config.validate();
+});
+
+Deno.test("RuntimeConfig.validate - throws for invalid manager", () => {
+  assertThrows(
+    () => new RuntimeConfig(makeBaseConfig({ runtimePackageManager: "conda" })).validate(),
+    Error,
+    "--runtime-package-manager"
+  );
+});
+
+Deno.test("RuntimeConfig.validate - throws for empty python path", () => {
+  assertThrows(
+    () => new RuntimeConfig(makeBaseConfig({ runtimePythonPath: "" })).validate(),
+    Error,
+    "--runtime-python-path"
+  );
+});
+
+Deno.test("RuntimeConfig.validate - throws for empty env path", () => {
+  assertThrows(
+    () => new RuntimeConfig(makeBaseConfig({ runtimeEnvPath: "" })).validate(),
+    Error,
+    "--runtime-env-path"
+  );
+});

--- a/packages/lib/test/integration.test.ts
+++ b/packages/lib/test/integration.test.ts
@@ -56,7 +56,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       notebookId: "test-notebook-integration",
       syncUrl: "ws://localhost:8787",
       authToken: "test-integration-token",
-
+      environmentOptions: {},
       capabilities,
     });
   };
@@ -146,6 +146,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
         syncUrl: "ws://localhost:8787",
         authToken: "valid-token",
         capabilities: capabilities,
+        environmentOptions: {},
       });
 
       const agent = new RuntimeAgent(validConfig, capabilities);
@@ -165,6 +166,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
           syncUrl: "ws://localhost:8787",
           authToken: "token",
           capabilities: capabilities,
+          environmentOptions: {},
         });
         config.validate(); // Explicitly call validate
       } catch (e) {
@@ -240,6 +242,7 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: true,
       },
+      environmentOptions: {},
     });
 
     assertEquals(config.runtimeId, "test-runtime");
@@ -262,6 +265,7 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
+      environmentOptions: {},
     });
 
     const config2 = new RuntimeConfig({
@@ -275,6 +279,7 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
+      environmentOptions: {},
     });
 
     // Session IDs should be different
@@ -294,6 +299,7 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
+      environmentOptions: {},
     });
   });
 });


### PR DESCRIPTION
In order to support running CPython kernels, we need to to have extra configuration from the user (via the command line or environment variables) that gets piped through to the runtime agent code.

After this PR is merged, we can tackle using these values in the python runtime agent.

This fixes #88 