### PR TITLE
[feature] MCP with tool approval

### DIFF
--- a/packages/ai/MCP_INTEGRATION.md
+++ b/packages/ai/MCP_INTEGRATION.md
@@ -1,10 +1,12 @@
 # MCP (Model Context Protocol) Integration
 
-The AI package now supports MCP (Model Context Protocol) integration, allowing you to extend AI capabilities with external tools and services.
+The AI package now supports MCP (Model Context Protocol) integration, allowing
+you to extend AI capabilities with external tools and services.
 
 ## Overview
 
-MCP integration allows your AI assistants to access additional tools beyond the built-in notebook tools. These tools can include:
+MCP integration allows your AI assistants to access additional tools beyond the
+built-in notebook tools. These tools can include:
 
 - File system operations
 - Web search capabilities
@@ -26,7 +28,8 @@ touch ~/.anode/mcp.json
 
 ### 2. Configure MCP Servers
 
-Edit `~/.anode/mcp.json` to configure your desired MCP servers. Here's a comprehensive example showing all supported server types:
+Edit `~/.anode/mcp.json` to configure your desired MCP servers. Here's a
+comprehensive example showing all supported server types:
 
 ```json
 {
@@ -64,7 +67,7 @@ Edit `~/.anode/mcp.json` to configure your desired MCP servers. Here's a compreh
     "sqlite": {
       "command": "npx -y @modelcontextprotocol/server-sqlite",
       "args": ["/path/to/database.db"],
-      "name": "SQLite Server", 
+      "name": "SQLite Server",
       "description": "Query SQLite databases"
     },
     "custom-sse-server": {
@@ -115,23 +118,29 @@ For servers that use Server-Sent Events:
 Here are some popular official MCP servers you can use:
 
 ### Filesystem Access
+
 ```bash
 npm install -g @modelcontextprotocol/server-filesystem
 ```
 
 ### Web Search (Brave)
+
 ```bash
 npm install -g @modelcontextprotocol/server-brave-search
 ```
+
 Requires: `BRAVE_API_KEY` environment variable
 
 ### GitHub Integration
+
 ```bash
 npm install -g @modelcontextprotocol/server-github
 ```
+
 Requires: `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable
 
 ### Database Access
+
 ```bash
 # PostgreSQL
 npm install -g @modelcontextprotocol/server-postgres
@@ -142,7 +151,9 @@ npm install -g @modelcontextprotocol/server-sqlite
 
 ## Usage
 
-Once configured, MCP tools are automatically available to AI assistants alongside built-in notebook tools. Tools are named with the format `serverName:toolName`.
+Once configured, MCP tools are automatically available to AI assistants
+alongside built-in notebook tools. Tools are named with the format
+`serverName:toolName`.
 
 ### Example Usage
 
@@ -156,6 +167,7 @@ Once configured, MCP tools are automatically available to AI assistants alongsid
 ### Tool Discovery
 
 The system automatically:
+
 1. Reads configuration from `~/.anode/mcp.json`
 2. Connects to configured MCP servers
 3. Discovers available tools from each server
@@ -164,6 +176,7 @@ The system automatically:
 ### Tool Execution
 
 When an AI assistant calls an MCP tool:
+
 1. The tool name is parsed to extract server and tool names
 2. The appropriate MCP server is located
 3. The tool is executed with the provided arguments
@@ -187,6 +200,7 @@ When an AI assistant calls an MCP tool:
 ### Server Connection Issues
 
 Check server logs and ensure:
+
 - Required packages are installed globally
 - Environment variables are set correctly
 - File paths and permissions are correct
@@ -196,7 +210,8 @@ Check server logs and ensure:
 When using full paths in the `command` array, ensure:
 
 1. **File exists**: The executable file exists at the specified path
-2. **Permissions**: The file has execute permissions (`chmod +x /path/to/executable`)
+2. **Permissions**: The file has execute permissions
+   (`chmod +x /path/to/executable`)
 3. **Correct format**: Use proper string and args format:
    ```json
    {
@@ -210,13 +225,17 @@ When using full paths in the `command` array, ensure:
 
 #### Common Path Issues
 
-- **Permission denied**: Check file permissions with `ls -la /path/to/executable`
-- **File not found**: Verify the path exists with `which executable-name` or `ls /path/to/executable`
-- **Empty path**: Ensure the command string is not empty and contains a valid executable path
+- **Permission denied**: Check file permissions with
+  `ls -la /path/to/executable`
+- **File not found**: Verify the path exists with `which executable-name` or
+  `ls /path/to/executable`
+- **Empty path**: Ensure the command string is not empty and contains a valid
+  executable path
 
 ### Tool Discovery Problems
 
 Verify:
+
 - Server configuration syntax in `mcp.json`
 - Server startup and connection success
 - Tool compatibility with MCP specification
@@ -229,4 +248,6 @@ Verify:
 
 ## Examples
 
-The configuration section above provides a complete example with multiple server types and configurations covering filesystem access, web search, GitHub integration, database access, and custom SSE servers. 
+The configuration section above provides a complete example with multiple server
+types and configurations covering filesystem access, web search, GitHub
+integration, database access, and custom SSE servers.

--- a/packages/ai/MCP_INTEGRATION.md
+++ b/packages/ai/MCP_INTEGRATION.md
@@ -1,0 +1,232 @@
+# MCP (Model Context Protocol) Integration
+
+The AI package now supports MCP (Model Context Protocol) integration, allowing you to extend AI capabilities with external tools and services.
+
+## Overview
+
+MCP integration allows your AI assistants to access additional tools beyond the built-in notebook tools. These tools can include:
+
+- File system operations
+- Web search capabilities
+- Database queries
+- GitHub repository access
+- Custom business logic tools
+- And many more...
+
+## Configuration
+
+### 1. Create MCP Configuration File
+
+Create a configuration file at `~/.anode/mcp.json`:
+
+```bash
+mkdir -p ~/.anode
+touch ~/.anode/mcp.json
+```
+
+### 2. Configure MCP Servers
+
+Edit `~/.anode/mcp.json` to configure your desired MCP servers. Here's a comprehensive example showing all supported server types:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx -y @modelcontextprotocol/server-filesystem",
+      "args": ["/path/to/allowed/directory"],
+      "name": "Filesystem Server",
+      "description": "Access and manipulate files and directories"
+    },
+    "brave-search": {
+      "command": "npx -y @modelcontextprotocol/server-brave-search",
+      "env": {
+        "BRAVE_API_KEY": "your-brave-api-key-here"
+      },
+      "name": "Brave Search",
+      "description": "Search the web using Brave Search API"
+    },
+    "github": {
+      "command": "npx -y @modelcontextprotocol/server-github",
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "your-github-token-here"
+      },
+      "name": "GitHub Server",
+      "description": "Access GitHub repositories and issues"
+    },
+    "postgres": {
+      "command": "npx -y @modelcontextprotocol/server-postgres",
+      "env": {
+        "POSTGRES_CONNECTION_STRING": "postgresql://user:password@localhost:5432/database"
+      },
+      "name": "PostgreSQL Server",
+      "description": "Query PostgreSQL databases"
+    },
+    "sqlite": {
+      "command": "npx -y @modelcontextprotocol/server-sqlite",
+      "args": ["/path/to/database.db"],
+      "name": "SQLite Server", 
+      "description": "Query SQLite databases"
+    },
+    "custom-sse-server": {
+      "url": "http://localhost:8080/sse",
+      "name": "Custom SSE Server",
+      "description": "Custom MCP server using Server-Sent Events"
+    }
+  }
+}
+```
+
+## Server Types
+
+### Command-based Servers
+
+Most MCP servers run as separate processes:
+
+```json
+{
+  "your-server": {
+    "command": "npx -y @modelcontextprotocol/server-package",
+    "args": ["additional", "arguments"],
+    "env": {
+      "API_KEY": "your-api-key-here"
+    },
+    "name": "Server Name",
+    "description": "Server description"
+  }
+}
+```
+
+### URL-based Servers (SSE)
+
+For servers that use Server-Sent Events:
+
+```json
+{
+  "your-sse-server": {
+    "url": "http://localhost:8080/sse",
+    "name": "SSE Server",
+    "description": "Custom SSE-based server"
+  }
+}
+```
+
+## Available Official MCP Servers
+
+Here are some popular official MCP servers you can use:
+
+### Filesystem Access
+```bash
+npm install -g @modelcontextprotocol/server-filesystem
+```
+
+### Web Search (Brave)
+```bash
+npm install -g @modelcontextprotocol/server-brave-search
+```
+Requires: `BRAVE_API_KEY` environment variable
+
+### GitHub Integration
+```bash
+npm install -g @modelcontextprotocol/server-github
+```
+Requires: `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable
+
+### Database Access
+```bash
+# PostgreSQL
+npm install -g @modelcontextprotocol/server-postgres
+
+# SQLite
+npm install -g @modelcontextprotocol/server-sqlite
+```
+
+## Usage
+
+Once configured, MCP tools are automatically available to AI assistants alongside built-in notebook tools. Tools are named with the format `serverName:toolName`.
+
+### Example Usage
+
+1. **File Operations**: `filesystem:read_file`, `filesystem:write_file`
+2. **Web Search**: `brave-search:brave_web_search`
+3. **GitHub Operations**: `github:create_issue`, `github:get_repo`
+4. **Database Queries**: `postgres:query`, `sqlite:execute_query`
+
+## Implementation Details
+
+### Tool Discovery
+
+The system automatically:
+1. Reads configuration from `~/.anode/mcp.json`
+2. Connects to configured MCP servers
+3. Discovers available tools from each server
+4. Makes tools available to AI assistants
+
+### Tool Execution
+
+When an AI assistant calls an MCP tool:
+1. The tool name is parsed to extract server and tool names
+2. The appropriate MCP server is located
+3. The tool is executed with the provided arguments
+4. Results are returned to the AI assistant
+
+### Error Handling
+
+- Failed server connections are logged but don't prevent startup
+- Individual tool failures are reported to the AI assistant
+- The system gracefully degrades to built-in tools if MCP is unavailable
+
+## Security Considerations
+
+1. **Filesystem Access**: Only grant access to directories you trust
+2. **API Keys**: Store sensitive keys in environment variables
+3. **Network Access**: Be cautious with URL-based servers
+4. **Command Execution**: MCP servers run with your user permissions
+
+## Troubleshooting
+
+### Server Connection Issues
+
+Check server logs and ensure:
+- Required packages are installed globally
+- Environment variables are set correctly
+- File paths and permissions are correct
+
+#### Using Full Paths to Executables
+
+When using full paths in the `command` array, ensure:
+
+1. **File exists**: The executable file exists at the specified path
+2. **Permissions**: The file has execute permissions (`chmod +x /path/to/executable`)
+3. **Correct format**: Use proper string and args format:
+   ```json
+   {
+     "my-server": {
+       "command": "/usr/local/bin/my-mcp-server",
+       "args": ["--flag", "value"],
+       "name": "My Server"
+     }
+   }
+   ```
+
+#### Common Path Issues
+
+- **Permission denied**: Check file permissions with `ls -la /path/to/executable`
+- **File not found**: Verify the path exists with `which executable-name` or `ls /path/to/executable`
+- **Empty path**: Ensure the command string is not empty and contains a valid executable path
+
+### Tool Discovery Problems
+
+Verify:
+- Server configuration syntax in `mcp.json`
+- Server startup and connection success
+- Tool compatibility with MCP specification
+
+### Performance Considerations
+
+- MCP tools add latency compared to built-in tools
+- Network-based operations may be slower
+- Consider caching for frequently used operations
+
+## Examples
+
+The configuration section above provides a complete example with multiple server types and configurations covering filesystem access, web search, GitHub integration, database access, and custom SSE servers. 

--- a/packages/ai/MCP_INTEGRATION.md
+++ b/packages/ai/MCP_INTEGRATION.md
@@ -19,16 +19,16 @@ built-in notebook tools. These tools can include:
 
 ### 1. Create MCP Configuration File
 
-Create a configuration file at `~/.anode/mcp.json`:
+Create a configuration file at `~/.runt/mcp.json`:
 
 ```bash
-mkdir -p ~/.anode
-touch ~/.anode/mcp.json
+mkdir -p ~/.runt
+touch ~/.runt/mcp.json
 ```
 
 ### 2. Configure MCP Servers
 
-Edit `~/.anode/mcp.json` to configure your desired MCP servers. Here's a
+Edit `~/.runt/mcp.json` to configure your desired MCP servers. Here's a
 comprehensive example showing all supported server types:
 
 ```json
@@ -168,7 +168,7 @@ alongside built-in notebook tools. Tools are named with the format
 
 The system automatically:
 
-1. Reads configuration from `~/.anode/mcp.json`
+1. Reads configuration from `~/.runt/mcp.json`
 2. Connects to configured MCP servers
 3. Discovers available tools from each server
 4. Makes tools available to AI assistants

--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -15,10 +15,12 @@
     "@runt/schema": "jsr:@runt/schema@^0.6.3",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
+    "@std/path": "jsr:@std/path@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
     "@openai/openai": "jsr:@openai/openai@^4.98.0",
     "npm:ollama": "npm:ollama@^0.5.16",
-    "strip-ansi": "npm:strip-ansi@^7.1.0"
+    "strip-ansi": "npm:strip-ansi@^7.1.0",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1.0.5"
   },
   "tasks": {
     "check": "deno check mod.ts src/*.ts examples/*.ts",
@@ -30,6 +32,9 @@
       "mod.ts",
       "openai-client.ts",
       "ollama-client.ts",
+      "mcp-client.ts",
+      "mcp-config.example.json",
+      "MCP_INTEGRATION.md",
       "shared-types.ts",
       "tool-registry.ts",
       "media-utils.ts",

--- a/packages/ai/mcp-client.ts
+++ b/packages/ai/mcp-client.ts
@@ -1,0 +1,281 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { CallToolResultSchema, ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createLogger } from "@runt/lib";
+import { join } from "@std/path";
+
+const logger = createLogger("mcp-client");
+
+interface MCPServerConfig {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  name: string;
+  description?: string;
+}
+
+interface MCPConfig {
+  mcpServers: Record<string, MCPServerConfig>;
+}
+
+interface MCPTool {
+  name: string;
+  description: string;
+  parameters: {
+    type: string;
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+  serverName: string;
+}
+
+export class MCPClient {
+  private clients = new Map<string, Client>();
+  private tools: MCPTool[] = [];
+  private isInitialized = false;
+
+  async initialize(): Promise<void> {
+    if (this.isInitialized) {
+      return;
+    }
+
+    try {
+      const config = await this.loadConfig();
+      await this.connectToServers(config);
+      await this.discoverTools();
+      this.isInitialized = true;
+      logger.info(`MCP client initialized with ${this.tools.length} tools from ${this.clients.size} servers`);
+    } catch (error) {
+      logger.warn("Failed to initialize MCP client", { error: String(error) });
+      // Don't throw - allow the system to work without MCP
+    }
+  }
+
+  private async loadConfig(): Promise<MCPConfig> {
+    try {
+      const homeDir = Deno.env.get("HOME") || Deno.env.get("USERPROFILE") || "";
+      const configPath = join(homeDir, ".anode", "mcp.json");
+      
+      try {
+        const configText = await Deno.readTextFile(configPath);
+        const config = JSON.parse(configText) as MCPConfig;
+        
+        if (!config.mcpServers || typeof config.mcpServers !== "object") {
+          throw new Error("Invalid config: missing or invalid 'mcpServers' object");
+        }
+        
+        logger.info(`Loaded MCP config from ${configPath}`, {
+          serverCount: Object.keys(config.mcpServers).length,
+          servers: Object.keys(config.mcpServers)
+        });
+        
+        return config;
+      } catch (error) {
+        if (error instanceof Deno.errors.NotFound) {
+          logger.info(`MCP config file not found at ${configPath}, using empty configuration`);
+          return { mcpServers: {} };
+        }
+        throw error;
+      }
+    } catch (error) {
+      logger.error("Error loading MCP config", error);
+      return { mcpServers: {} };
+    }
+  }
+
+  private async connectToServers(config: MCPConfig): Promise<void> {
+    const connectionPromises = Object.entries(config.mcpServers).map(
+      async ([serverName, serverConfig]) => {
+        try {
+          await this.connectToServer(serverName, serverConfig);
+        } catch (error) {
+          logger.error(`Failed to connect to MCP server ${serverName}`, error);
+        }
+      }
+    );
+
+    await Promise.allSettled(connectionPromises);
+  }
+
+  private async connectToServer(serverName: string, config: MCPServerConfig): Promise<void> {
+    logger.info(`Connecting to MCP server: ${serverName}`, {
+      hasCommand: !!config.command,
+      hasUrl: !!config.url,
+    });
+
+    let transport;
+    let client;
+
+    try {
+      if (config.command) {
+        // Stdio transport for command-based servers
+        // Parse the command string into command and arguments
+        const commandParts = config.command.split(' ');
+        const command = commandParts[0];
+        const commandArgs = commandParts.slice(1);
+        
+        transport = new StdioClientTransport({
+          command: command,
+          args: commandArgs.concat(config.args || []),
+          env: config.env || {},
+        });
+      } else if (config.url) {
+        // SSE transport for URL-based servers
+        transport = new SSEClientTransport(new URL(config.url));
+      } else {
+        throw new Error(`Server ${serverName} must specify either 'command' or 'url'`);
+      }
+
+      client = new Client(
+        {
+          name: "anode-ai",
+          version: "1.0.0",
+        },
+        {
+          capabilities: {
+            tools: {},
+          },
+        }
+      );
+
+      await client.connect(transport);
+      this.clients.set(serverName, client);
+      
+      logger.info(`Successfully connected to MCP server: ${serverName}`);
+    } catch (error) {
+      logger.error(`Failed to connect to MCP server ${serverName}`, error);
+      if (transport) {
+        try {
+          await transport.close();
+        } catch (closeError) {
+          logger.debug(`Error closing transport for ${serverName}`, { error: String(closeError) });
+        }
+      }
+      throw error;
+    }
+  }
+
+  private async discoverTools(): Promise<void> {
+    this.tools = [];
+
+    const discoveryPromises = Array.from(this.clients.entries()).map(
+      async ([serverName, client]) => {
+        try {
+          const response = await client.listTools();
+          const tools = ListToolsResultSchema.parse(response).tools;
+          
+          for (const tool of tools) {
+            this.tools.push({
+              name: `mcp__${serverName}__${tool.name}`,
+              description: tool.description || `Tool from ${serverName}`,
+              parameters: tool.inputSchema as {
+                type: string;
+                properties: Record<string, unknown>;
+                required?: string[];
+              },
+              serverName,
+            });
+          }
+          
+          logger.info(`Discovered ${tools.length} tools from server ${serverName}`, {
+            tools: tools.map(t => t.name)
+          });
+        } catch (error) {
+          logger.error(`Failed to discover tools from server ${serverName}`, error);
+        }
+      }
+    );
+
+    await Promise.allSettled(discoveryPromises);
+  }
+
+  getTools(): MCPTool[] {
+    return [...this.tools];
+  }
+
+  async callTool(toolName: string, args: Record<string, unknown>): Promise<string> {
+    if (!this.isInitialized) {
+      throw new Error("MCP client not initialized");
+    }
+
+    // Parse server name and tool name
+    const colonIndex = toolName.indexOf(":");
+    if (colonIndex === -1) {
+      throw new Error(`Invalid MCP tool name format: ${toolName}. Expected format: serverName:toolName`);
+    }
+
+    const serverName = toolName.substring(0, colonIndex);
+    const actualToolName = toolName.substring(colonIndex + 1);
+
+    const client = this.clients.get(serverName);
+    if (!client) {
+      throw new Error(`MCP server not found: ${serverName}`);
+    }
+
+    try {
+      logger.info(`Calling MCP tool ${actualToolName} on server ${serverName}`, { args });
+
+      const response = await client.callTool({
+        name: actualToolName,
+        arguments: args,
+      });
+
+      const result = CallToolResultSchema.parse(response);
+      
+      // Process the tool result content
+      if (result.content && result.content.length > 0) {
+        const content = result.content[0];
+        if (content.type === "text") {
+          return content.text;
+        } else if (content.type === "image") {
+          return `[Image result from ${toolName}]`;
+        } else if (content.type === "resource") {
+          return `[Resource result from ${toolName}: ${content.resource?.uri || "unknown"}]`;
+        }
+      }
+
+      return `Tool ${toolName} executed successfully`;
+    } catch (error) {
+      logger.error(`Error calling MCP tool ${toolName}`, error);
+      throw new Error(`MCP tool call failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  async close(): Promise<void> {
+    const closePromises = Array.from(this.clients.values()).map(
+      async (client) => {
+        try {
+          await client.close();
+        } catch (error) {
+          logger.debug("Error closing MCP client", { error: String(error) });
+        }
+      }
+    );
+
+    await Promise.allSettled(closePromises);
+    this.clients.clear();
+    this.tools = [];
+    this.isInitialized = false;
+    logger.info("MCP client closed");
+  }
+}
+
+// Global MCP client instance
+let mcpClient: MCPClient | null = null;
+
+export async function getMCPClient(): Promise<MCPClient> {
+  if (!mcpClient) {
+    mcpClient = new MCPClient();
+    await mcpClient.initialize();
+  }
+  return mcpClient;
+}
+
+export async function closeMCPClient(): Promise<void> {
+  if (mcpClient) {
+    await mcpClient.close();
+    mcpClient = null;
+  }
+} 

--- a/packages/ai/mcp-client.ts
+++ b/packages/ai/mcp-client.ts
@@ -61,7 +61,7 @@ export class MCPClient {
   private async loadConfig(): Promise<MCPConfig> {
     try {
       const homeDir = Deno.env.get("HOME") || Deno.env.get("USERPROFILE") || "";
-      const configPath = join(homeDir, ".anode", "mcp.json");
+      const configPath = join(homeDir, ".runt", "mcp.json");
 
       try {
         const configText = await Deno.readTextFile(configPath);

--- a/packages/ai/mcp-client.ts
+++ b/packages/ai/mcp-client.ts
@@ -1,7 +1,10 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import { CallToolResultSchema, ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { createLogger } from "@runt/lib";
 import { join } from "@std/path";
 
@@ -46,7 +49,9 @@ export class MCPClient {
       await this.connectToServers(config);
       await this.discoverTools();
       this.isInitialized = true;
-      logger.info(`MCP client initialized with ${this.tools.length} tools from ${this.clients.size} servers`);
+      logger.info(
+        `MCP client initialized with ${this.tools.length} tools from ${this.clients.size} servers`,
+      );
     } catch (error) {
       logger.warn("Failed to initialize MCP client", { error: String(error) });
       // Don't throw - allow the system to work without MCP
@@ -57,24 +62,28 @@ export class MCPClient {
     try {
       const homeDir = Deno.env.get("HOME") || Deno.env.get("USERPROFILE") || "";
       const configPath = join(homeDir, ".anode", "mcp.json");
-      
+
       try {
         const configText = await Deno.readTextFile(configPath);
         const config = JSON.parse(configText) as MCPConfig;
-        
+
         if (!config.mcpServers || typeof config.mcpServers !== "object") {
-          throw new Error("Invalid config: missing or invalid 'mcpServers' object");
+          throw new Error(
+            "Invalid config: missing or invalid 'mcpServers' object",
+          );
         }
-        
+
         logger.info(`Loaded MCP config from ${configPath}`, {
           serverCount: Object.keys(config.mcpServers).length,
-          servers: Object.keys(config.mcpServers)
+          servers: Object.keys(config.mcpServers),
         });
-        
+
         return config;
       } catch (error) {
         if (error instanceof Deno.errors.NotFound) {
-          logger.info(`MCP config file not found at ${configPath}, using empty configuration`);
+          logger.info(
+            `MCP config file not found at ${configPath}, using empty configuration`,
+          );
           return { mcpServers: {} };
         }
         throw error;
@@ -93,13 +102,16 @@ export class MCPClient {
         } catch (error) {
           logger.error(`Failed to connect to MCP server ${serverName}`, error);
         }
-      }
+      },
     );
 
     await Promise.allSettled(connectionPromises);
   }
 
-  private async connectToServer(serverName: string, config: MCPServerConfig): Promise<void> {
+  private async connectToServer(
+    serverName: string,
+    config: MCPServerConfig,
+  ): Promise<void> {
     logger.info(`Connecting to MCP server: ${serverName}`, {
       hasCommand: !!config.command,
       hasUrl: !!config.url,
@@ -112,10 +124,13 @@ export class MCPClient {
       if (config.command) {
         // Stdio transport for command-based servers
         // Parse the command string into command and arguments
-        const commandParts = config.command.split(' ');
+        const commandParts = config.command.split(" ");
         const command = commandParts[0];
+        if (!command) {
+          throw new Error(`Invalid command specified for server ${serverName}`);
+        }
         const commandArgs = commandParts.slice(1);
-        
+
         transport = new StdioClientTransport({
           command: command,
           args: commandArgs.concat(config.args || []),
@@ -125,7 +140,9 @@ export class MCPClient {
         // SSE transport for URL-based servers
         transport = new SSEClientTransport(new URL(config.url));
       } else {
-        throw new Error(`Server ${serverName} must specify either 'command' or 'url'`);
+        throw new Error(
+          `Server ${serverName} must specify either 'command' or 'url'`,
+        );
       }
 
       client = new Client(
@@ -137,12 +154,12 @@ export class MCPClient {
           capabilities: {
             tools: {},
           },
-        }
+        },
       );
 
       await client.connect(transport);
       this.clients.set(serverName, client);
-      
+
       logger.info(`Successfully connected to MCP server: ${serverName}`);
     } catch (error) {
       logger.error(`Failed to connect to MCP server ${serverName}`, error);
@@ -150,7 +167,9 @@ export class MCPClient {
         try {
           await transport.close();
         } catch (closeError) {
-          logger.debug(`Error closing transport for ${serverName}`, { error: String(closeError) });
+          logger.debug(`Error closing transport for ${serverName}`, {
+            error: String(closeError),
+          });
         }
       }
       throw error;
@@ -165,7 +184,7 @@ export class MCPClient {
         try {
           const response = await client.listTools();
           const tools = ListToolsResultSchema.parse(response).tools;
-          
+
           for (const tool of tools) {
             this.tools.push({
               name: `mcp__${serverName}__${tool.name}`,
@@ -178,14 +197,20 @@ export class MCPClient {
               serverName,
             });
           }
-          
-          logger.info(`Discovered ${tools.length} tools from server ${serverName}`, {
-            tools: tools.map(t => t.name)
-          });
+
+          logger.info(
+            `Discovered ${tools.length} tools from server ${serverName}`,
+            {
+              tools: tools.map((t) => t.name),
+            },
+          );
         } catch (error) {
-          logger.error(`Failed to discover tools from server ${serverName}`, error);
+          logger.error(
+            `Failed to discover tools from server ${serverName}`,
+            error,
+          );
         }
-      }
+      },
     );
 
     await Promise.allSettled(discoveryPromises);
@@ -195,7 +220,10 @@ export class MCPClient {
     return [...this.tools];
   }
 
-  async callTool(toolName: string, args: Record<string, unknown>): Promise<string> {
+  async callTool(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<string> {
     if (!this.isInitialized) {
       throw new Error("MCP client not initialized");
     }
@@ -203,7 +231,9 @@ export class MCPClient {
     // Parse server name and tool name
     const colonIndex = toolName.indexOf(":");
     if (colonIndex === -1) {
-      throw new Error(`Invalid MCP tool name format: ${toolName}. Expected format: serverName:toolName`);
+      throw new Error(
+        `Invalid MCP tool name format: ${toolName}. Expected format: serverName:toolName`,
+      );
     }
 
     const serverName = toolName.substring(0, colonIndex);
@@ -215,7 +245,10 @@ export class MCPClient {
     }
 
     try {
-      logger.info(`Calling MCP tool ${actualToolName} on server ${serverName}`, { args });
+      logger.info(
+        `Calling MCP tool ${actualToolName} on server ${serverName}`,
+        { args },
+      );
 
       const response = await client.callTool({
         name: actualToolName,
@@ -223,23 +256,34 @@ export class MCPClient {
       });
 
       const result = CallToolResultSchema.parse(response);
-      
+
       // Process the tool result content
       if (result.content && result.content.length > 0) {
         const content = result.content[0];
+        if (!content) {
+          return `Tool ${toolName} executed successfully`;
+        }
         if (content.type === "text") {
-          return content.text;
+          return (content as { text: string }).text;
         } else if (content.type === "image") {
           return `[Image result from ${toolName}]`;
         } else if (content.type === "resource") {
-          return `[Resource result from ${toolName}: ${content.resource?.uri || "unknown"}]`;
+          const resource =
+            (content as { resource?: { uri?: string } }).resource;
+          return `[Resource result from ${toolName}: ${
+            resource?.uri || "unknown"
+          }]`;
         }
       }
 
       return `Tool ${toolName} executed successfully`;
     } catch (error) {
       logger.error(`Error calling MCP tool ${toolName}`, error);
-      throw new Error(`MCP tool call failed: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `MCP tool call failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
 
@@ -251,7 +295,7 @@ export class MCPClient {
         } catch (error) {
           logger.debug("Error closing MCP client", { error: String(error) });
         }
-      }
+      },
     );
 
     await Promise.allSettled(closePromises);
@@ -278,4 +322,4 @@ export async function closeMCPClient(): Promise<void> {
     await mcpClient.close();
     mcpClient = null;
   }
-} 
+}

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -407,7 +407,7 @@ const getDefaultModel = (provider: string): string => {
  */
 // Export the AI clients and MCP client for external use
 export { OpenAIClient, RuntOllamaClient };
-export { MCPClient, getMCPClient, closeMCPClient } from "./mcp-client.ts";
+export { closeMCPClient, getMCPClient, MCPClient } from "./mcp-client.ts";
 export { getAllTools } from "./tool-registry.ts";
 
 /**

--- a/packages/ai/mod.ts
+++ b/packages/ai/mod.ts
@@ -396,8 +396,10 @@ const getDefaultModel = (provider: string): string => {
 /**
  * Execute AI prompts using OpenAI, Ollama, or other providers
  */
-// Export the AI clients for external use
+// Export the AI clients and MCP client for external use
 export { OpenAIClient, RuntOllamaClient };
+export { MCPClient, getMCPClient, closeMCPClient } from "./mcp-client.ts";
+export { getAllTools } from "./tool-registry.ts";
 
 /**
  * Discover available AI models from all configured providers

--- a/packages/ai/ollama-client.ts
+++ b/packages/ai/ollama-client.ts
@@ -5,7 +5,7 @@ import { createLogger, type ExecutionContext } from "@runt/lib";
 
 import { AI_TOOL_CALL_MIME_TYPE, AI_TOOL_RESULT_MIME_TYPE } from "@runt/schema";
 
-import { NOTEBOOK_TOOLS } from "./tool-registry.ts";
+import { getAllTools } from "./tool-registry.ts";
 import {
   type AgenticOptions,
   type AnodeCellMetadata,
@@ -321,6 +321,9 @@ export class RuntOllamaClient {
       return;
     }
 
+    // Get all available tools (notebook + MCP) at the start
+    const allTools = enableTools ? await getAllTools() : [];
+
     const conversationMessages: OllamaChatMessage[] = messages;
     let iteration = 0;
 
@@ -349,8 +352,8 @@ export class RuntOllamaClient {
         this.logger.info(`Agentic iteration ${iteration + 1}/${maxIterations}`);
 
         // Prepare tools if enabled
-        const tools: Tool[] | undefined = enableTools
-          ? NOTEBOOK_TOOLS.map((tool) => ({
+        const tools: Tool[] | undefined = enableTools && allTools.length > 0
+          ? allTools.map((tool) => ({
             type: "function",
             function: {
               name: tool.name,

--- a/packages/ai/openai-client.ts
+++ b/packages/ai/openai-client.ts
@@ -7,7 +7,7 @@ import {
 } from "@runt/lib";
 import { AI_TOOL_CALL_MIME_TYPE, AI_TOOL_RESULT_MIME_TYPE } from "@runt/schema";
 
-import { NOTEBOOK_TOOLS } from "./tool-registry.ts";
+import { getAllTools } from "./tool-registry.ts";
 
 // Define message types inline to avoid import issues
 type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
@@ -328,6 +328,9 @@ export class RuntOpenAIClient {
       return;
     }
 
+    // Get all available tools (notebook + MCP) at the start
+    const allTools = enableTools ? await getAllTools() : [];
+
     const conversationMessages: ChatMessage[] = messages;
 
     let iteration = 0;
@@ -357,8 +360,8 @@ export class RuntOpenAIClient {
         this.logger.info(`Agentic iteration ${iteration + 1}/${maxIterations}`);
 
         // Prepare tools if enabled
-        const tools = enableTools
-          ? NOTEBOOK_TOOLS.map((tool) => ({
+        const tools = enableTools && allTools.length > 0
+          ? allTools.map((tool) => ({
             type: "function" as const,
             function: {
               name: tool.name,

--- a/packages/ai/openai-client.ts
+++ b/packages/ai/openai-client.ts
@@ -331,8 +331,6 @@ export class RuntOpenAIClient {
       return;
     }
 
-
-
     const conversationMessages: ChatMessage[] = messages;
 
     let iteration = 0;
@@ -371,7 +369,7 @@ export class RuntOpenAIClient {
             all_tools = [...this.notebookTools, ...all_tools];
           }
         }
-        
+
         const tools = enableTools && all_tools.length > 0
           ? all_tools.map((tool) => ({
             type: "function" as const,

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -1,6 +1,7 @@
 import { type CellData, events, type Store, tables } from "@runt/schema";
 import type { Logger } from "@runt/lib";
 import { createLogger } from "@runt/lib";
+import { getMCPClient } from "./mcp-client.ts";
 
 // Create logger for tool execution debugging
 const toolLogger = createLogger("ai-tools");
@@ -23,7 +24,7 @@ interface ToolParameter {
 }
 
 // Define available notebook tools
-export const NOTEBOOK_TOOLS: NotebookTool[] = [
+const NOTEBOOK_TOOLS: NotebookTool[] = [
   {
     name: "create_cell",
     description:
@@ -88,6 +89,47 @@ export const NOTEBOOK_TOOLS: NotebookTool[] = [
     },
   },
 ];
+
+/**
+ * Get all available tools including both notebook tools and MCP tools
+ */
+export async function getAllTools(): Promise<NotebookTool[]> {
+  try {
+    const mcpClient = await getMCPClient();
+    const mcpTools = mcpClient.getTools();
+    
+    // Convert MCP tools to notebook tool format
+    const convertedMcpTools: NotebookTool[] = mcpTools.map((mcpTool) => ({
+      name: mcpTool.name,
+      description: mcpTool.description,
+      parameters: {
+        type: mcpTool.parameters.type,
+        properties: Object.fromEntries(
+          Object.entries(mcpTool.parameters.properties || {}).map(([key, value]) => [
+            key,
+            {
+              type: (value as Record<string, unknown>)?.type as string || "string",
+              description: (value as Record<string, unknown>)?.description as string,
+              enum: (value as Record<string, unknown>)?.enum as string[],
+              default: (value as Record<string, unknown>)?.default as string,
+            } as ToolParameter
+          ])
+        ),
+        required: mcpTool.parameters.required || [],
+      },
+    }));
+    
+    return [...NOTEBOOK_TOOLS, ...convertedMcpTools];
+  } catch (error) {
+    toolLogger.warn("Failed to get MCP tools, using only notebook tools", { error: String(error) });
+    return [...NOTEBOOK_TOOLS];
+  }
+}
+
+/**
+ * Get only the notebook tools (for backward compatibility)
+ */
+export const NOTEBOOK_TOOLS_EXPORT = NOTEBOOK_TOOLS;
 
 function calculateNewCellPosition(
   store: Store,
@@ -185,6 +227,29 @@ export async function handleToolCallWithResult(
 ): Promise<string> {
   const { name, arguments: args } = toolCall;
 
+  // Handle MCP tools first (with mcp__ prefix)
+  if (name.startsWith("mcp__")) {
+    try {
+      // Transform name from mcp__<servername>__<toolname> to <servername>:<toolname>
+      const transformedName = name.slice(5).replace('__', ':'); // Remove 'mcp__' prefix and replace first '__' with ':'
+
+      logger.info("Calling MCP tool", { toolName: name, transformedName, args });
+      const mcpClient = await getMCPClient();
+      const result = await mcpClient.callTool(transformedName, args);
+      
+      logger.info("MCP tool executed successfully", {
+        toolName: name,
+        resultLength: result.length,
+      });
+      
+      return result;
+    } catch (error) {
+      logger.error("MCP tool execution failed", { toolName: name, error });
+      throw new Error(`MCP tool execution failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  // Handle built-in notebook tools
   switch (name) {
     case "create_cell": {
       return createCell(store, logger, sessionId, currentCell, args);

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -233,6 +233,94 @@ export async function handleToolCallWithResult(
 ): Promise<string> {
   const { name, arguments: args } = toolCall;
 
+  // Check if tool requires approval - all tools require approval
+  const requiresApproval = true;
+  
+  if (requiresApproval) {
+    // Check if we already have an approval for this specific tool call
+    let existingApproval = store.query(
+      tables.toolApprovals.select().where({ toolCallId: toolCall.id }),
+    )[0];
+
+    // If no specific approval, check for a blanket "always" approval for this tool
+    if (!existingApproval) {
+      const alwaysApprovals = store.query(
+        tables.toolApprovals.select().where({ 
+          toolName: name, 
+          status: "approved_always" 
+        }),
+      );
+      
+      if (alwaysApprovals.length > 0) {
+        // Use the blanket approval
+        existingApproval = alwaysApprovals[0];
+      }
+    }
+
+    if (!existingApproval || existingApproval.status === "pending") {
+      // Request approval if we don't have one
+      if (!existingApproval) {
+        logger.info("Requesting tool approval", { toolName: name, toolCallId: toolCall.id });
+        
+        store.commit(
+          events.toolApprovalRequested({
+            toolCallId: toolCall.id,
+            cellId: currentCell.id,
+            toolName: name,
+            arguments: args,
+            requestedAt: new Date(),
+          }),
+        );
+      }
+
+      // Wait for approval with polling
+      const approvalPromise = new Promise<string>((resolve, reject) => {
+        const cleanup = () => {
+          if (timeout) clearTimeout(timeout);
+          if (pollInterval) clearInterval(pollInterval);
+        };
+
+        const timeout = setTimeout(() => {
+          cleanup();
+          reject(new Error(`Tool approval timeout after 60 seconds for ${name}`));
+        }, 60000); // 60 second timeout
+
+        // Poll for approval status
+        const pollInterval = setInterval(() => {
+          const approval = store.query(
+            tables.toolApprovals.select().where({ toolCallId: toolCall.id }),
+          )[0];
+
+          if (approval && approval.status !== "pending") {
+            cleanup();
+
+            if (approval.status === "denied") {
+              reject(new Error(`Tool call denied by user: ${name}`));
+              return;
+            }
+
+            if (approval.status === "approved_once" || approval.status === "approved_always") {
+              resolve("approved");
+              return;
+            }
+          }
+        }, 500); // Poll every 500ms
+      });
+
+      try {
+        await approvalPromise;
+      } catch (error) {
+        logger.error("Tool approval failed", { toolName: name, error });
+        throw error;
+      }
+    } else if (existingApproval.status === "denied") {
+      logger.warn("Tool call denied by previous approval", { toolName: name });
+      throw new Error(`Tool call denied: ${name}`);
+    }
+
+    logger.info("Tool approved, proceeding with execution", { toolName: name });
+  }
+
   // Handle MCP tools first (with mcp__ prefix)
   if (name.startsWith("mcp__")) {
     try {

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -103,7 +103,7 @@ export async function getAllTools(): Promise<NotebookTool[]> {
   try {
     const mcpClient = await getMCPClient();
     const mcpTools = mcpClient.getTools();
-    
+
     // Convert MCP tools to notebook tool format
     const convertedMcpTools: NotebookTool[] = mcpTools.map((mcpTool) => ({
       name: mcpTool.name,
@@ -111,23 +111,29 @@ export async function getAllTools(): Promise<NotebookTool[]> {
       parameters: {
         type: mcpTool.parameters.type,
         properties: Object.fromEntries(
-          Object.entries(mcpTool.parameters.properties || {}).map(([key, value]) => [
+          Object.entries(mcpTool.parameters.properties || {}).map((
+            [key, value],
+          ) => [
             key,
             {
-              type: (value as Record<string, unknown>)?.type as string || "string",
-              description: (value as Record<string, unknown>)?.description as string,
+              type: (value as Record<string, unknown>)?.type as string ||
+                "string",
+              description: (value as Record<string, unknown>)
+                ?.description as string,
               enum: (value as Record<string, unknown>)?.enum as string[],
               default: (value as Record<string, unknown>)?.default as string,
-            } as ToolParameter
-          ])
+            } as ToolParameter,
+          ]),
         ),
         required: mcpTool.parameters.required || [],
       },
     }));
-    
+
     return [...NOTEBOOK_TOOLS, ...convertedMcpTools];
   } catch (error) {
-    toolLogger.warn("Failed to get MCP tools, using only notebook tools", { error: String(error) });
+    toolLogger.warn("Failed to get MCP tools, using only notebook tools", {
+      error: String(error),
+    });
     return [...NOTEBOOK_TOOLS];
   }
 }
@@ -236,7 +242,7 @@ export async function handleToolCallWithResult(
 
   // Check if tool requires approval - all tools require approval
   const requiresApproval = true;
-  
+
   if (requiresApproval) {
     // Check if we already have an approval for this specific tool call
     let existingApproval = store.query(
@@ -246,12 +252,12 @@ export async function handleToolCallWithResult(
     // If no specific approval, check for a blanket "always" approval for this tool
     if (!existingApproval) {
       const alwaysApprovals = store.query(
-        tables.toolApprovals.select().where({ 
-          toolName: name, 
-          status: "approved_always" 
+        tables.toolApprovals.select().where({
+          toolName: name,
+          status: "approved_always",
         }),
       );
-      
+
       if (alwaysApprovals.length > 0) {
         // Use the blanket approval
         existingApproval = alwaysApprovals[0];
@@ -261,8 +267,11 @@ export async function handleToolCallWithResult(
     if (!existingApproval || existingApproval.status === "pending") {
       // Request approval if we don't have one
       if (!existingApproval) {
-        logger.info("Requesting tool approval", { toolName: name, toolCallId: toolCall.id });
-        
+        logger.info("Requesting tool approval", {
+          toolName: name,
+          toolCallId: toolCall.id,
+        });
+
         store.commit(
           events.toolApprovalRequested({
             toolCallId: toolCall.id,
@@ -283,7 +292,9 @@ export async function handleToolCallWithResult(
 
         const timeout = setTimeout(() => {
           cleanup();
-          reject(new Error(`Tool approval timeout after 60 seconds for ${name}`));
+          reject(
+            new Error(`Tool approval timeout after 60 seconds for ${name}`),
+          );
         }, 60000); // 60 second timeout
 
         // Poll for approval status
@@ -300,7 +311,10 @@ export async function handleToolCallWithResult(
               return;
             }
 
-            if (approval.status === "approved_once" || approval.status === "approved_always") {
+            if (
+              approval.status === "approved_once" ||
+              approval.status === "approved_always"
+            ) {
               resolve("approved");
               return;
             }
@@ -326,21 +340,29 @@ export async function handleToolCallWithResult(
   if (name.startsWith("mcp__")) {
     try {
       // Transform name from mcp__<servername>__<toolname> to <servername>:<toolname>
-      const transformedName = name.slice(5).replace('__', ':'); // Remove 'mcp__' prefix and replace first '__' with ':'
+      const transformedName = name.slice(5).replace("__", ":"); // Remove 'mcp__' prefix and replace first '__' with ':'
 
-      logger.info("Calling MCP tool", { toolName: name, transformedName, args });
+      logger.info("Calling MCP tool", {
+        toolName: name,
+        transformedName,
+        args,
+      });
       const mcpClient = await getMCPClient();
       const result = await mcpClient.callTool(transformedName, args);
-      
+
       logger.info("MCP tool executed successfully", {
         toolName: name,
         resultLength: result.length,
       });
-      
+
       return result;
     } catch (error) {
       logger.error("MCP tool execution failed", { toolName: name, error });
-      throw new Error(`MCP tool execution failed: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `MCP tool execution failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     }
   }
 

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -358,6 +358,22 @@ export const tables = {
       avatar: State.SQLite.text({ nullable: true }),
     },
   }),
+
+  // Tool approvals for AI tool calls
+  toolApprovals: State.SQLite.table({
+    name: "toolApprovals",
+    columns: {
+      toolCallId: State.SQLite.text({ primaryKey: true }),
+      cellId: State.SQLite.text(),
+      toolName: State.SQLite.text(),
+      status: State.SQLite.text({
+        schema: Schema.Literal("pending", "approved_once", "approved_always", "denied"),
+      }),
+      approvedBy: State.SQLite.text({ nullable: true }),
+      requestedAt: State.SQLite.datetime(),
+      respondedAt: State.SQLite.datetime({ nullable: true }),
+    },
+  }),
 };
 
 // Events describe notebook and cell changes
@@ -702,6 +718,28 @@ export const events = {
       type: Schema.Literal("human", "runtime_agent"),
       displayName: Schema.String,
       avatar: Schema.optional(Schema.String),
+    }),
+  }),
+
+  // Tool approval events
+  toolApprovalRequested: Events.synced({
+    name: "v1.ToolApprovalRequested",
+    schema: Schema.Struct({
+      toolCallId: Schema.String,
+      cellId: Schema.String,
+      toolName: Schema.String,
+      arguments: Schema.Record({ key: Schema.String, value: Schema.Any }),
+      requestedAt: Schema.Date,
+    }),
+  }),
+
+  toolApprovalResponded: Events.synced({
+    name: "v1.ToolApprovalResponded",
+    schema: Schema.Struct({
+      toolCallId: Schema.String,
+      status: Schema.Literal("approved_once", "approved_always", "denied"),
+      approvedBy: Schema.String,
+      respondedAt: Schema.Date,
     }),
   }),
 };
@@ -1343,6 +1381,29 @@ export const materializers = State.SQLite.materializers(events, {
         avatar: avatar ?? null,
       })
       .onConflict("id", "replace"),
+
+  // Tool approval materializers
+  "v1.ToolApprovalRequested": ({ toolCallId, cellId, toolName, arguments: args, requestedAt }) =>
+    tables.toolApprovals
+      .insert({
+        toolCallId,
+        cellId,
+        toolName,
+        status: "pending",
+        approvedBy: null,
+        requestedAt,
+        respondedAt: null,
+      })
+      .onConflict("toolCallId", "replace"),
+
+  "v1.ToolApprovalResponded": ({ toolCallId, status, approvedBy, respondedAt }) =>
+    tables.toolApprovals
+      .update({
+        status,
+        approvedBy,
+        respondedAt,
+      })
+      .where({ toolCallId }),
 });
 
 // Type exports derived from the actual table definitions - full type inference works here!

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -367,7 +367,12 @@ export const tables = {
       cellId: State.SQLite.text(),
       toolName: State.SQLite.text(),
       status: State.SQLite.text({
-        schema: Schema.Literal("pending", "approved_once", "approved_always", "denied"),
+        schema: Schema.Literal(
+          "pending",
+          "approved_once",
+          "approved_always",
+          "denied",
+        ),
       }),
       approvedBy: State.SQLite.text({ nullable: true }),
       requestedAt: State.SQLite.datetime(),
@@ -1383,7 +1388,9 @@ export const materializers = State.SQLite.materializers(events, {
       .onConflict("id", "replace"),
 
   // Tool approval materializers
-  "v1.ToolApprovalRequested": ({ toolCallId, cellId, toolName, arguments: args, requestedAt }) =>
+  "v1.ToolApprovalRequested": (
+    { toolCallId, cellId, toolName, arguments: _args, requestedAt },
+  ) =>
     tables.toolApprovals
       .insert({
         toolCallId,
@@ -1396,7 +1403,9 @@ export const materializers = State.SQLite.materializers(events, {
       })
       .onConflict("toolCallId", "replace"),
 
-  "v1.ToolApprovalResponded": ({ toolCallId, status, approvedBy, respondedAt }) =>
+  "v1.ToolApprovalResponded": (
+    { toolCallId, status, approvedBy, respondedAt },
+  ) =>
     tables.toolApprovals
       .update({
         status,


### PR DESCRIPTION
This adds an MCP client (config at `~/.anode/mcp.json`) and adds events and materializers for full tool approval flow for all tools (builtin-in, notebook-defined, and MCP).

See: https://github.com/runtimed/anode/pull/259