### PR TITLE
Properly convert CHANGED_PACKAGES values to bools

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,10 +125,10 @@ jobs:
       - name: Set outputs
         id: set_outputs
         run: |
-          BUILD_LIST=${{ steps.build_list.outputs.build_list }}
-          GITHUB_ACTION_CHANGED=${{ steps.filter.outputs.publish }}
-          GITHUB_EVENT_NAME=${{ github.event_name }}
-          GITHUB_REF_NAME=${{ github.ref_name }}
+          BUILD_LIST='${{ steps.build_list.outputs.build_list }}'
+          GITHUB_ACTION_CHANGED='${{ steps.filter.outputs.publish }}'
+          GITHUB_EVENT_NAME='${{ github.event_name }}'
+          GITHUB_REF_NAME='${{ github.ref_name }}'
 
           DRY_RUN=false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,12 +59,24 @@ jobs:
           JQ_FILTER=$(echo "$BUILD_ORDER" | jq -r 'map("\"" + . + "\": .[\"" + . + "\"]") | join(", ")')
           # Compose the final object
           CHANGED_PACKAGES=$(jq -n --argjson obj '${{ toJson(steps.filter.outputs) }}' '$obj' | jq -c "{ $JQ_FILTER }")
+          # Dorny has values of true/false, but they're strings not booleans. Fix that here
+          CHANGED_PACKAGES=$(echo "$CHANGED_PACKAGES" | jq -c 'with_entries(
+            .value |= (
+              if type == "string" then
+                (if (ascii_downcase == "true") then true
+                 elif (ascii_downcase == "false") then false
+                 else . end)
+              else
+                .
+              end
+            )
+          )')
           MISSING_KEYS=$(echo "$CHANGED_PACKAGES" | jq -r 'to_entries | map(select(.value == null) | .key) | join(",")')
           if [ -n "$MISSING_KEYS" ]; then
             echo "Error: The following keys are missing from the dorny filter step: $MISSING_KEYS"
             exit 1
           fi
-          echo "$CHANGED_PACKAGES"
+          echo "CHANGED_PACKAGES: $CHANGED_PACKAGES"
           echo "changed_packages=$CHANGED_PACKAGES" >> $GITHUB_OUTPUT
 
       - name: Ensure build-order is up to date


### PR DESCRIPTION
Dorny/filter returns a map where the values are strings. This fixes the logic to be booleans, so the rest of the publish detection works.

There is an additional bug where the quotes were getting lost in the set output step, due to the bash parsing of the variable. Adding single quotes preserves the double quotes within the string

# Test plan
Include a fake change to the python-runtime-agent to ensure the flow works properly. Revert before merging