### PR TITLE
Bump all package versions to 0.6.3

### DIFF
--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/ai",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Runtime AI Clients",
   "license": "MIT",
   "repository": {
@@ -11,8 +11,8 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.6.2",
-    "@runt/schema": "jsr:@runt/schema@^0.6.2",
+    "@runt/lib": "jsr:@runt/lib@^0.6.3",
+    "@runt/schema": "jsr:@runt/schema@^0.6.3",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Runtime agent library for building Anode runtime agents",
   "license": "MIT",
   "repository": {
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.6.2",
+    "@runt/schema": "jsr:@runt/schema@^0.6.3",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "MIT",
   "repository": {
@@ -14,9 +14,9 @@
     "pyorunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/ai": "jsr:@runt/ai@^0.6.2",
-    "@runt/lib": "jsr:@runt/lib@^0.6.2",
-    "@runt/schema": "jsr:@runt/schema@^0.6.2",
+    "@runt/ai": "jsr:@runt/ai@^0.6.3",
+    "@runt/lib": "jsr:@runt/lib@^0.6.3",
+    "@runt/schema": "jsr:@runt/schema@^0.6.3",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/python-runtime-agent",
-  "version": "0.0.1",
+  "version": "0.6.3",
   "description": "Stub Python runtime agent for Runt platform.",
   "license": "MIT",
   "repository": {
@@ -14,8 +14,8 @@
     "pyrunt": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.6.2",
-    "@runt/schema": "jsr:@runt/schema@^0.6.2"
+    "@runt/lib": "jsr:@runt/lib@^0.6.3",
+    "@runt/schema": "jsr:@runt/schema@^0.6.3"
   },
   "tasks": {
     "test": "deno test --allow-all",

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.6.0",
+  "version": "0.6.3",
   "description": "This package.json is solely here to make linking possible for npm users",
   "type": "module",
   "main": "./mod.ts",


### PR DESCRIPTION
- @runt/schema: 0.6.2 → 0.6.3 (deno.json), 0.6.0 → 0.6.3 (package.json)
- @runt/lib: 0.6.2 → 0.6.3
- @runt/ai: 0.6.2 → 0.6.3
- @runt/pyodide-runtime-agent: 0.6.2 → 0.6.3
- @runt/python-runtime-agent: 0.0.1 → 0.6.3
- Updated all internal package dependencies to use ^0.6.3

Release includes:
- Key-value notebook metadata architecture
- UPSERT conflict handling for all insert operations
- Clean table naming (debug table without dashes)
- Backward compatible event handling