### PR TITLE
Update presence tracking to use user actions

### DIFF
--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -362,14 +362,7 @@ export const tables = {
       id: State.SQLite.text({ primaryKey: true }),
       type: State.SQLite.text(), // "human" | "runtime_agent"
       displayName: State.SQLite.text(),
-
-      // Human-specific fields
-      email: State.SQLite.text({ nullable: true }),
       avatar: State.SQLite.text({ nullable: true }),
-      provider: State.SQLite.text({ nullable: true }), // "google" | "anaconda" | "local"
-
-      // Runtime agent fields
-      ownedBy: State.SQLite.text({ nullable: true }), // Which user/project owns this runtime agent
     },
   }),
 };

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -354,6 +354,24 @@ export const tables = {
       value: {},
     },
   }),
+
+  // Actors table for tracking who/what performs actions
+  actors: State.SQLite.table({
+    name: "actors",
+    columns: {
+      id: State.SQLite.text({ primaryKey: true }),
+      type: State.SQLite.text(), // "human" | "runtime_agent"
+      displayName: State.SQLite.text(),
+
+      // Human-specific fields
+      email: State.SQLite.text({ nullable: true }),
+      avatar: State.SQLite.text({ nullable: true }),
+      provider: State.SQLite.text({ nullable: true }), // "google" | "anaconda" | "local"
+
+      // Runtime agent fields
+      ownedBy: State.SQLite.text({ nullable: true }), // Which user/project owns this runtime agent
+    },
+  }),
 };
 
 // Events describe notebook and cell changes
@@ -393,6 +411,7 @@ export const events = {
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
       position: Schema.Number,
       createdBy: Schema.String,
+      actorId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -411,6 +430,7 @@ export const events = {
       id: Schema.String,
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
       changedBy: Schema.optional(Schema.String),
+      actorId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -419,6 +439,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       deletedBy: Schema.optional(Schema.String),
+      actorId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -428,6 +449,7 @@ export const events = {
       id: Schema.String,
       newPosition: Schema.Number,
       movedBy: Schema.optional(Schema.String),
+      actorId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -437,6 +459,7 @@ export const events = {
       id: Schema.String,
       sourceVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
+      actorId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -446,6 +469,7 @@ export const events = {
       id: Schema.String,
       outputVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
+      actorId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -455,6 +479,7 @@ export const events = {
       id: Schema.String,
       aiContextVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
+      actorId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -512,6 +537,7 @@ export const events = {
       cellId: Schema.String,
       executionCount: Schema.Number,
       requestedBy: Schema.String,
+      actorId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -551,6 +577,7 @@ export const events = {
       queueId: Schema.String,
       cellId: Schema.String,
       cancelledBy: Schema.String,
+      actorId: Schema.optional(Schema.String),
       reason: Schema.String,
     }),
   }),
@@ -825,7 +852,7 @@ const materializers = State.SQLite.materializers(events, {
       .onConflict("key", "replace"),
 
   // Cell materializers
-  "v1.CellCreated": ({ id, cellType, position, createdBy }) => [
+  "v1.CellCreated": ({ id, cellType, position, createdBy, actorId }) => [
     tables.cells
       .insert({
         id,
@@ -835,7 +862,7 @@ const materializers = State.SQLite.materializers(events, {
       })
       .onConflict("id", "ignore"),
     // Update presence table
-    updatePresence(createdBy, id),
+    updatePresence(actorId || createdBy, id),
   ],
 
   "v1.CellSourceChanged": ({ id, source, modifiedBy }) => [
@@ -844,62 +871,68 @@ const materializers = State.SQLite.materializers(events, {
     updatePresence(modifiedBy, id),
   ],
 
-  "v1.CellTypeChanged": ({ id, cellType, changedBy }) => {
+  "v1.CellTypeChanged": ({ id, cellType, changedBy, actorId }) => {
     const ops = [];
     ops.push(tables.cells.update({ cellType }).where({ id }));
-    if (changedBy) {
-      ops.push(updatePresence(changedBy, id));
+    const actor = actorId || changedBy;
+    if (actor) {
+      ops.push(updatePresence(actor, id));
     }
     return ops;
   },
 
-  "v1.CellDeleted": ({ id, deletedBy }) => {
+  "v1.CellDeleted": ({ id, deletedBy, actorId }) => {
     const ops = [];
     ops.push(tables.cells.delete().where({ id }));
-    if (deletedBy) {
-      ops.push(updatePresence(deletedBy, id));
+    const actor = actorId || deletedBy;
+    if (actor) {
+      ops.push(updatePresence(actor, id));
     }
     return ops;
   },
 
-  "v1.CellMoved": ({ id, newPosition, movedBy }) => {
+  "v1.CellMoved": ({ id, newPosition, movedBy, actorId }) => {
     const ops = [];
     ops.push(tables.cells.update({ position: newPosition }).where({ id }));
-    if (movedBy) {
-      ops.push(updatePresence(movedBy, id));
+    const actor = actorId || movedBy;
+    if (actor) {
+      ops.push(updatePresence(actor, id));
     }
     return ops;
   },
 
   "v1.CellSourceVisibilityToggled": (
-    { id, sourceVisible, toggledBy },
+    { id, sourceVisible, toggledBy, actorId },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ sourceVisible }).where({ id }));
-    if (toggledBy) {
-      ops.push(updatePresence(toggledBy, id));
+    const actor = actorId || toggledBy;
+    if (actor) {
+      ops.push(updatePresence(actor, id));
     }
     return ops;
   },
 
   "v1.CellOutputVisibilityToggled": (
-    { id, outputVisible, toggledBy },
+    { id, outputVisible, toggledBy, actorId },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ outputVisible }).where({ id }));
-    if (toggledBy) {
-      ops.push(updatePresence(toggledBy, id));
+    const actor = actorId || toggledBy;
+    if (actor) {
+      ops.push(updatePresence(actor, id));
     }
     return ops;
   },
 
   "v1.CellAiContextVisibilityToggled": (
-    { id, aiContextVisible, toggledBy },
+    { id, aiContextVisible, toggledBy, actorId },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ aiContextVisible }).where({ id }));
-    if (toggledBy) {
-      ops.push(updatePresence(toggledBy, id));
+    const actor = actorId || toggledBy;
+    if (actor) {
+      ops.push(updatePresence(actor, id));
     }
     return ops;
   },
@@ -947,6 +980,7 @@ const materializers = State.SQLite.materializers(events, {
     cellId,
     executionCount,
     requestedBy,
+    actorId,
   }) => [
     tables.executionQueue
       .insert({
@@ -965,7 +999,7 @@ const materializers = State.SQLite.materializers(events, {
       })
       .where({ id: cellId }),
     // Update presence table
-    updatePresence(requestedBy, cellId),
+    updatePresence(actorId || requestedBy, cellId),
   ],
 
   "v1.ExecutionAssigned": ({ queueId, runtimeSessionId }) =>
@@ -1017,7 +1051,7 @@ const materializers = State.SQLite.materializers(events, {
       .where({ id: cellId }),
   ],
 
-  "v1.ExecutionCancelled": ({ queueId, cellId, cancelledBy }) => [
+  "v1.ExecutionCancelled": ({ queueId, cellId, cancelledBy, actorId }) => [
     // Update execution queue
     tables.executionQueue
       .update({
@@ -1031,7 +1065,7 @@ const materializers = State.SQLite.materializers(events, {
       })
       .where({ id: cellId }),
     // Update presence table
-    updatePresence(cancelledBy, cellId),
+    updatePresence(actorId || cancelledBy, cellId),
   ],
 
   // Unified output system materializers with pending clear support

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -840,62 +840,65 @@ const materializers = State.SQLite.materializers(events, {
   ],
 
   "v1.CellTypeChanged": ({ id, cellType, changedBy }) => {
-    const ops = [tables.cells.update({ cellType }).where({ id })];
+    const ops = [];
+    ops.push(tables.cells.update({ cellType }).where({ id }));
     if (changedBy) {
       ops.push(
         tables.presence
           .insert({ userId: changedBy, cellId: id })
-          .onConflict("userId", "replace") as any,
+          .onConflict("userId", "replace"),
       );
     }
     return ops;
   },
 
   "v1.CellDeleted": ({ id, deletedBy }) => {
-    const ops = [tables.cells.delete().where({ id })];
+    const ops = [];
+    ops.push(tables.cells.delete().where({ id }));
     if (deletedBy) {
       ops.push(
         tables.presence
           .insert({ userId: deletedBy, cellId: id })
-          .onConflict("userId", "replace") as any,
+          .onConflict("userId", "replace"),
       );
     }
     return ops;
   },
 
   "v1.CellMoved": ({ id, newPosition, movedBy }) => {
-    const ops = [
-      tables.cells.update({ position: newPosition }).where({ id }),
-    ];
+    const ops = [];
+    ops.push(tables.cells.update({ position: newPosition }).where({ id }));
     if (movedBy) {
       ops.push(
         tables.presence
           .insert({ userId: movedBy, cellId: id })
-          .onConflict("userId", "replace") as any,
+          .onConflict("userId", "replace"),
       );
     }
     return ops;
   },
 
   "v1.CellSourceVisibilityToggled": ({ id, sourceVisible, toggledBy }) => {
-    const ops = [tables.cells.update({ sourceVisible }).where({ id })];
+    const ops = [];
+    ops.push(tables.cells.update({ sourceVisible }).where({ id }));
     if (toggledBy) {
       ops.push(
         tables.presence
           .insert({ userId: toggledBy, cellId: id })
-          .onConflict("userId", "replace") as any,
+          .onConflict("userId", "replace"),
       );
     }
     return ops;
   },
 
   "v1.CellOutputVisibilityToggled": ({ id, outputVisible, toggledBy }) => {
-    const ops = [tables.cells.update({ outputVisible }).where({ id })];
+    const ops = [];
+    ops.push(tables.cells.update({ outputVisible }).where({ id }));
     if (toggledBy) {
       ops.push(
         tables.presence
           .insert({ userId: toggledBy, cellId: id })
-          .onConflict("userId", "replace") as any,
+          .onConflict("userId", "replace"),
       );
     }
     return ops;
@@ -904,14 +907,13 @@ const materializers = State.SQLite.materializers(events, {
   "v1.CellAiContextVisibilityToggled": (
     { id, aiContextVisible, toggledBy },
   ) => {
-    const ops = [
-      tables.cells.update({ aiContextVisible }).where({ id }),
-    ];
+    const ops = [];
+    ops.push(tables.cells.update({ aiContextVisible }).where({ id }));
     if (toggledBy) {
       ops.push(
         tables.presence
           .insert({ userId: toggledBy, cellId: id })
-          .onConflict("userId", "replace") as any,
+          .onConflict("userId", "replace"),
       );
     }
     return ops;
@@ -1309,7 +1311,7 @@ const materializers = State.SQLite.materializers(events, {
       ops.push(
         tables.presence
           .insert({ userId: clearedBy, cellId })
-          .onConflict("userId", "replace") as any,
+          .onConflict("userId", "replace"),
       );
     }
 

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -411,7 +411,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
-      changedBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -420,7 +419,6 @@ export const events = {
     name: "v1.CellDeleted",
     schema: Schema.Struct({
       id: Schema.String,
-      deletedBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -430,7 +428,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       newPosition: Schema.Number,
-      movedBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -850,29 +847,29 @@ const materializers = State.SQLite.materializers(events, {
     updatePresence(modifiedBy, id),
   ],
 
-  "v1.CellTypeChanged": ({ id, cellType, changedBy }) => {
+  "v1.CellTypeChanged": ({ id, cellType, userId }) => {
     const ops = [];
     ops.push(tables.cells.update({ cellType }).where({ id }));
-    if (changedBy) {
-      ops.push(updatePresence(changedBy, id));
+    if (userId) {
+      ops.push(updatePresence(userId, id));
     }
     return ops;
   },
 
-  "v1.CellDeleted": ({ id, deletedBy }) => {
+  "v1.CellDeleted": ({ id, userId }) => {
     const ops = [];
     ops.push(tables.cells.delete().where({ id }));
-    if (deletedBy) {
-      ops.push(updatePresence(deletedBy, id));
+    if (userId) {
+      ops.push(updatePresence(userId, id));
     }
     return ops;
   },
 
-  "v1.CellMoved": ({ id, newPosition, movedBy }) => {
+  "v1.CellMoved": ({ id, newPosition, userId }) => {
     const ops = [];
     ops.push(tables.cells.update({ position: newPosition }).where({ id }));
-    if (movedBy) {
-      ops.push(updatePresence(movedBy, id));
+    if (userId) {
+      ops.push(updatePresence(userId, id));
     }
     return ops;
   },

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -409,6 +409,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
+      changedBy: Schema.String,
     }),
   }),
 
@@ -416,6 +417,7 @@ export const events = {
     name: "v1.CellDeleted",
     schema: Schema.Struct({
       id: Schema.String,
+      deletedBy: Schema.String,
     }),
   }),
 
@@ -424,6 +426,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       newPosition: Schema.Number,
+      movedBy: Schema.String,
     }),
   }),
 
@@ -432,6 +435,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       sourceVisible: Schema.Boolean,
+      toggledBy: Schema.String,
     }),
   }),
 
@@ -440,6 +444,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       outputVisible: Schema.Boolean,
+      toggledBy: Schema.String,
     }),
   }),
 
@@ -448,6 +453,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       aiContextVisible: Schema.Boolean,
+      toggledBy: Schema.String,
     }),
   }),
 
@@ -825,25 +831,63 @@ const materializers = State.SQLite.materializers(events, {
       .onConflict("userId", "replace"),
   ],
 
-  "v1.CellSourceChanged": ({ id, source }) =>
+  "v1.CellSourceChanged": ({ id, source, modifiedBy }) => [
     tables.cells.update({ source }).where({ id }),
+    // Update presence based on cell source modification
+    tables.presence
+      .insert({ userId: modifiedBy, cellId: id })
+      .onConflict("userId", "replace"),
+  ],
 
-  "v1.CellTypeChanged": ({ id, cellType }) =>
+  "v1.CellTypeChanged": ({ id, cellType, changedBy }) => [
     tables.cells.update({ cellType }).where({ id }),
+    // Update presence based on cell type change
+    tables.presence
+      .insert({ userId: changedBy, cellId: id })
+      .onConflict("userId", "replace"),
+  ],
 
-  "v1.CellDeleted": ({ id }) => tables.cells.delete().where({ id }),
+  "v1.CellDeleted": ({ id, deletedBy }) => [
+    tables.cells.delete().where({ id }),
+    // Update presence based on cell deletion
+    tables.presence
+      .insert({ userId: deletedBy, cellId: id })
+      .onConflict("userId", "replace"),
+  ],
 
-  "v1.CellMoved": ({ id, newPosition }) =>
+  "v1.CellMoved": ({ id, newPosition, movedBy }) => [
     tables.cells.update({ position: newPosition }).where({ id }),
+    // Update presence based on cell movement
+    tables.presence
+      .insert({ userId: movedBy, cellId: id })
+      .onConflict("userId", "replace"),
+  ],
 
-  "v1.CellSourceVisibilityToggled": ({ id, sourceVisible }) =>
+  "v1.CellSourceVisibilityToggled": ({ id, sourceVisible, toggledBy }) => [
     tables.cells.update({ sourceVisible }).where({ id }),
+    // Update presence based on source visibility toggle
+    tables.presence
+      .insert({ userId: toggledBy, cellId: id })
+      .onConflict("userId", "replace"),
+  ],
 
-  "v1.CellOutputVisibilityToggled": ({ id, outputVisible }) =>
+  "v1.CellOutputVisibilityToggled": ({ id, outputVisible, toggledBy }) => [
     tables.cells.update({ outputVisible }).where({ id }),
+    // Update presence based on output visibility toggle
+    tables.presence
+      .insert({ userId: toggledBy, cellId: id })
+      .onConflict("userId", "replace"),
+  ],
 
-  "v1.CellAiContextVisibilityToggled": ({ id, aiContextVisible }) =>
+  "v1.CellAiContextVisibilityToggled": (
+    { id, aiContextVisible, toggledBy },
+  ) => [
     tables.cells.update({ aiContextVisible }).where({ id }),
+    // Update presence based on AI context visibility toggle
+    tables.presence
+      .insert({ userId: toggledBy, cellId: id })
+      .onConflict("userId", "replace"),
+  ],
 
   "v1.PresenceSet": ({ userId, cellId }) =>
     tables.presence.insert({ userId, cellId: cellId || null }).onConflict(
@@ -1219,14 +1263,23 @@ const materializers = State.SQLite.materializers(events, {
   },
 
   "v1.CellOutputsCleared": ({ cellId, wait, clearedBy }) => {
+    const presenceUpdate = tables.presence
+      .insert({ userId: clearedBy, cellId })
+      .onConflict("userId", "replace");
     if (wait) {
       // Store pending clear for wait=True
-      return tables.pendingClears
-        .insert({ cellId, clearedBy })
-        .onConflict("cellId", "replace");
+      return [
+        tables.pendingClears
+          .insert({ cellId, clearedBy })
+          .onConflict("cellId", "replace"),
+        presenceUpdate,
+      ];
     } else {
       // Immediate clear for wait=False
-      return tables.outputs.delete().where({ cellId });
+      return [
+        tables.outputs.delete().where({ cellId }),
+        presenceUpdate,
+      ];
     }
   },
 

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -360,6 +360,7 @@ export const tables = {
 // All events are scoped to a single notebook (storeId = notebookId)
 export const events = {
   // Notebook events (single notebook per store)
+  /** @deprecated  */
   notebookInitialized: Events.synced({
     name: "v1.NotebookInitialized",
     schema: Schema.Struct({
@@ -778,6 +779,7 @@ function updateExistingDisplays(
 // Materializers map events to state changes
 const materializers = State.SQLite.materializers(events, {
   // Notebook materializers
+  /** @deprecated */
   "v1.NotebookInitialized": ({ id, title, ownerId }) => [
     // Legacy event - convert to metadata format
     tables.notebookMetadata

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -429,7 +429,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
-      changedBy: Schema.optional(Schema.String),
       actorId: Schema.optional(Schema.String),
     }),
   }),
@@ -438,7 +437,6 @@ export const events = {
     name: "v1.CellDeleted",
     schema: Schema.Struct({
       id: Schema.String,
-      deletedBy: Schema.optional(Schema.String),
       actorId: Schema.optional(Schema.String),
     }),
   }),
@@ -448,7 +446,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       newPosition: Schema.Number,
-      movedBy: Schema.optional(Schema.String),
       actorId: Schema.optional(Schema.String),
     }),
   }),
@@ -458,7 +455,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       sourceVisible: Schema.Boolean,
-      toggledBy: Schema.optional(Schema.String),
       actorId: Schema.optional(Schema.String),
     }),
   }),
@@ -468,7 +464,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       outputVisible: Schema.Boolean,
-      toggledBy: Schema.optional(Schema.String),
       actorId: Schema.optional(Schema.String),
     }),
   }),
@@ -478,7 +473,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       aiContextVisible: Schema.Boolean,
-      toggledBy: Schema.optional(Schema.String),
       actorId: Schema.optional(Schema.String),
     }),
   }),
@@ -871,68 +865,62 @@ const materializers = State.SQLite.materializers(events, {
     updatePresence(modifiedBy, id),
   ],
 
-  "v1.CellTypeChanged": ({ id, cellType, changedBy, actorId }) => {
+  "v1.CellTypeChanged": ({ id, cellType, actorId }) => {
     const ops = [];
     ops.push(tables.cells.update({ cellType }).where({ id }));
-    const actor = actorId || changedBy;
-    if (actor) {
-      ops.push(updatePresence(actor, id));
+    if (actorId) {
+      ops.push(updatePresence(actorId, id));
     }
     return ops;
   },
 
-  "v1.CellDeleted": ({ id, deletedBy, actorId }) => {
+  "v1.CellDeleted": ({ id, actorId }) => {
     const ops = [];
     ops.push(tables.cells.delete().where({ id }));
-    const actor = actorId || deletedBy;
-    if (actor) {
-      ops.push(updatePresence(actor, id));
+    if (actorId) {
+      ops.push(updatePresence(actorId, id));
     }
     return ops;
   },
 
-  "v1.CellMoved": ({ id, newPosition, movedBy, actorId }) => {
+  "v1.CellMoved": ({ id, newPosition, actorId }) => {
     const ops = [];
     ops.push(tables.cells.update({ position: newPosition }).where({ id }));
-    const actor = actorId || movedBy;
-    if (actor) {
-      ops.push(updatePresence(actor, id));
+    if (actorId) {
+      ops.push(updatePresence(actorId, id));
     }
     return ops;
   },
 
   "v1.CellSourceVisibilityToggled": (
-    { id, sourceVisible, toggledBy, actorId },
+    { id, sourceVisible, actorId },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ sourceVisible }).where({ id }));
-    const actor = actorId || toggledBy;
-    if (actor) {
-      ops.push(updatePresence(actor, id));
+    if (actorId) {
+      ops.push(updatePresence(actorId, id));
     }
     return ops;
   },
 
   "v1.CellOutputVisibilityToggled": (
-    { id, outputVisible, toggledBy, actorId },
+    { id, outputVisible, actorId },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ outputVisible }).where({ id }));
-    const actor = actorId || toggledBy;
-    if (actor) {
-      ops.push(updatePresence(actor, id));
+    if (actorId) {
+      ops.push(updatePresence(actorId, id));
     }
     return ops;
   },
 
   "v1.CellAiContextVisibilityToggled": (
-    { id, aiContextVisible, toggledBy, actorId },
+    { id, aiContextVisible, actorId },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ aiContextVisible }).where({ id }));
-    const actor = actorId || toggledBy;
-    if (actor) {
-      ops.push(updatePresence(actor, id));
+    if (actorId) {
+      ops.push(updatePresence(actorId, id));
     }
     return ops;
   },

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -411,6 +411,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
+      changedBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -419,6 +420,7 @@ export const events = {
     name: "v1.CellDeleted",
     schema: Schema.Struct({
       id: Schema.String,
+      deletedBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -428,6 +430,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       newPosition: Schema.Number,
+      movedBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -437,6 +440,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       sourceVisible: Schema.Boolean,
+      toggledBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -446,6 +450,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       outputVisible: Schema.Boolean,
+      toggledBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -455,6 +460,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       aiContextVisible: Schema.Boolean,
+      toggledBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -847,58 +853,68 @@ const materializers = State.SQLite.materializers(events, {
     updatePresence(modifiedBy, id),
   ],
 
-  "v1.CellTypeChanged": ({ id, cellType, userId }) => {
+  "v1.CellTypeChanged": ({ id, cellType, changedBy, userId }) => {
     const ops = [];
     ops.push(tables.cells.update({ cellType }).where({ id }));
-    if (userId) {
-      ops.push(updatePresence(userId, id));
+    const user = userId || changedBy;
+    if (user) {
+      ops.push(updatePresence(user, id));
     }
     return ops;
   },
 
-  "v1.CellDeleted": ({ id, userId }) => {
+  "v1.CellDeleted": ({ id, deletedBy, userId }) => {
     const ops = [];
     ops.push(tables.cells.delete().where({ id }));
-    if (userId) {
-      ops.push(updatePresence(userId, id));
+    const user = userId || deletedBy;
+    if (user) {
+      ops.push(updatePresence(user, id));
     }
     return ops;
   },
 
-  "v1.CellMoved": ({ id, newPosition, userId }) => {
+  "v1.CellMoved": ({ id, newPosition, movedBy, userId }) => {
     const ops = [];
     ops.push(tables.cells.update({ position: newPosition }).where({ id }));
-    if (userId) {
-      ops.push(updatePresence(userId, id));
+    const user = userId || movedBy;
+    if (user) {
+      ops.push(updatePresence(user, id));
     }
     return ops;
   },
 
-  "v1.CellSourceVisibilityToggled": ({ id, sourceVisible, userId }) => {
+  "v1.CellSourceVisibilityToggled": (
+    { id, sourceVisible, toggledBy, userId },
+  ) => {
     const ops = [];
     ops.push(tables.cells.update({ sourceVisible }).where({ id }));
-    if (userId) {
-      ops.push(updatePresence(userId, id));
+    const user = userId || toggledBy;
+    if (user) {
+      ops.push(updatePresence(user, id));
     }
     return ops;
   },
 
-  "v1.CellOutputVisibilityToggled": ({ id, outputVisible, userId }) => {
+  "v1.CellOutputVisibilityToggled": (
+    { id, outputVisible, toggledBy, userId },
+  ) => {
     const ops = [];
     ops.push(tables.cells.update({ outputVisible }).where({ id }));
-    if (userId) {
-      ops.push(updatePresence(userId, id));
+    const user = userId || toggledBy;
+    if (user) {
+      ops.push(updatePresence(user, id));
     }
     return ops;
   },
 
   "v1.CellAiContextVisibilityToggled": (
-    { id, aiContextVisible, userId },
+    { id, aiContextVisible, toggledBy, userId },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ aiContextVisible }).where({ id }));
-    if (userId) {
-      ops.push(updatePresence(userId, id));
+    const user = userId || toggledBy;
+    if (user) {
+      ops.push(updatePresence(user, id));
     }
     return ops;
   },

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -409,7 +409,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
-      changedBy: Schema.String,
+      changedBy: Schema.optional(Schema.String),
     }),
   }),
 
@@ -417,7 +417,7 @@ export const events = {
     name: "v1.CellDeleted",
     schema: Schema.Struct({
       id: Schema.String,
-      deletedBy: Schema.String,
+      deletedBy: Schema.optional(Schema.String),
     }),
   }),
 
@@ -426,7 +426,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       newPosition: Schema.Number,
-      movedBy: Schema.String,
+      movedBy: Schema.optional(Schema.String),
     }),
   }),
 
@@ -435,7 +435,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       sourceVisible: Schema.Boolean,
-      toggledBy: Schema.String,
+      toggledBy: Schema.optional(Schema.String),
     }),
   }),
 
@@ -444,7 +444,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       outputVisible: Schema.Boolean,
-      toggledBy: Schema.String,
+      toggledBy: Schema.optional(Schema.String),
     }),
   }),
 
@@ -453,7 +453,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       aiContextVisible: Schema.Boolean,
-      toggledBy: Schema.String,
+      toggledBy: Schema.optional(Schema.String),
     }),
   }),
 
@@ -839,55 +839,83 @@ const materializers = State.SQLite.materializers(events, {
       .onConflict("userId", "replace"),
   ],
 
-  "v1.CellTypeChanged": ({ id, cellType, changedBy }) => [
-    tables.cells.update({ cellType }).where({ id }),
-    // Update presence based on cell type change
-    tables.presence
-      .insert({ userId: changedBy, cellId: id })
-      .onConflict("userId", "replace"),
-  ],
+  "v1.CellTypeChanged": ({ id, cellType, changedBy }) => {
+    const ops = [tables.cells.update({ cellType }).where({ id })];
+    if (changedBy) {
+      ops.push(
+        tables.presence
+          .insert({ userId: changedBy, cellId: id })
+          .onConflict("userId", "replace") as any,
+      );
+    }
+    return ops;
+  },
 
-  "v1.CellDeleted": ({ id, deletedBy }) => [
-    tables.cells.delete().where({ id }),
-    // Update presence based on cell deletion
-    tables.presence
-      .insert({ userId: deletedBy, cellId: id })
-      .onConflict("userId", "replace"),
-  ],
+  "v1.CellDeleted": ({ id, deletedBy }) => {
+    const ops = [tables.cells.delete().where({ id })];
+    if (deletedBy) {
+      ops.push(
+        tables.presence
+          .insert({ userId: deletedBy, cellId: id })
+          .onConflict("userId", "replace") as any,
+      );
+    }
+    return ops;
+  },
 
-  "v1.CellMoved": ({ id, newPosition, movedBy }) => [
-    tables.cells.update({ position: newPosition }).where({ id }),
-    // Update presence based on cell movement
-    tables.presence
-      .insert({ userId: movedBy, cellId: id })
-      .onConflict("userId", "replace"),
-  ],
+  "v1.CellMoved": ({ id, newPosition, movedBy }) => {
+    const ops = [
+      tables.cells.update({ position: newPosition }).where({ id }),
+    ];
+    if (movedBy) {
+      ops.push(
+        tables.presence
+          .insert({ userId: movedBy, cellId: id })
+          .onConflict("userId", "replace") as any,
+      );
+    }
+    return ops;
+  },
 
-  "v1.CellSourceVisibilityToggled": ({ id, sourceVisible, toggledBy }) => [
-    tables.cells.update({ sourceVisible }).where({ id }),
-    // Update presence based on source visibility toggle
-    tables.presence
-      .insert({ userId: toggledBy, cellId: id })
-      .onConflict("userId", "replace"),
-  ],
+  "v1.CellSourceVisibilityToggled": ({ id, sourceVisible, toggledBy }) => {
+    const ops = [tables.cells.update({ sourceVisible }).where({ id })];
+    if (toggledBy) {
+      ops.push(
+        tables.presence
+          .insert({ userId: toggledBy, cellId: id })
+          .onConflict("userId", "replace") as any,
+      );
+    }
+    return ops;
+  },
 
-  "v1.CellOutputVisibilityToggled": ({ id, outputVisible, toggledBy }) => [
-    tables.cells.update({ outputVisible }).where({ id }),
-    // Update presence based on output visibility toggle
-    tables.presence
-      .insert({ userId: toggledBy, cellId: id })
-      .onConflict("userId", "replace"),
-  ],
+  "v1.CellOutputVisibilityToggled": ({ id, outputVisible, toggledBy }) => {
+    const ops = [tables.cells.update({ outputVisible }).where({ id })];
+    if (toggledBy) {
+      ops.push(
+        tables.presence
+          .insert({ userId: toggledBy, cellId: id })
+          .onConflict("userId", "replace") as any,
+      );
+    }
+    return ops;
+  },
 
   "v1.CellAiContextVisibilityToggled": (
     { id, aiContextVisible, toggledBy },
-  ) => [
-    tables.cells.update({ aiContextVisible }).where({ id }),
-    // Update presence based on AI context visibility toggle
-    tables.presence
-      .insert({ userId: toggledBy, cellId: id })
-      .onConflict("userId", "replace"),
-  ],
+  ) => {
+    const ops = [
+      tables.cells.update({ aiContextVisible }).where({ id }),
+    ];
+    if (toggledBy) {
+      ops.push(
+        tables.presence
+          .insert({ userId: toggledBy, cellId: id })
+          .onConflict("userId", "replace") as any,
+      );
+    }
+    return ops;
+  },
 
   "v1.PresenceSet": ({ userId, cellId }) =>
     tables.presence.insert({ userId, cellId: cellId || null }).onConflict(
@@ -1263,24 +1291,29 @@ const materializers = State.SQLite.materializers(events, {
   },
 
   "v1.CellOutputsCleared": ({ cellId, wait, clearedBy }) => {
-    const presenceUpdate = tables.presence
-      .insert({ userId: clearedBy, cellId })
-      .onConflict("userId", "replace");
+    const ops = [];
     if (wait) {
       // Store pending clear for wait=True
-      return [
+      ops.push(
         tables.pendingClears
           .insert({ cellId, clearedBy })
           .onConflict("cellId", "replace"),
-        presenceUpdate,
-      ];
+      );
     } else {
       // Immediate clear for wait=False
-      return [
-        tables.outputs.delete().where({ cellId }),
-        presenceUpdate,
-      ];
+      ops.push(tables.outputs.delete().where({ cellId }));
     }
+
+    // Add presence update if user is provided
+    if (clearedBy) {
+      ops.push(
+        tables.presence
+          .insert({ userId: clearedBy, cellId })
+          .onConflict("userId", "replace") as any,
+      );
+    }
+
+    return ops;
   },
 
   // AI materializers

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -810,7 +810,7 @@ const materializers = State.SQLite.materializers(events, {
       .onConflict("key", "replace"),
 
   // Cell materializers
-  "v1.CellCreated": ({ id, cellType, position, createdBy }) =>
+  "v1.CellCreated": ({ id, cellType, position, createdBy }) => [
     tables.cells
       .insert({
         id,
@@ -819,6 +819,11 @@ const materializers = State.SQLite.materializers(events, {
         createdBy,
       })
       .onConflict("id", "ignore"),
+    // Update presence based on cell creation
+    tables.presence
+      .insert({ userId: createdBy, cellId: id })
+      .onConflict("userId", "replace"),
+  ],
 
   "v1.CellSourceChanged": ({ id, source }) =>
     tables.cells.update({ source }).where({ id }),
@@ -904,6 +909,10 @@ const materializers = State.SQLite.materializers(events, {
         executionCount,
       })
       .where({ id: cellId }),
+    // Update presence based on execution request
+    tables.presence
+      .insert({ userId: requestedBy, cellId })
+      .onConflict("userId", "replace"),
   ],
 
   "v1.ExecutionAssigned": ({ queueId, runtimeSessionId }) =>
@@ -955,7 +964,7 @@ const materializers = State.SQLite.materializers(events, {
       .where({ id: cellId }),
   ],
 
-  "v1.ExecutionCancelled": ({ queueId, cellId }) => [
+  "v1.ExecutionCancelled": ({ queueId, cellId, cancelledBy }) => [
     // Update execution queue
     tables.executionQueue
       .update({
@@ -968,6 +977,10 @@ const materializers = State.SQLite.materializers(events, {
         executionState: "idle",
       })
       .where({ id: cellId }),
+    // Update presence based on execution cancellation
+    tables.presence
+      .insert({ userId: cancelledBy, cellId })
+      .onConflict("userId", "replace"),
   ],
 
   // Unified output system materializers with pending clear support

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -393,7 +393,6 @@ export const events = {
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
       position: Schema.Number,
       createdBy: Schema.String,
-      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -412,7 +411,6 @@ export const events = {
       id: Schema.String,
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
       changedBy: Schema.optional(Schema.String),
-      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -421,7 +419,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       deletedBy: Schema.optional(Schema.String),
-      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -431,7 +428,6 @@ export const events = {
       id: Schema.String,
       newPosition: Schema.Number,
       movedBy: Schema.optional(Schema.String),
-      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -441,7 +437,6 @@ export const events = {
       id: Schema.String,
       sourceVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
-      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -451,7 +446,6 @@ export const events = {
       id: Schema.String,
       outputVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
-      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -461,7 +455,6 @@ export const events = {
       id: Schema.String,
       aiContextVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
-      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -519,7 +512,6 @@ export const events = {
       cellId: Schema.String,
       executionCount: Schema.Number,
       requestedBy: Schema.String,
-      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -559,7 +551,6 @@ export const events = {
       queueId: Schema.String,
       cellId: Schema.String,
       cancelledBy: Schema.String,
-      userId: Schema.optional(Schema.String),
       reason: Schema.String,
     }),
   }),
@@ -834,7 +825,7 @@ const materializers = State.SQLite.materializers(events, {
       .onConflict("key", "replace"),
 
   // Cell materializers
-  "v1.CellCreated": ({ id, cellType, position, createdBy, userId }) => [
+  "v1.CellCreated": ({ id, cellType, position, createdBy }) => [
     tables.cells
       .insert({
         id,
@@ -844,7 +835,7 @@ const materializers = State.SQLite.materializers(events, {
       })
       .onConflict("id", "ignore"),
     // Update presence table
-    updatePresence(userId || createdBy, id),
+    updatePresence(createdBy, id),
   ],
 
   "v1.CellSourceChanged": ({ id, source, modifiedBy }) => [
@@ -853,68 +844,62 @@ const materializers = State.SQLite.materializers(events, {
     updatePresence(modifiedBy, id),
   ],
 
-  "v1.CellTypeChanged": ({ id, cellType, changedBy, userId }) => {
+  "v1.CellTypeChanged": ({ id, cellType, changedBy }) => {
     const ops = [];
     ops.push(tables.cells.update({ cellType }).where({ id }));
-    const user = userId || changedBy;
-    if (user) {
-      ops.push(updatePresence(user, id));
+    if (changedBy) {
+      ops.push(updatePresence(changedBy, id));
     }
     return ops;
   },
 
-  "v1.CellDeleted": ({ id, deletedBy, userId }) => {
+  "v1.CellDeleted": ({ id, deletedBy }) => {
     const ops = [];
     ops.push(tables.cells.delete().where({ id }));
-    const user = userId || deletedBy;
-    if (user) {
-      ops.push(updatePresence(user, id));
+    if (deletedBy) {
+      ops.push(updatePresence(deletedBy, id));
     }
     return ops;
   },
 
-  "v1.CellMoved": ({ id, newPosition, movedBy, userId }) => {
+  "v1.CellMoved": ({ id, newPosition, movedBy }) => {
     const ops = [];
     ops.push(tables.cells.update({ position: newPosition }).where({ id }));
-    const user = userId || movedBy;
-    if (user) {
-      ops.push(updatePresence(user, id));
+    if (movedBy) {
+      ops.push(updatePresence(movedBy, id));
     }
     return ops;
   },
 
   "v1.CellSourceVisibilityToggled": (
-    { id, sourceVisible, toggledBy, userId },
+    { id, sourceVisible, toggledBy },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ sourceVisible }).where({ id }));
-    const user = userId || toggledBy;
-    if (user) {
-      ops.push(updatePresence(user, id));
+    if (toggledBy) {
+      ops.push(updatePresence(toggledBy, id));
     }
     return ops;
   },
 
   "v1.CellOutputVisibilityToggled": (
-    { id, outputVisible, toggledBy, userId },
+    { id, outputVisible, toggledBy },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ outputVisible }).where({ id }));
-    const user = userId || toggledBy;
-    if (user) {
-      ops.push(updatePresence(user, id));
+    if (toggledBy) {
+      ops.push(updatePresence(toggledBy, id));
     }
     return ops;
   },
 
   "v1.CellAiContextVisibilityToggled": (
-    { id, aiContextVisible, toggledBy, userId },
+    { id, aiContextVisible, toggledBy },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ aiContextVisible }).where({ id }));
-    const user = userId || toggledBy;
-    if (user) {
-      ops.push(updatePresence(user, id));
+    if (toggledBy) {
+      ops.push(updatePresence(toggledBy, id));
     }
     return ops;
   },
@@ -962,7 +947,6 @@ const materializers = State.SQLite.materializers(events, {
     cellId,
     executionCount,
     requestedBy,
-    userId,
   }) => [
     tables.executionQueue
       .insert({
@@ -981,7 +965,7 @@ const materializers = State.SQLite.materializers(events, {
       })
       .where({ id: cellId }),
     // Update presence table
-    updatePresence(userId || requestedBy, cellId),
+    updatePresence(requestedBy, cellId),
   ],
 
   "v1.ExecutionAssigned": ({ queueId, runtimeSessionId }) =>
@@ -1033,7 +1017,7 @@ const materializers = State.SQLite.materializers(events, {
       .where({ id: cellId }),
   ],
 
-  "v1.ExecutionCancelled": ({ queueId, cellId, cancelledBy, userId }) => [
+  "v1.ExecutionCancelled": ({ queueId, cellId, cancelledBy }) => [
     // Update execution queue
     tables.executionQueue
       .update({
@@ -1047,7 +1031,7 @@ const materializers = State.SQLite.materializers(events, {
       })
       .where({ id: cellId }),
     // Update presence table
-    updatePresence(userId || cancelledBy, cellId),
+    updatePresence(cancelledBy, cellId),
   ],
 
   // Unified output system materializers with pending clear support

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -440,7 +440,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       sourceVisible: Schema.Boolean,
-      toggledBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -450,7 +449,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       outputVisible: Schema.Boolean,
-      toggledBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -460,7 +458,6 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       aiContextVisible: Schema.Boolean,
-      toggledBy: Schema.optional(Schema.String),
       userId: Schema.optional(Schema.String),
     }),
   }),
@@ -880,31 +877,31 @@ const materializers = State.SQLite.materializers(events, {
     return ops;
   },
 
-  "v1.CellSourceVisibilityToggled": ({ id, sourceVisible, toggledBy }) => {
+  "v1.CellSourceVisibilityToggled": ({ id, sourceVisible, userId }) => {
     const ops = [];
     ops.push(tables.cells.update({ sourceVisible }).where({ id }));
-    if (toggledBy) {
-      ops.push(updatePresence(toggledBy, id));
+    if (userId) {
+      ops.push(updatePresence(userId, id));
     }
     return ops;
   },
 
-  "v1.CellOutputVisibilityToggled": ({ id, outputVisible, toggledBy }) => {
+  "v1.CellOutputVisibilityToggled": ({ id, outputVisible, userId }) => {
     const ops = [];
     ops.push(tables.cells.update({ outputVisible }).where({ id }));
-    if (toggledBy) {
-      ops.push(updatePresence(toggledBy, id));
+    if (userId) {
+      ops.push(updatePresence(userId, id));
     }
     return ops;
   },
 
   "v1.CellAiContextVisibilityToggled": (
-    { id, aiContextVisible, toggledBy },
+    { id, aiContextVisible, userId },
   ) => {
     const ops = [];
     ops.push(tables.cells.update({ aiContextVisible }).where({ id }));
-    if (toggledBy) {
-      ops.push(updatePresence(toggledBy, id));
+    if (userId) {
+      ops.push(updatePresence(userId, id));
     }
     return ops;
   },

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -785,6 +785,13 @@ function updateExistingDisplays(
   ];
 }
 
+// Shared helper function for updating presence
+function updatePresence(userId: string, cellId?: string) {
+  return tables.presence
+    .insert({ userId, cellId: cellId || null })
+    .onConflict("userId", "replace");
+}
+
 // Materializers map events to state changes
 const materializers = State.SQLite.materializers(events, {
   // Notebook materializers
@@ -837,28 +844,20 @@ const materializers = State.SQLite.materializers(events, {
       })
       .onConflict("id", "ignore"),
     // Update presence table
-    tables.presence
-      .insert({ userId: userId || createdBy, cellId: id })
-      .onConflict("userId", "replace"),
+    updatePresence(userId || createdBy, id),
   ],
 
   "v1.CellSourceChanged": ({ id, source, modifiedBy }) => [
     tables.cells.update({ source }).where({ id }),
     // Update presence based on cell source modification
-    tables.presence
-      .insert({ userId: modifiedBy, cellId: id })
-      .onConflict("userId", "replace"),
+    updatePresence(modifiedBy, id),
   ],
 
   "v1.CellTypeChanged": ({ id, cellType, changedBy }) => {
     const ops = [];
     ops.push(tables.cells.update({ cellType }).where({ id }));
     if (changedBy) {
-      ops.push(
-        tables.presence
-          .insert({ userId: changedBy, cellId: id })
-          .onConflict("userId", "replace"),
-      );
+      ops.push(updatePresence(changedBy, id));
     }
     return ops;
   },
@@ -867,11 +866,7 @@ const materializers = State.SQLite.materializers(events, {
     const ops = [];
     ops.push(tables.cells.delete().where({ id }));
     if (deletedBy) {
-      ops.push(
-        tables.presence
-          .insert({ userId: deletedBy, cellId: id })
-          .onConflict("userId", "replace"),
-      );
+      ops.push(updatePresence(deletedBy, id));
     }
     return ops;
   },
@@ -880,11 +875,7 @@ const materializers = State.SQLite.materializers(events, {
     const ops = [];
     ops.push(tables.cells.update({ position: newPosition }).where({ id }));
     if (movedBy) {
-      ops.push(
-        tables.presence
-          .insert({ userId: movedBy, cellId: id })
-          .onConflict("userId", "replace"),
-      );
+      ops.push(updatePresence(movedBy, id));
     }
     return ops;
   },
@@ -893,11 +884,7 @@ const materializers = State.SQLite.materializers(events, {
     const ops = [];
     ops.push(tables.cells.update({ sourceVisible }).where({ id }));
     if (toggledBy) {
-      ops.push(
-        tables.presence
-          .insert({ userId: toggledBy, cellId: id })
-          .onConflict("userId", "replace"),
-      );
+      ops.push(updatePresence(toggledBy, id));
     }
     return ops;
   },
@@ -906,11 +893,7 @@ const materializers = State.SQLite.materializers(events, {
     const ops = [];
     ops.push(tables.cells.update({ outputVisible }).where({ id }));
     if (toggledBy) {
-      ops.push(
-        tables.presence
-          .insert({ userId: toggledBy, cellId: id })
-          .onConflict("userId", "replace"),
-      );
+      ops.push(updatePresence(toggledBy, id));
     }
     return ops;
   },
@@ -921,20 +904,12 @@ const materializers = State.SQLite.materializers(events, {
     const ops = [];
     ops.push(tables.cells.update({ aiContextVisible }).where({ id }));
     if (toggledBy) {
-      ops.push(
-        tables.presence
-          .insert({ userId: toggledBy, cellId: id })
-          .onConflict("userId", "replace"),
-      );
+      ops.push(updatePresence(toggledBy, id));
     }
     return ops;
   },
 
-  "v1.PresenceSet": ({ userId, cellId }) =>
-    tables.presence.insert({ userId, cellId: cellId || null }).onConflict(
-      "userId",
-      "replace",
-    ),
+  "v1.PresenceSet": ({ userId, cellId }) => updatePresence(userId, cellId),
 
   // Runtime lifecycle materializers
   "v1.RuntimeSessionStarted": ({
@@ -996,9 +971,7 @@ const materializers = State.SQLite.materializers(events, {
       })
       .where({ id: cellId }),
     // Update presence table
-    tables.presence
-      .insert({ userId: userId || requestedBy, cellId })
-      .onConflict("userId", "replace"),
+    updatePresence(userId || requestedBy, cellId),
   ],
 
   "v1.ExecutionAssigned": ({ queueId, runtimeSessionId }) =>
@@ -1064,9 +1037,7 @@ const materializers = State.SQLite.materializers(events, {
       })
       .where({ id: cellId }),
     // Update presence table
-    tables.presence
-      .insert({ userId: userId || cancelledBy, cellId })
-      .onConflict("userId", "replace"),
+    updatePresence(userId || cancelledBy, cellId),
   ],
 
   // Unified output system materializers with pending clear support
@@ -1320,11 +1291,7 @@ const materializers = State.SQLite.materializers(events, {
 
     // Add presence update if user is provided
     if (clearedBy) {
-      ops.push(
-        tables.presence
-          .insert({ userId: clearedBy, cellId })
-          .onConflict("userId", "replace"),
-      );
+      ops.push(updatePresence(clearedBy, cellId));
     }
 
     return ops;

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -393,6 +393,7 @@ export const events = {
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
       position: Schema.Number,
       createdBy: Schema.String,
+      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -411,6 +412,7 @@ export const events = {
       id: Schema.String,
       cellType: Schema.Literal("code", "markdown", "raw", "sql", "ai"),
       changedBy: Schema.optional(Schema.String),
+      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -419,6 +421,7 @@ export const events = {
     schema: Schema.Struct({
       id: Schema.String,
       deletedBy: Schema.optional(Schema.String),
+      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -428,6 +431,7 @@ export const events = {
       id: Schema.String,
       newPosition: Schema.Number,
       movedBy: Schema.optional(Schema.String),
+      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -437,6 +441,7 @@ export const events = {
       id: Schema.String,
       sourceVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
+      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -446,6 +451,7 @@ export const events = {
       id: Schema.String,
       outputVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
+      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -455,6 +461,7 @@ export const events = {
       id: Schema.String,
       aiContextVisible: Schema.Boolean,
       toggledBy: Schema.optional(Schema.String),
+      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -512,6 +519,7 @@ export const events = {
       cellId: Schema.String,
       executionCount: Schema.Number,
       requestedBy: Schema.String,
+      userId: Schema.optional(Schema.String),
     }),
   }),
 
@@ -551,6 +559,7 @@ export const events = {
       queueId: Schema.String,
       cellId: Schema.String,
       cancelledBy: Schema.String,
+      userId: Schema.optional(Schema.String),
       reason: Schema.String,
     }),
   }),
@@ -818,7 +827,7 @@ const materializers = State.SQLite.materializers(events, {
       .onConflict("key", "replace"),
 
   // Cell materializers
-  "v1.CellCreated": ({ id, cellType, position, createdBy }) => [
+  "v1.CellCreated": ({ id, cellType, position, createdBy, userId }) => [
     tables.cells
       .insert({
         id,
@@ -827,9 +836,9 @@ const materializers = State.SQLite.materializers(events, {
         createdBy,
       })
       .onConflict("id", "ignore"),
-    // Update presence based on cell creation
+    // Update presence table
     tables.presence
-      .insert({ userId: createdBy, cellId: id })
+      .insert({ userId: userId || createdBy, cellId: id })
       .onConflict("userId", "replace"),
   ],
 
@@ -968,6 +977,7 @@ const materializers = State.SQLite.materializers(events, {
     cellId,
     executionCount,
     requestedBy,
+    userId,
   }) => [
     tables.executionQueue
       .insert({
@@ -985,9 +995,9 @@ const materializers = State.SQLite.materializers(events, {
         executionCount,
       })
       .where({ id: cellId }),
-    // Update presence based on execution request
+    // Update presence table
     tables.presence
-      .insert({ userId: requestedBy, cellId })
+      .insert({ userId: userId || requestedBy, cellId })
       .onConflict("userId", "replace"),
   ],
 
@@ -1040,7 +1050,7 @@ const materializers = State.SQLite.materializers(events, {
       .where({ id: cellId }),
   ],
 
-  "v1.ExecutionCancelled": ({ queueId, cellId, cancelledBy }) => [
+  "v1.ExecutionCancelled": ({ queueId, cellId, cancelledBy, userId }) => [
     // Update execution queue
     tables.executionQueue
       .update({
@@ -1053,9 +1063,9 @@ const materializers = State.SQLite.materializers(events, {
         executionState: "idle",
       })
       .where({ id: cellId }),
-    // Update presence based on execution cancellation
+    // Update presence table
     tables.presence
-      .insert({ userId: cancelledBy, cellId })
+      .insert({ userId: userId || cancelledBy, cellId })
       .onConflict("userId", "replace"),
   ],
 


### PR DESCRIPTION

- CellCreated materializer now updates presence table with createdBy user
- ExecutionRequested materializer now updates presence table with requestedBy user
- ExecutionCancelled materializer now uses cancelledBy parameter and updates presence
- Sets foundation for deprecating PresenceSet event in favor of userJoined/userLeft events
- Presence now accurately reflects actual user activity rather than just 'being there'