### PR TITLE
WIP: Upgrade @livestore/wa-sqlite to 1.0.5 to fix WebAssembly memory limitation

### DIFF
--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -16,6 +16,7 @@
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
+    "npm:@livestore/wa-sqlite": "npm:@livestore/wa-sqlite@1.0.5",
     "@openai/openai": "jsr:@openai/openai@^4.98.0",
     "npm:ollama": "npm:ollama@^0.5.16",
     "strip-ansi": "npm:strip-ansi@^7.1.0"

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -19,6 +19,8 @@
     "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
     "npm:@livestore/sync-cf": "npm:@livestore/sync-cf@^0.3.1",
+    "npm:@livestore/wa-sqlite": "npm:@livestore/wa-sqlite@1.0.5",
+    "@livestore/wa-sqlite": "npm:@livestore/wa-sqlite@1.0.5",
     "npm:@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0"
   },
   "tasks": {

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -20,6 +20,8 @@
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
+    "npm:@livestore/wa-sqlite": "npm:@livestore/wa-sqlite@1.0.5",
+    "@livestore/wa-sqlite": "npm:@livestore/wa-sqlite@1.0.5",
     "npm:strip-ansi": "npm:strip-ansi@^7.1.0"
   },
   "tasks": {

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -18,7 +18,9 @@
     "lib": ["ESNext", "DOM"]
   },
   "imports": {
-    "@livestore/livestore": "npm:@livestore/livestore@^0.3.1"
+    "@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
+    "@livestore/wa-sqlite": "npm:@livestore/wa-sqlite@1.0.5",
+    "npm:@livestore/wa-sqlite": "npm:@livestore/wa-sqlite@1.0.5"
   },
   "lint": {
     "rules": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -16,7 +16,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@livestore/livestore": "^0.3.1"
+    "@livestore/livestore": "^0.3.1",
+    "@livestore/wa-sqlite": "1.0.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hoping to address the LiveStore Node Adapter WebAssembly memory limitation by upgrading to the fixed version.

- Add @livestore/wa-sqlite@1.0.5 to all runt packages
- Fixes 16MB memory limit in server environments
