### PR TITLE
Create a PythonRuntimeAgent stub by refactoring PyodideRuntimeAgent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ on:
 
 env:
   DENO_VERSION: v2.x
-  BUILD_ORDER: '["schema","lib", "ai", "pyodide-runtime-agent"]'
+  BUILD_ORDER: '["schema","lib", "ai", "pyodide-runtime-agent", "python-runtime-agent"]'
 
 jobs:
   generate-build-order:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ AI behavior with iterative tool calls.
 - ✅ Cross-package TypeScript imports with proper typing
 - ✅ CI/CD pipeline with multi-platform testing
 - ✅ JSR publishing for all packages with executable installation
-- ✅ Global executable installation as `pyrunt`
+- ✅ Global executable installation as `pyrunt` or `pyorunt` (pyodide)
 - ✅ Agentic AI behavior with iterative tool call responses
 - ✅ Interrupt-aware AI conversations with configurable max iterations
 - ✅ Streaming output support with granular event types

--- a/deno.json
+++ b/deno.json
@@ -3,13 +3,15 @@
     "./packages/ai",
     "./packages/schema",
     "./packages/lib",
-    "./packages/pyodide-runtime-agent"
+    "./packages/pyodide-runtime-agent",
+    "./packages/python-runtime-agent"
   ],
   "imports": {
     "@runt/ai": "./packages/ai/mod.ts",
     "@runt/schema": "./packages/schema/mod.ts",
     "@runt/lib": "./packages/lib/mod.ts",
-    "@runt/pyodide-runtime-agent": "./packages/pyodide-runtime-agent/src/mod.ts"
+    "@runt/pyodide-runtime-agent": "./packages/pyodide-runtime-agent/src/mod.ts",
+    "@runt/python-runtime-agent": "./packages/python-runtime-agent/mod.ts"
   },
   "lint": {
     "rules": {

--- a/packages/lib/examples/echo-agent.ts
+++ b/packages/lib/examples/echo-agent.ts
@@ -68,14 +68,8 @@ agent.onExecution(async (context) => {
 
 // Start the agent
 try {
-  await agent.start();
-
-  logger.info("Echo agent started", {
-    runtimeId: config.runtimeId,
-    runtimeType: config.runtimeType,
-    notebookId: config.notebookId,
-    sessionId: config.sessionId,
-  });
+  const startInfo = await agent.start();
+  logger.info("Echo agent started", startInfo || {});
 
   await agent.keepAlive();
 } catch (error) {

--- a/packages/lib/examples/echo-agent.ts
+++ b/packages/lib/examples/echo-agent.ts
@@ -68,8 +68,13 @@ agent.onExecution(async (context) => {
 
 // Start the agent
 try {
-  const startInfo = await agent.start();
-  logger.info("Echo agent started", startInfo || {});
+  await agent.start();
+  logger.info("Echo agent started", {
+    runtimeId: agent.config.runtimeId,
+    runtimeType: agent.config.runtimeType,
+    notebookId: agent.config.notebookId,
+    sessionId: agent.config.sessionId,
+  });
 
   await agent.keepAlive();
 } catch (error) {

--- a/packages/lib/examples/enhanced-output-example.ts
+++ b/packages/lib/examples/enhanced-output-example.ts
@@ -39,7 +39,7 @@ class ExamplePythonRuntime {
   }
 
   async start() {
-    return await this.agent.start();
+    await this.agent.start();
   }
 
   async shutdown() {

--- a/packages/lib/examples/streaming-demo.ts
+++ b/packages/lib/examples/streaming-demo.ts
@@ -37,12 +37,10 @@ class StreamingDemoAgent {
   }
 
   async start() {
-    const result = await this.agent.start();
+    await this.agent.start();
 
     // Auto-create help cell if notebook is empty
     this.createHelpCellIfEmpty();
-
-    return result;
   }
 
   async shutdown() {
@@ -56,7 +54,7 @@ class StreamingDemoAgent {
   private createHelpCellIfEmpty() {
     try {
       // Check if there are any existing cells using LiveStore query
-      const cells = this.agent.liveStore.query(
+      const cells = this.agent.store.query(
         tables.cells.select(),
       );
 
@@ -65,7 +63,7 @@ class StreamingDemoAgent {
 
         // Create a cell with help command
         const cellId = crypto.randomUUID();
-        this.agent.liveStore.commit(events.cellCreated({
+        this.agent.store.commit(events.cellCreated({
           id: cellId,
           cellType: "code",
           position: 0,
@@ -73,7 +71,7 @@ class StreamingDemoAgent {
         }));
 
         // Update the cell with source content
-        this.agent.liveStore.commit(events.cellSourceChanged({
+        this.agent.store.commit(events.cellSourceChanged({
           id: cellId,
           source: "help",
           modifiedBy: "streaming-demo-runtime",
@@ -81,7 +79,7 @@ class StreamingDemoAgent {
 
         // Queue it for execution
         const queueId = crypto.randomUUID();
-        this.agent.liveStore.commit(events.executionRequested({
+        this.agent.store.commit(events.executionRequested({
           queueId: queueId,
           cellId: cellId,
           executionCount: 1,

--- a/packages/lib/mod.ts
+++ b/packages/lib/mod.ts
@@ -34,3 +34,5 @@ export type { LoggerConfig } from "./src/logging.ts";
 
 // Media types and utilities for rich content handling
 export * from "./src/media/mod.ts";
+
+export { runner } from "./src/runtime-runner.ts";

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -37,7 +37,7 @@ export class RuntimeAgent {
   private signalHandlers = new Map<string, () => void>();
 
   constructor(
-    private config: RuntimeConfig,
+    public config: RuntimeConfig,
     private capabilities: RuntimeCapabilities,
     private handlers: RuntimeAgentEventHandlers = {},
   ) {}

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -45,7 +45,7 @@ export class RuntimeAgent {
   /**
    * Start the runtime agent - connects to LiveStore and begins processing
    */
-  async start(): Promise<Record<string, unknown> | void> {
+  async start(): Promise<void> {
     try {
       await this.handlers.onStartup?.(this.config.environmentOptions);
 
@@ -119,14 +119,7 @@ export class RuntimeAgent {
       // Set up shutdown handlers
       this.setupShutdownHandlers();
 
-      // Return startup info for logging
-      return {
-        runtimeId: this.config.runtimeId,
-        runtimeType: this.config.runtimeType,
-        notebookId: this.config.notebookId,
-        sessionId: this.config.sessionId,
-        syncUrl: this.config.syncUrl,
-      };
+      // No return value
     } catch (error) {
       const logger = createLogger(`${this.config.runtimeType}-agent`);
       logger.error("Failed to start runtime agent", error);

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -45,7 +45,7 @@ export class RuntimeAgent {
   /**
    * Start the runtime agent - connects to LiveStore and begins processing
    */
-  async start(): Promise<void> {
+  async start(): Promise<Record<string, unknown> | void> {
     try {
       await this.handlers.onStartup?.(this.config.environmentOptions);
 
@@ -118,6 +118,15 @@ export class RuntimeAgent {
 
       // Set up shutdown handlers
       this.setupShutdownHandlers();
+
+      // Return startup info for logging
+      return {
+        runtimeId: this.config.runtimeId,
+        runtimeType: this.config.runtimeType,
+        notebookId: this.config.notebookId,
+        sessionId: this.config.sessionId,
+        syncUrl: this.config.syncUrl,
+      };
     } catch (error) {
       const logger = createLogger(`${this.config.runtimeType}-agent`);
       logger.error("Failed to start runtime agent", error);

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -27,7 +27,7 @@ import type { RuntimeConfig } from "./config.ts";
  * Base RuntimeAgent class providing LiveStore integration and execution management
  */
 export class RuntimeAgent {
-  private store!: Store<typeof schema>;
+  #store!: Store<typeof schema>;
   private isShuttingDown = false;
   private processedExecutions = new Set<string>();
 
@@ -71,7 +71,7 @@ export class RuntimeAgent {
         },
       });
 
-      this.store = await createStorePromise({
+      this.#store = await createStorePromise({
         adapter,
         schema,
         storeId: this.config.notebookId,
@@ -157,7 +157,7 @@ export class RuntimeAgent {
 
       // Mark session as terminated
       try {
-        if (this.store) {
+        if (this.#store) {
           // Terminate session on shutdown
           this.store.commit(events.runtimeSessionTerminated({
             sessionId: this.config.sessionId,
@@ -179,7 +179,7 @@ export class RuntimeAgent {
       this.cleanupSignalHandlers();
 
       // Close LiveStore connection
-      if (this.store) {
+      if (this.#store) {
         await this.store.shutdown?.();
       }
     } catch (error) {
@@ -210,11 +210,8 @@ export class RuntimeAgent {
     this.cancellationHandlers.push(handler);
   }
 
-  /**
-   * Get the LiveStore instance (for testing)
-   */
-  get liveStore(): Store<typeof schema> {
-    return this.store;
+  public get store(): Store<typeof schema> {
+    return this.#store;
   }
 
   private executionHandler: ExecutionHandler = async (context) => {

--- a/packages/lib/src/runtime-runner.ts
+++ b/packages/lib/src/runtime-runner.ts
@@ -10,7 +10,13 @@ export async function runner(agent: RuntimeAgent, name: string) {
 
   try {
     await agent.start();
-    logger.info(`${name} started`);
+    logger.info(`${name} started`, {
+      runtimeId: agent.config.runtimeId,
+      runtimeType: agent.config.runtimeType,
+      notebookId: agent.config.notebookId,
+      sessionId: agent.config.sessionId,
+      syncUrl: agent.config.syncUrl,
+    });
 
     await agent.keepAlive();
   } catch (error) {

--- a/packages/lib/src/runtime-runner.ts
+++ b/packages/lib/src/runtime-runner.ts
@@ -1,0 +1,22 @@
+import { createLogger } from "./logging.ts";
+import type { RuntimeAgent } from "./runtime-agent.ts";
+
+/**
+ * Helper function to implement a CLI entrypoint for python agents
+ * Each agent implementation just needs to call main() with their RuntimeAgent
+ */
+export async function runner(agent: RuntimeAgent) {
+  const logger = createLogger("pyrunt");
+
+  try {
+    await agent.start();
+    logger.info("PyRunt started");
+
+    await agent.keepAlive();
+  } catch (error) {
+    logger.error("Failed to start PyRunt", error);
+    Deno.exit(1);
+  } finally {
+    await agent.shutdown();
+  }
+}

--- a/packages/lib/src/runtime-runner.ts
+++ b/packages/lib/src/runtime-runner.ts
@@ -5,16 +5,16 @@ import type { RuntimeAgent } from "./runtime-agent.ts";
  * Helper function to implement a CLI entrypoint for python agents
  * Each agent implementation just needs to call main() with their RuntimeAgent
  */
-export async function runner(agent: RuntimeAgent) {
-  const logger = createLogger("pyrunt");
+export async function runner(agent: RuntimeAgent, name: string) {
+  const logger = createLogger(name);
 
   try {
     await agent.start();
-    logger.info("PyRunt started");
+    logger.info(`${name} started`);
 
     await agent.keepAlive();
   } catch (error) {
-    logger.error("Failed to start PyRunt", error);
+    logger.error(`Failed to start ${name}`, error);
     Deno.exit(1);
   } finally {
     await agent.shutdown();

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -25,28 +25,28 @@ export interface RawOutputData {
  */
 export interface RuntimeAgentOptions {
   /** Unique identifier for this runtime */
-  runtimeId: string;
+  readonly runtimeId: string;
   /** Human-readable runtime type (appears in UI) */
-  runtimeType: string;
+  readonly runtimeType: string;
   /** Capabilities this runtime supports */
-  capabilities: RuntimeCapabilities;
+  readonly capabilities: Readonly<RuntimeCapabilities>;
   /** LiveStore sync URL */
-  syncUrl: string;
+  readonly syncUrl: string;
   /** Authentication token */
-  authToken: string;
+  readonly authToken: string;
   /** Notebook ID to connect to */
-  notebookId: string;
+  readonly notebookId: string;
   /** Environment-related options for the runtime */
-  environmentOptions: {
+  readonly environmentOptions: Readonly<{
     /** Path to the python executable to use (default: "python3") */
-    runtimePythonPath?: string;
+    readonly runtimePythonPath?: string;
     /** Path to the environment/venv to use (default: unset) */
-    runtimeEnvPath?: string;
+    readonly runtimeEnvPath?: string;
     /** Package manager to use (default: "pip") */
-    runtimePackageManager?: string;
+    readonly runtimePackageManager?: string;
     /** If true, treat the environment as externally managed (default: false) */
-    runtimeEnvExternallyManaged?: boolean;
-  };
+    readonly runtimeEnvExternallyManaged?: boolean;
+  }>;
 }
 
 /**

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -11,7 +11,7 @@
     ".": "./src/mod.ts"
   },
   "bin": {
-    "pyrunt": "./src/mod.ts"
+    "pyorunt": "./src/mod.ts"
   },
   "imports": {
     "@runt/ai": "jsr:@runt/ai@^0.6.2",

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -7,7 +7,7 @@
  */
 
 import { PyodideRuntimeAgent } from "./pyodide-agent.ts";
-import { createLogger } from "@runt/lib";
+import { runner } from "@runt/lib";
 
 export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 export {
@@ -20,28 +20,8 @@ export {
   isFirstRun,
 } from "./cache-utils.ts";
 
-/**
- * Main function to run the Pyodide runtime agent
- */
-async function main() {
-  const agent = new PyodideRuntimeAgent();
-  const logger = createLogger("pyrunt");
-
-  try {
-    const startInfo = await agent.start();
-
-    logger.info("PyRunt started", startInfo || {});
-
-    await agent.keepAlive();
-  } catch (error) {
-    logger.error("Failed to start PyRunt", error);
-    Deno.exit(1);
-  } finally {
-    await agent.shutdown();
-  }
-}
-
-// Run as script if this file is executed directly
+// Run the agent if this file is executed directly
 if (import.meta.main) {
-  await main();
+  const agent = new PyodideRuntimeAgent();
+  await runner(agent);
 }

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S deno run --allow-all --unstable-broadcast-channel
 /**
- * PyRunt - Python Runtime Agent
+ * PyoRunt - Python Runtime Agent
  *
  * Main executable entry point for the Pyodide runtime agent.
  * This file serves as both the library entry point and the executable.
@@ -23,5 +23,5 @@ export {
 // Run the agent if this file is executed directly
 if (import.meta.main) {
   const agent = new PyodideRuntimeAgent();
-  await runner(agent);
+  await runner(agent, "PyoRunt");
 }

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -28,15 +28,9 @@ async function main() {
   const logger = createLogger("pyrunt");
 
   try {
-    await agent.start();
+    const startInfo = await agent.start();
 
-    logger.info("PyRunt started", {
-      runtimeId: agent.config.runtimeId,
-      runtimeType: agent.config.runtimeType,
-      notebookId: agent.config.notebookId,
-      sessionId: agent.config.sessionId,
-      syncUrl: agent.config.syncUrl,
-    });
+    logger.info("PyRunt started", startInfo || {});
 
     await agent.keepAlive();
   } catch (error) {

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -41,8 +41,7 @@ interface PyodideAgentOptions {
  * including IPython integration, rich display support, matplotlib SVG output,
  * pandas HTML tables, and enhanced error formatting.
  */
-export class PyodideRuntimeAgent {
-  private agent: RuntimeAgent;
+export class PyodideRuntimeAgent extends RuntimeAgent {
   private worker: Worker | null = null;
   private interruptBuffer?: SharedArrayBuffer;
   private isInitialized = false;
@@ -96,20 +95,24 @@ export class PyodideRuntimeAgent {
       Deno.exit(1);
     }
 
-    this.agent = new RuntimeAgent(config, config.capabilities, {
-      onStartup: this.initializePyodideWorker.bind(this),
-      onShutdown: this.cleanupWorker.bind(this),
+    super(config, config.capabilities, {
+      onStartup: async () => {
+        await this.initializePyodideWorker();
+      },
+      onShutdown: () => {
+        this.cleanupWorker();
+      },
     });
 
     this.options = options;
-    this.agent.onExecution(this.executeCell.bind(this));
-    this.agent.onCancellation(this.handleCancellation.bind(this));
+    this.onExecution(this.executeCell.bind(this));
+    this.onCancellation(this.handlePyodideCancellation.bind(this));
   }
 
   /**
    * Start the Pyodide runtime agent
    */
-  async start(): Promise<Record<string, unknown> | void> {
+  override async start(): Promise<Record<string, unknown> | void> {
     this.logger.info("Starting Pyodide Python runtime agent");
 
     // Discover available AI models if enabled
@@ -135,29 +138,7 @@ export class PyodideRuntimeAgent {
       }
     }
 
-    return this.agent.start();
-  }
-
-  /**
-   * Shutdown the runtime agent
-   */
-  async shutdown(): Promise<void> {
-    await this.agent.shutdown();
-  }
-
-  /**
-   * Keep the agent alive
-   */
-  async keepAlive(): Promise<void> {
-    await this.agent.keepAlive();
-  }
-
-  public get store() {
-    return this.agent.store;
-  }
-
-  get config(): RuntimeConfig {
-    return this.agent.config;
+    return super.start();
   }
 
   /**
@@ -620,7 +601,7 @@ export class PyodideRuntimeAgent {
   /**
    * Handle cancellation events
    */
-  private handleCancellation(
+  private handlePyodideCancellation(
     queueId: string,
     cellId: string,
     reason: string,

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -91,7 +91,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       console.error(
         "  deno install -gf --allow-all jsr:@runt/pyodide-runtime-agent",
       );
-      console.error("  pyrunt --notebook my-notebook --auth-token your-token");
+      console.error("  pyorunt --notebook my-notebook --auth-token your-token");
       Deno.exit(1);
     }
 

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -4,7 +4,11 @@
 // IPython integration, rich display support, and true interruption support
 // via Pyodide's built-in interrupt system.
 
-import { createRuntimeConfig, RuntimeAgent } from "@runt/lib";
+import {
+  createRuntimeConfig,
+  RuntimeAgent,
+  type RuntimeConfig,
+} from "@runt/lib";
 import type { ExecutionContext } from "@runt/lib";
 import { createLogger } from "@runt/lib";
 import { type MediaBundle, validateMediaBundle } from "@runt/lib";
@@ -59,12 +63,12 @@ export class PyodideRuntimeAgent {
     reject: (error: unknown) => void;
   }>();
   private logger = createLogger("pyodide-agent");
-  public config: ReturnType<typeof createRuntimeConfig>;
   private options: PyodideAgentOptions;
 
   constructor(args: string[] = Deno.args, options: PyodideAgentOptions = {}) {
+    let config: RuntimeConfig;
     try {
-      this.config = createRuntimeConfig(args, {
+      config = createRuntimeConfig(args, {
         runtimeType: "python3-pyodide",
         capabilities: {
           canExecuteCode: true,
@@ -92,7 +96,7 @@ export class PyodideRuntimeAgent {
       Deno.exit(1);
     }
 
-    this.agent = new RuntimeAgent(this.config, this.config.capabilities, {
+    this.agent = new RuntimeAgent(config, config.capabilities, {
       onStartup: this.initializePyodideWorker.bind(this),
       onShutdown: this.cleanupWorker.bind(this),
     });
@@ -150,6 +154,10 @@ export class PyodideRuntimeAgent {
 
   public get store() {
     return this.agent.store;
+  }
+
+  get config(): RuntimeConfig {
+    return this.agent.config;
   }
 
   /**

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -107,7 +107,7 @@ export class PyodideRuntimeAgent {
   /**
    * Start the Pyodide runtime agent
    */
-  async start(): Promise<void> {
+  async start(): Promise<Record<string, unknown> | void> {
     this.logger.info("Starting Pyodide Python runtime agent");
 
     // Discover available AI models if enabled
@@ -133,7 +133,7 @@ export class PyodideRuntimeAgent {
       }
     }
 
-    await this.agent.start();
+    return this.agent.start();
   }
 
   /**

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -112,7 +112,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
   /**
    * Start the Pyodide runtime agent
    */
-  override async start(): Promise<Record<string, unknown> | void> {
+  override async start(): Promise<void> {
     this.logger.info("Starting Pyodide Python runtime agent");
 
     // Discover available AI models if enabled
@@ -138,7 +138,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       }
     }
 
-    return super.start();
+    await super.start();
   }
 
   /**

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -15,8 +15,6 @@ import {
   type KnownMimeType,
 } from "@runt/schema";
 import { getEssentialPackages } from "./cache-utils.ts";
-import type { Store } from "npm:@livestore/livestore";
-import { schema } from "@runt/schema";
 import {
   discoverAvailableAiModels,
   ensureTextPlainFallback,
@@ -150,11 +148,8 @@ export class PyodideRuntimeAgent {
     await this.agent.keepAlive();
   }
 
-  /**
-   * Get the LiveStore instance (for testing)
-   */
-  get store(): Store<typeof schema> {
-    return this.agent.liveStore;
+  public get store() {
+    return this.agent.store;
   }
 
   /**

--- a/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
@@ -36,11 +36,10 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
 
   await t.step("can execute AI cell with mock response", async () => {
     if (!agent) throw new Error("Agent not initialized");
-    const store = agent.store;
 
     // Create an AI cell
     const aiCellId = "ai-cell-test-1";
-    store.commit(
+    agent.store.commit(
       events.cellCreated({
         id: aiCellId,
         cellType: "ai",
@@ -51,7 +50,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
 
     // Set the AI cell source
     const prompt = "Explain what machine learning is in simple terms";
-    store.commit(
+    agent.store.commit(
       events.cellSourceChanged({
         id: aiCellId,
         source: prompt,
@@ -63,7 +62,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     const queueId1 = `exec-${Date.now()}-${
       Math.random().toString(36).slice(2)
     }`;
-    store.commit(
+    agent.store.commit(
       events.executionRequested({
         queueId: queueId1,
         cellId: aiCellId,
@@ -76,7 +75,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     let attempts = 0;
     const maxAttempts = 20; // 20 seconds max wait
     while (attempts < maxAttempts) {
-      const queueEntries = store.query(
+      const queueEntries = agent.store.query(
         tables.executionQueue.select().where({ cellId: aiCellId }),
       );
 
@@ -95,7 +94,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     }
 
     // Check that we got outputs
-    const outputs = store.query(
+    const outputs = agent.store.query(
       tables.outputs.select().where({ cellId: aiCellId }),
     );
 
@@ -133,11 +132,10 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
 
   await t.step("can handle AI cell tool calling (create_cell)", async () => {
     if (!agent) throw new Error("Agent not initialized");
-    const store = agent.store;
 
     // Create an AI cell that should trigger tool calling
     const aiCellId = "ai-cell-tool-test";
-    store.commit(
+    agent.store.commit(
       events.cellCreated({
         id: aiCellId,
         cellType: "ai",
@@ -148,7 +146,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
 
     // Set a prompt that should trigger cell creation in a real scenario
     const prompt = "Create a Python cell that prints 'Hello, AI!'";
-    store.commit(
+    agent.store.commit(
       events.cellSourceChanged({
         id: aiCellId,
         source: prompt,
@@ -160,7 +158,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     const queueId2 = `exec-${Date.now()}-${
       Math.random().toString(36).slice(2)
     }`;
-    store.commit(
+    agent.store.commit(
       events.executionRequested({
         queueId: queueId2,
         cellId: aiCellId,
@@ -173,7 +171,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     let attempts = 0;
     const maxAttempts = 20;
     while (attempts < maxAttempts) {
-      const queueEntries = store.query(
+      const queueEntries = agent.store.query(
         tables.executionQueue.select().where({ cellId: aiCellId }),
       );
 
@@ -199,11 +197,10 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
 
   await t.step("can handle mixed AI and Python cells", async () => {
     if (!agent) throw new Error("Agent not initialized");
-    const store = agent.store;
 
     // Create a Python cell first
     const pythonCellId = "python-cell-mixed";
-    store.commit(
+    agent.store.commit(
       events.cellCreated({
         id: pythonCellId,
         cellType: "code",
@@ -212,7 +209,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
       }),
     );
 
-    store.commit(
+    agent.store.commit(
       events.cellSourceChanged({
         id: pythonCellId,
         source: "x = 42\nprint(f'The answer is {x}')",
@@ -224,7 +221,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     const queueId3 = `exec-${Date.now()}-${
       Math.random().toString(36).slice(2)
     }`;
-    store.commit(
+    agent.store.commit(
       events.executionRequested({
         queueId: queueId3,
         cellId: pythonCellId,
@@ -236,7 +233,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     // Wait for Python execution
     let attempts = 0;
     while (attempts < 15) {
-      const queueEntries = store.query(
+      const queueEntries = agent.store.query(
         tables.executionQueue.select().where({ cellId: pythonCellId }),
       );
 
@@ -253,7 +250,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
 
     // Now create an AI cell that can see the Python cell
     const aiCellId = "ai-cell-context";
-    store.commit(
+    agent.store.commit(
       events.cellCreated({
         id: aiCellId,
         cellType: "ai",
@@ -262,7 +259,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
       }),
     );
 
-    store.commit(
+    agent.store.commit(
       events.cellSourceChanged({
         id: aiCellId,
         source: "What did the previous Python cell do?",
@@ -274,7 +271,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     const queueId4 = `exec-${Date.now()}-${
       Math.random().toString(36).slice(2)
     }`;
-    store.commit(
+    agent.store.commit(
       events.executionRequested({
         queueId: queueId4,
         cellId: aiCellId,
@@ -286,7 +283,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     // Wait for AI execution
     attempts = 0;
     while (attempts < 15) {
-      const queueEntries = store.query(
+      const queueEntries = agent.store.query(
         tables.executionQueue.select().where({ cellId: aiCellId }),
       );
 
@@ -302,7 +299,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Integration", async (t) => {
     }
 
     // Check that AI cell completed
-    const aiOutputs = store.query(
+    const aiOutputs = agent.store.query(
       tables.outputs.select().where({ cellId: aiCellId }),
     );
 
@@ -363,11 +360,10 @@ Deno.test("PyodideRuntimeAgent - AI Cell Error Handling", async (t) => {
 
   await t.step("handles empty AI cell gracefully", async () => {
     if (!agent) throw new Error("Agent not initialized");
-    const store = agent.store;
 
     // Create an AI cell with empty content
     const aiCellId = "ai-cell-empty";
-    store.commit(
+    agent.store.commit(
       events.cellCreated({
         id: aiCellId,
         cellType: "ai",
@@ -382,7 +378,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Error Handling", async (t) => {
     const queueId5 = `exec-${Date.now()}-${
       Math.random().toString(36).slice(2)
     }`;
-    store.commit(
+    agent.store.commit(
       events.executionRequested({
         queueId: queueId5,
         cellId: aiCellId,
@@ -394,7 +390,7 @@ Deno.test("PyodideRuntimeAgent - AI Cell Error Handling", async (t) => {
     // Wait for execution to complete
     let attempts = 0;
     while (attempts < 10) {
-      const queueEntries = store.query(
+      const queueEntries = agent.store.query(
         tables.executionQueue.select().where({ cellId: aiCellId }),
       );
 

--- a/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
@@ -66,14 +66,11 @@ Deno.test({
     await t.step("can execute Python code and get results", async () => {
       if (!agent) throw new Error("Agent not started");
 
-      // Get access to the agent's store (type-safe shared instance)
-      const store = agent.store;
-
       console.log("📊 Testing complete execution pipeline...");
 
       // Create notebook
       const notebookId = agent.config.notebookId;
-      store.commit(events.notebookInitialized({
+      agent.store.commit(events.notebookInitialized({
         id: notebookId,
         title: "Integration Test Notebook",
         ownerId: "test-user",
@@ -81,7 +78,7 @@ Deno.test({
 
       // Create a cell with Python arithmetic
       const cellId = `cell-${crypto.randomUUID()}`;
-      store.commit(events.cellCreated({
+      agent.store.commit(events.cellCreated({
         id: cellId,
         position: 0,
         cellType: "code",
@@ -90,7 +87,7 @@ Deno.test({
 
       // Test basic arithmetic
       const pythonCode = "3 * 7";
-      store.commit(events.cellSourceChanged({
+      agent.store.commit(events.cellSourceChanged({
         id: cellId,
         source: pythonCode,
         modifiedBy: "test-user",
@@ -100,7 +97,7 @@ Deno.test({
       const queueId = `exec-${Date.now()}-${
         Math.random().toString(36).slice(2)
       }`;
-      store.commit(events.executionRequested({
+      agent.store.commit(events.executionRequested({
         queueId,
         cellId,
         executionCount: 1,
@@ -113,11 +110,11 @@ Deno.test({
       await delay(3000);
 
       // Check results
-      const queueEntries = store.query(queryDb(
+      const queueEntries = agent.store.query(queryDb(
         tables.executionQueue.select().where({ cellId }),
       ));
 
-      const outputs = store.query(queryDb(
+      const outputs = agent.store.query(queryDb(
         tables.outputs.select().where({ cellId }),
       ));
 

--- a/packages/python-runtime-agent/README.md
+++ b/packages/python-runtime-agent/README.md
@@ -1,0 +1,10 @@
+# @runt/python-runtime-agent
+
+Stub Python runtime agent for the Runt platform.
+
+This package provides a placeholder `PythonRuntimeAgent` class that subclasses
+`RuntimeAgent` from `@runt/lib`.
+
+## Usage
+
+This package is a stub and does not implement any Python execution logic yet.

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -10,6 +10,9 @@
   "exports": {
     ".": "./mod.ts"
   },
+  "bin": {
+    "pyrunt": "./mod.ts"
+  },
   "imports": {
     "@runt/lib": "jsr:@runt/lib@^0.6.2",
     "@runt/schema": "jsr:@runt/schema@^0.6.2"

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -1,0 +1,46 @@
+{
+  "name": "@runt/python-runtime-agent",
+  "version": "0.0.1",
+  "description": "Stub Python runtime agent for Runt platform.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/runtimed/anode.git"
+  },
+  "exports": {
+    ".": "./mod.ts"
+  },
+  "imports": {
+    "@runt/lib": "jsr:@runt/lib@^0.6.2",
+    "@runt/schema": "jsr:@runt/schema@^0.6.2"
+  },
+  "tasks": {
+    "test": "deno test --allow-all",
+    "check": "deno check src/**/*.ts",
+    "fmt": "deno fmt",
+    "lint": "deno lint"
+  },
+  "compilerOptions": {
+    "strict": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "fmt": {
+    "useTabs": false,
+    "lineWidth": 80,
+    "indentWidth": 2,
+    "semiColons": true,
+    "singleQuote": false,
+    "proseWrap": "preserve"
+  },
+  "lint": {
+    "rules": {
+      "tags": ["recommended"]
+    }
+  },
+  "publish": {
+    "include": ["mod.ts", "src/", "README.md"],
+    "exclude": ["**/*.test.ts", "**/test_*.ts"]
+  }
+}

--- a/packages/python-runtime-agent/mod.ts
+++ b/packages/python-runtime-agent/mod.ts
@@ -4,5 +4,5 @@ export { PythonRuntimeAgent };
 
 if (import.meta.main) {
   const agent = new PythonRuntimeAgent();
-  await runner(agent);
+  await runner(agent, "PyRunt");
 }

--- a/packages/python-runtime-agent/mod.ts
+++ b/packages/python-runtime-agent/mod.ts
@@ -1,0 +1,8 @@
+import { PythonRuntimeAgent } from "./src/python-runtime-agent.ts";
+import { runner } from "@runt/lib";
+export { PythonRuntimeAgent };
+
+if (import.meta.main) {
+  const agent = new PythonRuntimeAgent();
+  await runner(agent);
+}

--- a/packages/python-runtime-agent/src/python-runtime-agent.ts
+++ b/packages/python-runtime-agent/src/python-runtime-agent.ts
@@ -1,0 +1,41 @@
+import {
+  createRuntimeConfig,
+  RuntimeAgent,
+  type RuntimeConfig,
+} from "@runt/lib";
+
+export class PythonRuntimeAgent extends RuntimeAgent {
+  constructor(args: string[] = Deno.args) {
+    let config: RuntimeConfig;
+    try {
+      config = createRuntimeConfig(args, {
+        runtimeType: "python3",
+        capabilities: {
+          canExecuteCode: true,
+          canExecuteSql: false,
+          canExecuteAi: false,
+          availableAiModels: [],
+        },
+      });
+    } catch (error) {
+      // Configuration errors should still go to console for CLI usability
+      console.error("❌ Configuration Error:");
+      console.error(error instanceof Error ? error.message : String(error));
+      console.error("\nExample usage:");
+      console.error(
+        '  deno run --allow-all "jsr:@runt/python-runtime-agent" --notebook my-notebook --auth-token your-token',
+      );
+      console.error("\nOr set environment variables in .env:");
+      console.error("  NOTEBOOK_ID=my-notebook");
+      console.error("  AUTH_TOKEN=your-token");
+      console.error("\nOr install globally:");
+      console.error(
+        "  deno install -gf --allow-all jsr:@runt/python-runtime-agent",
+      );
+      console.error("  pyrunt --notebook my-notebook --auth-token your-token");
+      Deno.exit(1);
+    }
+
+    super(config, config.capabilities, {});
+  }
+}

--- a/packages/python-runtime-agent/test/simple-integration.test.ts
+++ b/packages/python-runtime-agent/test/simple-integration.test.ts
@@ -1,0 +1,37 @@
+// Simple Integration Test for PythonRuntimeAgent
+
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import { PythonRuntimeAgent } from "../src/python-runtime-agent.ts";
+
+Deno.test("PythonRuntimeAgent - Basic Functionality (Stub)", async (t) => {
+  const env = {
+    RUNTIME_ID: "test-runtime",
+    NOTEBOOK_ID: "test-notebook",
+    AUTH_TOKEN: "test-token",
+  };
+  for (const [k, v] of Object.entries(env)) {
+    Deno.env.set(k, v);
+  }
+  try {
+    await t.step("can be constructed with minimal args", () => {
+      const agent = new PythonRuntimeAgent([]);
+      assertExists(agent);
+    });
+
+    await t.step("exposes required methods (stub)", () => {
+      const agent = new PythonRuntimeAgent([]);
+      assertEquals(typeof agent.start, "function");
+      assertEquals(typeof agent.shutdown, "function");
+      assertEquals(typeof agent.keepAlive, "function");
+    });
+
+    await t.step("has a config property (stub)", () => {
+      const agent = new PythonRuntimeAgent([]);
+      assertExists(agent.config);
+    });
+  } finally {
+    for (const k of Object.keys(env)) {
+      Deno.env.delete(k);
+    }
+  }
+});


### PR DESCRIPTION
Creates a stub implementation for the python runtime agent. Most of the work here is refactoring the PyodideRuntimeAgent to be slightly more generic. This includes:
* passing back logging information from start()
* Exposing commit/query methods from the RuntimeAgent itself (currently only used in unit tests)
* Making the RuntimeConfig deeply read-only
* Changing all access of the config to go through the base RuntimeAgent
* Create the new PythonRuntimeAgent

# Test plan
* Ran the local pyodide agent, make sure a simple smoke test still works
* Unit tests
* Run the new python agent, see that it just returns the input when executing the cell

Closes #91 