### PR TITLE
feat(schema): Add ActorProfileSet event for user presence

### DIFF
--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/ai",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Runtime AI Clients",
   "license": "BSD-3-Clause",
   "repository": {
@@ -11,8 +11,8 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.7.1",
-    "@runt/schema": "jsr:@runt/schema@^0.7.1",
+    "@runt/lib": "jsr:@runt/lib@^0.7.2",
+    "@runt/schema": "jsr:@runt/schema@^0.7.2",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Runtime agent library for building Anode runtime agents",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.7.1",
+    "@runt/schema": "jsr:@runt/schema@^0.7.2",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,9 +14,9 @@
     "pyorunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/ai": "jsr:@runt/ai@^0.7.1",
-    "@runt/lib": "jsr:@runt/lib@^0.7.1",
-    "@runt/schema": "jsr:@runt/schema@^0.7.1",
+    "@runt/ai": "jsr:@runt/ai@^0.7.2",
+    "@runt/lib": "jsr:@runt/lib@^0.7.2",
+    "@runt/schema": "jsr:@runt/schema@^0.7.2",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/python-runtime-agent",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Stub Python runtime agent for Runt platform.",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,8 +14,8 @@
     "pyrunt": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.7.1",
-    "@runt/schema": "jsr:@runt/schema@^0.7.1"
+    "@runt/lib": "jsr:@runt/lib@^0.7.2",
+    "@runt/schema": "jsr:@runt/schema@^0.7.2"
   },
   "tasks": {
     "test": "deno test --allow-all",

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -694,6 +694,16 @@ export const events = {
 
   // UI state
   uiStateSet: tables.uiState.set,
+
+  actorProfileSet: Events.synced({
+    name: "v1.ActorProfileSet",
+    schema: Schema.Struct({
+      id: Schema.String,
+      type: Schema.Literal("human", "runtime_agent"),
+      displayName: Schema.String,
+      avatar: Schema.optional(Schema.String),
+    }),
+  }),
 };
 
 // Helper function to select primary representation from multimedia data
@@ -1323,6 +1333,16 @@ export const materializers = State.SQLite.materializers(events, {
         sqlResultVariable: resultVariable ?? null,
       })
       .where({ id: cellId }),
+
+  "v1.ActorProfileSet": ({ id, type, displayName, avatar }) =>
+    tables.actors
+      .insert({
+        id,
+        type,
+        displayName,
+        avatar: avatar ?? null,
+      })
+      .onConflict("id", "replace"),
 });
 
 // Type exports derived from the actual table definitions - full type inference works here!

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "This package.json is solely here to make linking possible for npm users",
   "type": "module",
   "main": "./mod.ts",

--- a/packages/tui/deno.json
+++ b/packages/tui/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/tui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Terminal notebook viewer for Runt runtime agents",
   "license": "BSD-3-Clause",
   "exports": "./mod.ts",
@@ -12,9 +12,9 @@
     "lint": "deno lint"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.7.1",
-    "@runt/lib": "jsr:@runt/lib@^0.7.1",
-    "@runt/ai": "jsr:@runt/ai@^0.7.1",
+    "@runt/schema": "jsr:@runt/schema@^0.7.2",
+    "@runt/lib": "jsr:@runt/lib@^0.7.2",
+    "@runt/ai": "jsr:@runt/ai@^0.7.2",
     "@inkjs/ui": "npm:@inkjs/ui@^2.0.0",
     "@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "@livestore/livestore": "npm:@livestore/livestore@^0.3.1",


### PR DESCRIPTION
This PR adds the `ActorProfileSet` event and corresponding materializer to the schema. This is the foundation for tracking user presence and displaying profile information in collaborative notebooks. It is a companion to the `anode` PR for implementing the UI.