### PR TITLE
Detect missing paths from the dorny filter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,8 @@ jobs:
               - 'packages/ai/**'
             pyodide-runtime-agent:
               - 'packages/pyodide-runtime-agent/**'
+            python-runtime-agent:
+              - 'packages/python-runtime-agent/**'
             publish:
               - '.github/workflows/publish.yml'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,11 @@ jobs:
           JQ_FILTER=$(echo "$BUILD_ORDER" | jq -r 'map("\"" + . + "\": .[\"" + . + "\"]") | join(", ")')
           # Compose the final object
           CHANGED_PACKAGES=$(jq -n --argjson obj '${{ toJson(steps.filter.outputs) }}' '$obj' | jq -c "{ $JQ_FILTER }")
+          MISSING_KEYS=$(echo "$CHANGED_PACKAGES" | jq -r 'to_entries | map(select(.value == null) | .key) | join(",")')
+          if [ -n "$MISSING_KEYS" ]; then
+            echo "Error: The following keys are missing from the dorny filter step: $MISSING_KEYS"
+            exit 1
+          fi
           echo "$CHANGED_PACKAGES"
           echo "changed_packages=$CHANGED_PACKAGES" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The python-runtime-agent wasn't being detected by the publish step,
due to a missing addition to dorny/paths-filter. This PR adds the missing line,
and also adds detection to prevent this in the future

# Test plan
The first commit fixes the detection, and we can see the github action properly fails.
The second commit adds the filter, and the actions pass

Fixes #102 