### PR TITLE
refactor: move from singleton schema to factory pattern for 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Type check
         run: deno task check
 
+      - name: Type check TUI
+        run: deno task check:tui
+
   test:
     name: Tests
     runs-on: ubuntu-latest

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -11,8 +11,8 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.6.4",
-    "@runt/schema": "jsr:@runt/schema@^0.6.4",
+    "@runt/lib": "jsr:@runt/lib@^0.7.0",
+    "@runt/schema": "jsr:@runt/schema@^0.7.0",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/ai",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Runtime AI Clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -13,10 +13,16 @@ import type {
   AiToolCallData,
   AiToolResultData,
   MediaContainer,
-  Store,
 } from "@runt/schema";
+import { events, materializers, tables } from "@runt/schema";
+import type { Store } from "npm:@livestore/livestore";
+import { makeSchema, State } from "npm:@livestore/livestore";
 import { AI_TOOL_CALL_MIME_TYPE, AI_TOOL_RESULT_MIME_TYPE } from "@runt/schema";
 import { createLogger } from "@runt/lib";
+
+// Create schema locally
+const state = State.SQLite.makeState({ tables, materializers });
+const schema = makeSchema({ events, state });
 
 import { OpenAIClient } from "./openai-client.ts";
 import { RuntOllamaClient } from "./ollama-client.ts";
@@ -457,7 +463,7 @@ export async function executeAI(
   context: ExecutionContext,
   notebookContext: NotebookContextData,
   logger: Logger,
-  store: Store,
+  store: Store<typeof schema>,
   sessionId: string,
 ): Promise<{ success: boolean; error?: string }> {
   const {

--- a/packages/ai/notebook-context.ts
+++ b/packages/ai/notebook-context.ts
@@ -5,13 +5,20 @@
  * for AI execution, preserving conversation flow and tool call information.
  */
 
-import type { Store } from "@runt/schema";
+import type { Store } from "npm:@livestore/livestore";
+import { makeSchema, State } from "npm:@livestore/livestore";
 import {
   type CellData,
+  events,
+  materializers,
   type MediaContainer,
   type OutputData,
   tables,
 } from "@runt/schema";
+
+// Create schema locally
+const state = State.SQLite.makeState({ tables, materializers });
+const schema = makeSchema({ events, state });
 import type { CellContextData, NotebookContextData } from "./mod.ts";
 
 /**
@@ -22,7 +29,7 @@ import type { CellContextData, NotebookContextData } from "./mod.ts";
  * destructive string conversion in the runtime agent.
  */
 export function gatherNotebookContext(
-  store: Store,
+  store: Store<typeof schema>,
   currentCell: { id: string; position: number },
 ): NotebookContextData {
   // Query all cells in order

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -1,6 +1,12 @@
-import { type CellData, events, type Store, tables } from "@runt/schema";
+import { type CellData, events, materializers, tables } from "@runt/schema";
 import type { Logger } from "@runt/lib";
+import type { Store } from "npm:@livestore/livestore";
+import { makeSchema, State } from "npm:@livestore/livestore";
 import { createLogger } from "@runt/lib";
+
+// Create schema locally
+const state = State.SQLite.makeState({ tables, materializers });
+const schema = makeSchema({ events, state });
 
 // Create logger for tool execution debugging
 const toolLogger = createLogger("ai-tools");
@@ -90,7 +96,7 @@ export const NOTEBOOK_TOOLS: NotebookTool[] = [
 ];
 
 function calculateNewCellPosition(
-  store: Store,
+  store: Store<typeof schema>,
   currentCell: CellData,
   placement: string,
 ): number {
@@ -114,7 +120,7 @@ function calculateNewCellPosition(
 }
 
 export function createCell(
-  store: Store,
+  store: Store<typeof schema>,
   logger: Logger,
   sessionId: string,
   currentCell: CellData,
@@ -173,7 +179,7 @@ export function createCell(
  * Handle tool calls from AI with result return
  */
 export async function handleToolCallWithResult(
-  store: Store,
+  store: Store<typeof schema>,
   logger: Logger,
   sessionId: string,
   currentCell: CellData,

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.6.4",
+    "@runt/schema": "jsr:@runt/schema@^0.7.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Runtime agent library for building Anode runtime agents",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -7,8 +7,18 @@ import {
   type Store,
 } from "npm:@livestore/livestore";
 import { makeCfSync } from "npm:@livestore/sync-cf";
-import { events, type MediaContainer, schema, tables } from "@runt/schema";
+import {
+  events,
+  materializers,
+  type MediaContainer,
+  tables,
+} from "@runt/schema";
 import { createLogger } from "./logging.ts";
+import { makeSchema, State } from "npm:@livestore/livestore";
+
+// Create schema locally
+const state = State.SQLite.makeState({ tables, materializers });
+const schema = makeSchema({ events, state });
 import type {
   CancellationHandler,
   CellData,

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -5,12 +5,13 @@
 // and adding runtime-specific extensions.
 
 import type { Store } from "npm:@livestore/livestore";
-import type {
-  CellData,
-  ExecutionQueueData,
-  OutputType,
-  schema,
-} from "@runt/schema";
+import type { CellData, ExecutionQueueData, OutputType } from "@runt/schema";
+import { events, materializers, tables } from "@runt/schema";
+import { makeSchema, State } from "npm:@livestore/livestore";
+
+// Create schema locally
+const state = State.SQLite.makeState({ tables, materializers });
+const schema = makeSchema({ events, state });
 
 /**
  * Raw output data format accepted by context.display() methods

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -14,9 +14,9 @@
     "pyorunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/ai": "jsr:@runt/ai@^0.6.4",
-    "@runt/lib": "jsr:@runt/lib@^0.6.4",
-    "@runt/schema": "jsr:@runt/schema@^0.6.4",
+    "@runt/ai": "jsr:@runt/ai@^0.7.0",
+    "@runt/lib": "jsr:@runt/lib@^0.7.0",
+    "@runt/schema": "jsr:@runt/schema@^0.7.0",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/python-runtime-agent",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Stub Python runtime agent for Runt platform.",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -14,8 +14,8 @@
     "pyrunt": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.6.4",
-    "@runt/schema": "jsr:@runt/schema@^0.6.4"
+    "@runt/lib": "jsr:@runt/lib@^0.7.0",
+    "@runt/schema": "jsr:@runt/schema@^0.7.0"
   },
   "tasks": {
     "test": "deno test --allow-all",

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -1332,12 +1332,6 @@ const materializers = State.SQLite.materializers(events, {
       .where({ id: cellId }),
 });
 
-const state = State.SQLite.makeState({ tables, materializers });
-
-export const schema = makeSchema({ events, state });
-
-export type Store = LiveStore<typeof schema>;
-
 // Type exports derived from the actual table definitions - full type inference works here!
 export type NotebookMetadataData = typeof tables.notebookMetadata.Type;
 export type CellData = typeof tables.cells.Type;
@@ -1511,3 +1505,14 @@ export const AI_TOOL_CALL_MIME_TYPE =
  */
 export const AI_TOOL_RESULT_MIME_TYPE =
   "application/vnd.anode.aitool.result+json" as const;
+
+// Pre 0.7.0 -- these types should get created in clients
+// const state = State.SQLite.makeState({ tables, materializers });
+// export const schema = makeSchema({ events, state });
+// export type Store = LiveStore<typeof schema>;
+
+export function makeStore() {
+  const state = State.SQLite.makeState({ tables, materializers });
+  const schema = makeSchema({ events, state });
+  return schema;
+}

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -1,11 +1,4 @@
-import {
-  Events,
-  makeSchema,
-  Schema,
-  SessionIdSymbol,
-  State,
-  type Store as LiveStore,
-} from "@livestore/livestore";
+import { Events, Schema, SessionIdSymbol, State } from "@livestore/livestore";
 
 // Base generic types for MediaContainer system
 export type InlineContainer<T = unknown> = {
@@ -1511,8 +1504,5 @@ export const AI_TOOL_RESULT_MIME_TYPE =
 // export const schema = makeSchema({ events, state });
 // export type Store = LiveStore<typeof schema>;
 
-export function makeStore() {
-  const state = State.SQLite.makeState({ tables, materializers });
-  const schema = makeSchema({ events, state });
-  return schema;
-}
+// Export materializers so clients can create their own schema
+export { materializers };

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "This package.json is solely here to make linking possible for npm users",
   "type": "module",
   "main": "./mod.ts",

--- a/packages/tui/deno.json
+++ b/packages/tui/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/tui",
-  "version": "0.6.4",
+  "version": "0.7.0",
   "description": "Terminal notebook viewer for Runt runtime agents",
   "license": "BSD-3-Clause",
   "exports": "./mod.ts",

--- a/packages/tui/deno.json
+++ b/packages/tui/deno.json
@@ -12,9 +12,9 @@
     "lint": "deno lint"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.6.4",
-    "@runt/lib": "jsr:@runt/lib@^0.6.4",
-    "@runt/ai": "jsr:@runt/ai@^0.6.4",
+    "@runt/schema": "jsr:@runt/schema@^0.7.0",
+    "@runt/lib": "jsr:@runt/lib@^0.7.0",
+    "@runt/ai": "jsr:@runt/ai@^0.7.0",
     "@inkjs/ui": "npm:@inkjs/ui@^2.0.0",
     "@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/tui/src/notebook.tsx
+++ b/packages/tui/src/notebook.tsx
@@ -3,12 +3,17 @@ import { Box, Text } from "ink";
 import { LiveStoreProvider } from "@livestore/react";
 import { makeAdapter } from "@livestore/adapter-node";
 import { makeCfSync } from "@livestore/sync-cf";
-import { schema } from "@runt/schema";
+import { events, materializers, tables } from "@runt/schema";
+import { makeSchema, State } from "@livestore/livestore";
 import { NotebookRenderer } from "./components/notebook/NotebookRenderer.tsx";
 import { LoadingIndicator } from "./components/layout/LoadingIndicator.tsx";
 import { ErrorDisplay } from "./components/layout/ErrorDisplay.tsx";
 import { Colors } from "./utils/colors.ts";
 import { useExitHandler } from "./utils/useExitHandler.ts";
+
+// Create schema locally
+const state = State.SQLite.makeState({ tables, materializers });
+const schema = makeSchema({ events, state });
 
 interface NotebookProps {
   notebookId: string;


### PR DESCRIPTION
Breaking change for 0.7.0 release:

- Remove pre-exported schema/Store type from @runt/schema
- Export materializers so clients create schemas locally  
- All consumers now use standard LiveStore pattern: Store<typeof schema>
- Eliminates singleton pattern, gives clients full control over schema creation

Migration: Import events, tables, materializers from @runt/schema and create schema using makeSchema({ events, state: State.SQLite.makeState({ tables, materializers }) })

All tests pass, ready for 0.7.0 release.