### PR TITLE
AI tool registration from pyodide agent

### DIFF
--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -22,6 +22,8 @@ import { OpenAIClient } from "./openai-client.ts";
 import { RuntOllamaClient } from "./ollama-client.ts";
 import type { NotebookTool } from "./tool-registry.ts";
 
+export type { NotebookTool };
+
 // Import and export AI-specific media utilities
 import {
   type AIMediaBundle,
@@ -454,8 +456,12 @@ const DEFAULT_MODELS = {
   ollama: "llama3.1",
 } as const;
 
+export type AIExecutionContext = ExecutionContext & {
+  sendWorkerMessage?: (type: string, data: unknown) => Promise<unknown>;
+};
+
 export async function executeAI(
-  context: ExecutionContext,
+  context: AIExecutionContext,
   notebookContext: NotebookContextData,
   logger: Logger,
   store: Store,
@@ -468,7 +474,6 @@ export async function executeAI(
     result: _result,
     error,
     abortSignal,
-    sendWorkerMessage,
   } = context;
   const prompt = cell.source?.trim() || "";
 

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -20,6 +20,7 @@ import { createLogger } from "@runt/lib";
 
 import { OpenAIClient } from "./openai-client.ts";
 import { RuntOllamaClient } from "./ollama-client.ts";
+import type { NotebookTool } from "./tool-registry.ts";
 
 // Import and export AI-specific media utilities
 import {
@@ -459,6 +460,7 @@ export async function executeAI(
   logger: Logger,
   store: Store,
   sessionId: string,
+  notebookTools: NotebookTool[] = [],
 ): Promise<{ success: boolean; error?: string }> {
   const {
     cell,
@@ -466,6 +468,7 @@ export async function executeAI(
     result: _result,
     error,
     abortSignal,
+    sendWorkerMessage,
   } = context;
   const prompt = cell.source?.trim() || "";
 
@@ -490,7 +493,7 @@ export async function executeAI(
     });
 
     // Initialize AI clients based on provider
-    const openaiClient = new OpenAIClient();
+    const openaiClient = new OpenAIClient(undefined, notebookTools);
 
     // Configure Ollama client with environment-aware host detection
     const ollamaHost = Deno.env.get("OLLAMA_HOST") || "http://localhost:11434";
@@ -547,6 +550,7 @@ export async function executeAI(
                 sessionId,
                 cell,
                 toolCall,
+                context.sendWorkerMessage,
               );
             },
             onIteration: (iteration, messages) => {
@@ -665,6 +669,7 @@ The system will automatically pull models if they're not available locally.`;
               sessionId,
               cell,
               toolCall,
+              context.sendWorkerMessage,
             );
           },
           onIteration: (iteration, messages) => {

--- a/packages/ai/openai-client.ts
+++ b/packages/ai/openai-client.ts
@@ -8,6 +8,7 @@ import {
 import { AI_TOOL_CALL_MIME_TYPE, AI_TOOL_RESULT_MIME_TYPE } from "@runt/schema";
 
 import { NOTEBOOK_TOOLS } from "./tool-registry.ts";
+import type { NotebookTool } from "./tool-registry.ts";
 
 // Define message types inline to avoid import issues
 type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
@@ -64,12 +65,14 @@ export class RuntOpenAIClient {
   private client: OpenAI | null = null;
   private isConfigured = false;
   private logger = createLogger("openai-client");
+  private notebookTools: NotebookTool[];
 
-  constructor(config?: OpenAIConfig) {
+  constructor(config?: OpenAIConfig, notebookTools: NotebookTool[] = []) {
     // Don't configure immediately to avoid early initialization logs
     if (config) {
       this.configure(config);
     }
+    this.notebookTools = [...notebookTools];
   }
 
   configure(config?: OpenAIConfig) {
@@ -357,8 +360,14 @@ export class RuntOpenAIClient {
         this.logger.info(`Agentic iteration ${iteration + 1}/${maxIterations}`);
 
         // Prepare tools if enabled
+        let all_tools: NotebookTool[];
+        if (this.notebookTools.length > 0) {
+          all_tools = [...this.notebookTools, ...NOTEBOOK_TOOLS];
+        } else {
+          all_tools = [...NOTEBOOK_TOOLS];
+        }
         const tools = enableTools
-          ? NOTEBOOK_TOOLS.map((tool) => ({
+          ? all_tools.map((tool) => ({
             type: "function" as const,
             function: {
               name: tool.name,
@@ -380,6 +389,7 @@ export class RuntOpenAIClient {
           messages: filteredMessages,
           ...(this.supportsCustomTemperature(model) ? { temperature } : {}),
           stream: true,
+          user: "me",
           ...(tools ? { tools } : {}),
           ...(enableTools && tools ? { tool_choice: "auto" as const } : {}),
         };

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -449,7 +449,9 @@ export async function handleToolCallWithResult(
           throw new Error(`Failed to execute tool ${name}: ${String(error)}`);
         }
       } else {
-        logger.warn("Unknown AI tool and no worker available", { toolName: name });
+        logger.warn("Unknown AI tool and no worker available", {
+          toolName: name,
+        });
         throw new Error(`Unknown tool: ${name}`);
       }
   }

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -5,7 +5,7 @@ import { createLogger } from "@runt/lib";
 // Create logger for tool execution debugging
 const toolLogger = createLogger("ai-tools");
 
-interface NotebookTool {
+export interface NotebookTool {
   name: string;
   description: string;
   parameters: {
@@ -182,6 +182,7 @@ export async function handleToolCallWithResult(
     name: string;
     arguments: Record<string, unknown>;
   },
+  sendWorkerMessage?: (type: string, data: unknown) => Promise<unknown>,
 ): Promise<string> {
   const { name, arguments: args } = toolCall;
 
@@ -421,7 +422,36 @@ export async function handleToolCallWithResult(
     }
 
     default:
-      logger.warn("Unknown AI tool", { toolName: name });
-      throw new Error(`Unknown tool: ${name}`);
+      // Handle unknown tools via Python worker if available
+      console.log(`sendWorkerMessage: ${sendWorkerMessage}`);
+      if (sendWorkerMessage) {
+        logger.info("Calling registered Python tool via worker", {
+          toolName: name,
+          argsKeys: Object.keys(args),
+        });
+
+        try {
+          const result = await sendWorkerMessage("run_registered_tool", {
+            toolName: name,
+            args: JSON.stringify(args),
+          });
+
+          logger.info("Python tool executed successfully", {
+            toolName: name,
+            result,
+          });
+
+          return `Tool ${name} executed successfully: ${String(result)}`;
+        } catch (error) {
+          logger.error("Python tool execution failed", {
+            toolName: name,
+            error: String(error),
+          });
+          throw new Error(`Failed to execute tool ${name}: ${String(error)}`);
+        }
+      } else {
+        logger.warn("Unknown AI tool and no worker available", { toolName: name });
+        throw new Error(`Unknown tool: ${name}`);
+      }
   }
 }

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -423,7 +423,6 @@ export async function handleToolCallWithResult(
 
     default:
       // Handle unknown tools via Python worker if available
-      console.log(`sendWorkerMessage: ${sendWorkerMessage}`);
       if (sendWorkerMessage) {
         logger.info("Calling registered Python tool via worker", {
           toolName: name,

--- a/packages/pyodide-runtime-agent/src/ipython-setup.py
+++ b/packages/pyodide-runtime-agent/src/ipython-setup.py
@@ -457,36 +457,28 @@ class RegisteredFunction:
         return result
 
 
-class FunctionRegistry:
-    def __init__(self) -> None:
-        self.registry = {}
-
-    def tool(self, func) -> Callable:
-        schema = FunctionInferrer.infer_from_function_reference(func).to_json_schema()
-        entry = RegisteredFunction(
-            name=func.__name__,
-            _func=func,
-            openai_tool_metadata=schema
-        )
-        self.registry[func.__name__] = entry
-
-        return func
-
-    @property
-    def tools(self) -> list:
-        return [func.openai_tool_metadata for func in self.registry.values()]
+_registry = {}
 
 
-registry = FunctionRegistry()
+def tool(func) -> Callable:
+    schema = FunctionInferrer.infer_from_function_reference(func).to_json_schema()
+    entry = RegisteredFunction(
+        name=func.__name__,
+        _func=func,
+        openai_tool_metadata=schema
+    )
+    _registry[func.__name__] = entry
+    return func
 
 
 def get_registered_tools():
     import json
-    return json.dumps(registry.tools, default=str)
+    tools = [func.openai_tool_metadata for func in _registry.values()]
+    return json.dumps(tools, default=str)
 
 
 def run_registered_tool(toolName: str, kwargs):
-    return registry.registry[toolName](**kwargs)
+    return _registry[toolName](**kwargs)
 
 
 # Export the configured shell for use by the worker
@@ -496,6 +488,6 @@ __all__ = [
     "js_execution_callback",
     "js_clear_callback",
     "setup_interrupt_patches",
-    "registry",
-    "get_registered_tools"
+    "get_registered_tools",
+    "run_registered_tool"
 ]

--- a/packages/pyodide-runtime-agent/src/ipython-setup.py
+++ b/packages/pyodide-runtime-agent/src/ipython-setup.py
@@ -433,15 +433,16 @@ js_clear_callback = default_clear_callback
 # Set up interrupt patches
 setup_interrupt_patches()
 
+# Setup tool registry
+
 import micropip
 
-await micropip.install("openai-function-calling")
 
-from openai_function_calling import FunctionInferrer
-from typing import Callable
+import json
+import warnings
 from dataclasses import dataclass
 from typing import Any
-import json
+from typing import Callable
 
 
 @dataclass
@@ -461,7 +462,19 @@ _registry = {}
 
 
 def tool(func) -> Callable:
-    schema = FunctionInferrer.infer_from_function_reference(func).to_json_schema()
+    try:
+        await micropip.install("openai-function-calling")
+        from openai_function_calling import FunctionInferrer
+    except Exception as e:
+        warnings.warn(f"Failed to install openai-function-calling: {e}")
+        return func
+
+    try:
+        schema = FunctionInferrer.infer_from_function_reference(func).to_json_schema()
+    except Exception as e:
+        warnings.warn(f"Failed to infer function schema: {e}")
+        return func
+
     entry = RegisteredFunction(
         name=func.__name__,
         _func=func,

--- a/packages/pyodide-runtime-agent/src/ipython-setup.py
+++ b/packages/pyodide-runtime-agent/src/ipython-setup.py
@@ -434,16 +434,14 @@ js_clear_callback = default_clear_callback
 setup_interrupt_patches()
 
 # Setup tool registry
-
-import micropip
-
-
 import json
 import warnings
 from dataclasses import dataclass
 from typing import Any
 from typing import Callable
 
+import micropip
+await micropip.install("openai-function-calling")
 
 class ToolNotFoundError(Exception):
     pass
@@ -466,18 +464,9 @@ _tool_registry = {}
 
 
 def tool(func) -> Callable:
-    try:
-        await micropip.install("openai-function-calling")
-        from openai_function_calling import FunctionInferrer
-    except Exception as e:
-        warnings.warn(f"Failed to install openai-function-calling: {e}")
-        return func
+    from openai_function_calling import FunctionInferrer
 
-    try:
-        schema = FunctionInferrer.infer_from_function_reference(func).to_json_schema()
-    except Exception as e:
-        warnings.warn(f"Failed to infer function schema: {e}")
-        return func
+    schema = FunctionInferrer.infer_from_function_reference(func).to_json_schema()
 
     entry = RegisteredFunction(
         name=func.__name__,

--- a/packages/pyodide-runtime-agent/src/ipython-setup.py
+++ b/packages/pyodide-runtime-agent/src/ipython-setup.py
@@ -433,6 +433,62 @@ js_clear_callback = default_clear_callback
 # Set up interrupt patches
 setup_interrupt_patches()
 
+import micropip
+
+await micropip.install("openai-function-calling")
+
+from openai_function_calling import FunctionInferrer
+from typing import Callable
+from dataclasses import dataclass
+from typing import Any
+import json
+
+
+@dataclass
+class RegisteredFunction:
+    name: str
+    openai_tool_metadata: dict
+    _func: Callable
+
+    def __call__(self, *args, **kwargs) -> Any:
+        result = self._func(*args, **kwargs)
+        if not isinstance(result, str):
+            result = json.dumps(result, default=str)
+        return result
+
+
+class FunctionRegistry:
+    def __init__(self) -> None:
+        self.registry = {}
+
+    def tool(self, func) -> Callable:
+        schema = FunctionInferrer.infer_from_function_reference(func).to_json_schema()
+        entry = RegisteredFunction(
+            name=func.__name__,
+            _func=func,
+            openai_tool_metadata=schema
+        )
+        self.registry[func.__name__] = entry
+
+        return func
+
+    @property
+    def tools(self) -> list:
+        return [func.openai_tool_metadata for func in self.registry.values()]
+
+
+registry = FunctionRegistry()
+
+
+def get_registered_tools():
+    import json
+    return json.dumps(registry.tools, default=str)
+
+
+def run_registered_tool(toolName: str, kwargs):
+    return registry.registry[toolName](**kwargs)
+
+
 # Export the configured shell for use by the worker
 __all__ = [
     "shell",
@@ -440,4 +496,6 @@ __all__ = [
     "js_execution_callback",
     "js_clear_callback",
     "setup_interrupt_patches",
+    "registry",
+    "get_registered_tools"
 ]

--- a/packages/pyodide-runtime-agent/src/ipython-setup.py
+++ b/packages/pyodide-runtime-agent/src/ipython-setup.py
@@ -445,6 +445,10 @@ from typing import Any
 from typing import Callable
 
 
+class ToolNotFoundError(Exception):
+    pass
+
+
 @dataclass
 class RegisteredFunction:
     name: str
@@ -491,6 +495,8 @@ def get_registered_tools():
 
 
 def run_registered_tool(toolName: str, kwargs):
+    if toolName not in _tool_registry:
+        raise ToolNotFoundError(f"Tool {toolName} not found")
     return _tool_registry[toolName](**kwargs)
 
 

--- a/packages/pyodide-runtime-agent/src/ipython-setup.py
+++ b/packages/pyodide-runtime-agent/src/ipython-setup.py
@@ -458,7 +458,7 @@ class RegisteredFunction:
         return result
 
 
-_registry = {}
+_tool_registry = {}
 
 
 def tool(func) -> Callable:
@@ -480,18 +480,18 @@ def tool(func) -> Callable:
         _func=func,
         openai_tool_metadata=schema
     )
-    _registry[func.__name__] = entry
+    _tool_registry[func.__name__] = entry
     return func
 
 
 def get_registered_tools():
     import json
-    tools = [func.openai_tool_metadata for func in _registry.values()]
+    tools = [func.openai_tool_metadata for func in _tool_registry.values()]
     return json.dumps(tools, default=str)
 
 
 def run_registered_tool(toolName: str, kwargs):
-    return _registry[toolName](**kwargs)
+    return _tool_registry[toolName](**kwargs)
 
 
 # Export the configured shell for use by the worker

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -24,6 +24,7 @@ import {
   ensureTextPlainFallback,
   executeAI,
   gatherNotebookContext,
+  type NotebookTool,
 } from "@runt/ai";
 
 /**
@@ -343,7 +344,10 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
         sendWorkerMessage: this.sendWorkerMessage.bind(this),
       };
 
-      const notebookTools = await this.sendWorkerMessage("get_registered_tools", {});
+      const notebookTools = await this.sendWorkerMessage(
+        "get_registered_tools",
+        {},
+      ) as NotebookTool[];
 
       try {
         return await executeAI(

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -336,11 +336,14 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
         });
       }
 
-      // Create a modified context with the AI-specific abort signal
+      // Create a modified context with the AI-specific abort signal and bound sendWorkerMessage
       const aiContext = {
         ...context,
         abortSignal: aiAbortController.signal,
+        sendWorkerMessage: this.sendWorkerMessage.bind(this),
       };
+
+      const notebookTools = await this.sendWorkerMessage("get_registered_tools", {});
 
       try {
         return await executeAI(
@@ -349,6 +352,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
           this.logger,
           this.store,
           this.config.sessionId,
+          notebookTools,
         );
       } finally {
         this.currentAIExecution = null;

--- a/packages/pyodide-runtime-agent/src/pyodide-worker.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-worker.ts
@@ -68,6 +68,19 @@ self.addEventListener("message", async (event) => {
         break;
       }
 
+      case "get_registered_tools": {
+        const result = await pyodide!.runPythonAsync(`get_registered_tools()`);
+        let parsed = JSON.parse(result);
+        self.postMessage({ id, type: "response", data: parsed });
+        break;
+      }
+
+      case "run_registered_tool": {
+        const result = await pyodide!.runPythonAsync(`run_registered_tool("${data.toolName}", ${data.args})`);
+        self.postMessage({ id, type: "response", data: result });
+        break;
+      }
+
       default:
         throw new Error(`Unknown message type: ${type}`);
     }

--- a/packages/pyodide-runtime-agent/src/pyodide-worker.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-worker.ts
@@ -70,13 +70,15 @@ self.addEventListener("message", async (event) => {
 
       case "get_registered_tools": {
         const result = await pyodide!.runPythonAsync(`get_registered_tools()`);
-        let parsed = JSON.parse(result);
+        const parsed = JSON.parse(result);
         self.postMessage({ id, type: "response", data: parsed });
         break;
       }
 
       case "run_registered_tool": {
-        const result = await pyodide!.runPythonAsync(`run_registered_tool("${data.toolName}", ${data.args})`);
+        const result = await pyodide!.runPythonAsync(
+          `run_registered_tool("${data.toolName}", ${data.args})`,
+        );
         self.postMessage({ id, type: "response", data: result });
         break;
       }


### PR DESCRIPTION
Here I've enabled the registration of a python function written in the notebook as an AI tool.

Using the `@tool` decorator the Python agent keeps a registry of the functions and provides the necessary metadata to register the function as a tool on the AI side (in typescript).

```python
import zoneinfo
import datetime as dt
import micropip
from typing import Any
await micropip.install('tzdata')

@tool
def current_time(timezone: str) -> dt.datetime:
    """The current time for the provided timezone"""
    tz = zoneinfo.ZoneInfo(timezone)
    return dt.datetime.now(tz)
```

When an AI cell is executed a message is sent  to the pyodide agent to ask for metadata about all registered functions. The new functions are added to AI invocation.

When one of the notebook-side functions are declared to be run by the AI a message is sent to the pyodide agent to execute the function with provided arguments and the result is serialized back as text.