### PR TITLE
Fix runtime agent clientId missing in sync payload

### DIFF
--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -90,6 +90,7 @@ export class RuntimeAgent {
           runtime: true,
           runtimeId: this.config.runtimeId,
           sessionId: this.config.sessionId,
+          clientId: this.config.runtimeId,
         },
       });
 


### PR DESCRIPTION
Fixes CLIENT_ID_MISSING error when runtime agents connect to anode backend.

Runtime agents now include clientId in sync payload using runtimeId as the identifier, preventing user impersonation while satisfying backend validation requirements.