### PR TITLE
Fix TUI exports for easier CLI usage

### DIFF
--- a/packages/tui/deno.json
+++ b/packages/tui/deno.json
@@ -3,7 +3,13 @@
   "version": "0.8.0",
   "description": "Terminal notebook viewer for Runt runtime agents",
   "license": "BSD-3-Clause",
-  "exports": "./mod.ts",
+  "exports": {
+    ".": "./mod.ts",
+    "./cli": "./src/cli.tsx"
+  },
+  "bin": {
+    "runt-tui": "./src/cli.tsx"
+  },
   "tasks": {
     "dev": "deno run --allow-net --allow-env --allow-read --allow-write --allow-sys --quiet src/cli.tsx",
     "test": "deno test --allow-env --allow-net --allow-read --allow-write --allow-sys",

--- a/packages/tui/deno.json
+++ b/packages/tui/deno.json
@@ -4,8 +4,8 @@
   "description": "Terminal notebook viewer for Runt runtime agents",
   "license": "BSD-3-Clause",
   "exports": {
-    ".": "./mod.ts",
-    "./cli": "./src/cli.tsx"
+    ".": "./src/cli.tsx",
+    "./mod": "./mod.ts"
   },
   "bin": {
     "runt-tui": "./src/cli.tsx"


### PR DESCRIPTION
Makes CLI the default export for much better UX.

Before: Only exported library components, CLI inaccessible 
After: CLI is default export, library components at ./mod

Primary usage now just works:
- jsr:@runt/tui runs CLI directly
- deno install jsr:@runt/tui for global executable  
- Library users can import from jsr:@runt/tui/mod