### PR TITLE
Artifacts!

### DIFF
--- a/packages/ai/media-utils.ts
+++ b/packages/ai/media-utils.ts
@@ -6,7 +6,11 @@
  * the flexibility to extend with custom AI-specific transformations.
  */
 
-import { IMAGE_MIME_TYPES, type MediaContainer } from "@runt/schema";
+import {
+  IMAGE_MIME_TYPES,
+  isImageMimeType,
+  type MediaContainer,
+} from "@runt/schema";
 
 /**
  * Media bundle interface for AI processing
@@ -138,7 +142,7 @@ export function ensureTextPlainFallback(bundle: AIMediaBundle): AIMediaBundle {
     const firstStringValue = Object.entries(result).find(
       ([mimeType, value]) => {
         // Skip image mime types to avoid using base64 data as text
-        if (IMAGE_MIME_TYPES.includes(mimeType)) {
+        if (isImageMimeType(mimeType)) {
           return false;
         }
         return typeof value === "string";
@@ -150,7 +154,7 @@ export function ensureTextPlainFallback(bundle: AIMediaBundle): AIMediaBundle {
     } else {
       // Last resort: JSON stringify first available non-image content
       const firstNonImageEntry = Object.entries(result).find(
-        ([mimeType]) => !IMAGE_MIME_TYPES.includes(mimeType),
+        ([mimeType]) => !isImageMimeType(mimeType),
       );
       if (firstNonImageEntry && firstNonImageEntry[1] != null) {
         try {

--- a/packages/ai/media-utils.ts
+++ b/packages/ai/media-utils.ts
@@ -134,20 +134,29 @@ export function ensureTextPlainFallback(bundle: AIMediaBundle): AIMediaBundle {
     // Markdown is readable as plain text
     result["text/plain"] = result["text/markdown"];
   } else {
-    // Use first available string content
-    const firstStringValue = Object.values(result).find(
-      (value): value is string => typeof value === "string",
-    );
+    // Use first available string content, but skip image mime types
+    const firstStringValue = Object.entries(result).find(
+      ([mimeType, value]) => {
+        // Skip image mime types to avoid using base64 data as text
+        if (IMAGE_MIME_TYPES.includes(mimeType)) {
+          return false;
+        }
+        return typeof value === "string";
+      },
+    )?.[1] as string | undefined;
+
     if (firstStringValue) {
       result["text/plain"] = firstStringValue;
     } else {
-      // Last resort: JSON stringify first available content
-      const firstEntry = Object.entries(result)[0];
-      if (firstEntry && firstEntry[1] != null) {
+      // Last resort: JSON stringify first available non-image content
+      const firstNonImageEntry = Object.entries(result).find(
+        ([mimeType]) => !IMAGE_MIME_TYPES.includes(mimeType),
+      );
+      if (firstNonImageEntry && firstNonImageEntry[1] != null) {
         try {
-          result["text/plain"] = JSON.stringify(firstEntry[1], null, 2);
+          result["text/plain"] = JSON.stringify(firstNonImageEntry[1], null, 2);
         } catch {
-          result["text/plain"] = String(firstEntry[1]);
+          result["text/plain"] = String(firstNonImageEntry[1]);
         }
       } else {
         result["text/plain"] = "";

--- a/packages/ai/test/media-utils.test.ts
+++ b/packages/ai/test/media-utils.test.ts
@@ -172,6 +172,60 @@ Deno.test("AI Media Utils - ensureTextPlainFallback", async (t) => {
     const result = ensureTextPlainFallback(bundle);
     assertEquals(result["text/plain"], "");
   });
+
+  await t.step(
+    "should skip image mime types when generating text/plain fallback",
+    () => {
+      const bundle: AIMediaBundle = {
+        "image/png":
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI/0VWoJQAAAABJRU5ErkJggg==",
+        "application/json": { some: "data" },
+      };
+
+      const result = ensureTextPlainFallback(bundle);
+
+      // Should use JSON data, not image base64
+      assertEquals(result["text/plain"], '{\n  "some": "data"\n}');
+      assertEquals(
+        result["image/png"],
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI/0VWoJQAAAABJRU5ErkJggg==",
+      );
+    },
+  );
+
+  await t.step("should prefer text content over image content", () => {
+    const bundle: AIMediaBundle = {
+      "image/png":
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI/0VWoJQAAAABJRU5ErkJggg==",
+      "custom/format": "Some readable text content",
+    };
+
+    const result = ensureTextPlainFallback(bundle);
+
+    // Should use the readable text, not the image base64
+    assertEquals(result["text/plain"], "Some readable text content");
+    assertEquals(
+      result["image/png"],
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI/0VWoJQAAAABJRU5ErkJggg==",
+    );
+  });
+
+  await t.step(
+    "should default to empty string when only images present",
+    () => {
+      const bundle: AIMediaBundle = {
+        "image/png":
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI/0VWoJQAAAABJRU5ErkJggg==",
+        "image/jpeg":
+          "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=",
+      };
+
+      const result = ensureTextPlainFallback(bundle);
+
+      // Should default to empty string since no non-image content
+      assertEquals(result["text/plain"], "");
+    },
+  );
 });
 
 Deno.test("AI Media Utils - toAIContext", async (t) => {

--- a/packages/lib/mod.ts
+++ b/packages/lib/mod.ts
@@ -38,10 +38,13 @@ export * from "./src/media/mod.ts";
 // Artifact service client for submitting artifacts to anode
 export {
   ArtifactClient,
-  type ArtifactSubmissionOptions,
-  type ArtifactSubmissionResult,
   createArtifactClient,
   PngProcessor,
 } from "./src/artifact-client.ts";
+
+export type {
+  ArtifactSubmissionOptions,
+  ArtifactSubmissionResult,
+} from "./src/types.ts";
 
 export { runner } from "./src/runtime-runner.ts";

--- a/packages/lib/src/artifact-client.ts
+++ b/packages/lib/src/artifact-client.ts
@@ -6,24 +6,30 @@
  */
 
 import { decodeBase64, encodeBase64 } from "@std/encoding/base64";
-
-export interface ArtifactSubmissionOptions {
-  notebookId: string;
-  authToken: string;
-  mimeType?: string;
-  filename?: string;
-}
-
-export interface ArtifactSubmissionResult {
-  artifactId: string;
-}
+import type {
+  ArtifactSubmissionOptions,
+  ArtifactSubmissionResult,
+  IArtifactClient,
+} from "./types.ts";
 
 /**
  * Client for interacting with the anode artifact service
  */
-export class ArtifactClient {
+export class ArtifactClient implements IArtifactClient {
   // TODO: Make artifact service URL configuration more general for @runt/lib package
   constructor(private baseUrl: string = "https://api.runt.run") {}
+
+  /**
+   * Submit content data to artifact service
+   */
+  async submitContent(
+    data: Uint8Array,
+    options: ArtifactSubmissionOptions,
+  ): Promise<ArtifactSubmissionResult> {
+    // For now, delegate to PNG-specific implementation
+    // TODO: Generalize to handle any content type
+    return await this.submitPng(data, options);
+  }
 
   /**
    * Submit PNG image data to the artifact service

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -5,7 +5,12 @@
 
 import { parseArgs } from "@std/cli/parse-args";
 import { createLogger } from "./logging.ts";
-import type { RuntimeAgentOptions, RuntimeCapabilities } from "./types.ts";
+import type {
+  IArtifactClient,
+  RuntimeAgentOptions,
+  RuntimeCapabilities,
+} from "./types.ts";
+import { ArtifactClient } from "./artifact-client.ts";
 
 /**
  * Default configuration values
@@ -28,6 +33,7 @@ export class RuntimeConfig {
   public readonly sessionId: string;
   public readonly environmentOptions: RuntimeAgentOptions["environmentOptions"];
   public readonly imageArtifactThresholdBytes: number;
+  public readonly artifactClient: IArtifactClient;
 
   constructor(options: RuntimeAgentOptions) {
     this.runtimeId = options.runtimeId;
@@ -40,10 +46,38 @@ export class RuntimeConfig {
     this.imageArtifactThresholdBytes = options.imageArtifactThresholdBytes ??
       DEFAULT_CONFIG.imageArtifactThresholdBytes;
 
+    // Use injected artifact client or create default one
+    this.artifactClient = options.artifactClient ??
+      new ArtifactClient(this.getArtifactServiceUrl(options.syncUrl));
+
     // Generate unique session ID
     this.sessionId = `${this.runtimeType}-${this.runtimeId}-${Date.now()}-${
-      Math.random().toString(36).slice(2)
+      Math.random().toString(36).substring(2, 15)
     }`;
+  }
+
+  /**
+   * Convert sync URL to artifact service URL
+   * Transforms WebSocket URLs to HTTP(S) URLs for the artifact service
+   */
+  private getArtifactServiceUrl(syncUrl: string): string {
+    try {
+      const url = new URL(syncUrl);
+      // Convert wss:// to https:// and ws:// to http://
+      const protocol = url.protocol === "wss:" ? "https:" : "http:";
+      return `${protocol}//${url.host}`;
+    } catch (error) {
+      // Fallback to default if URL parsing fails
+      const logger = createLogger("runtime-config");
+      logger.warn(
+        "Failed to parse sync URL for artifact service, using default",
+        {
+          syncUrl,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return "https://api.runt.run";
+    }
   }
 
   /**

--- a/packages/lib/src/runtime-agent-text-representations.test.ts
+++ b/packages/lib/src/runtime-agent-text-representations.test.ts
@@ -255,88 +255,11 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
 
       await agent.start();
 
-      // Create a larger valid PNG that will exceed the 10-byte threshold
-      // Start with the valid black pixel PNG data and pad it to make it larger
-      const validPngBytes = new Uint8Array([
-        0x89,
-        0x50,
-        0x4E,
-        0x47,
-        0x0D,
-        0x0A,
-        0x1A,
-        0x0A, // PNG signature
-        0x00,
-        0x00,
-        0x00,
-        0x0D,
-        0x49,
-        0x48,
-        0x44,
-        0x52, // IHDR chunk start
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x01, // 1x1 image
-        0x08,
-        0x02,
-        0x00,
-        0x00,
-        0x00,
-        0x90,
-        0x77,
-        0x53,
-        0xDE, // IHDR data + CRC
-        0x00,
-        0x00,
-        0x00,
-        0x0C,
-        0x49,
-        0x44,
-        0x41,
-        0x54, // IDAT chunk start
-        0x08,
-        0x99,
-        0x01,
-        0x01,
-        0x00,
-        0x03,
-        0x00,
-        0xFC,
-        0xFF,
-        0x00,
-        0x00,
-        0x00, // IDAT data
-        0x02,
-        0x00,
-        0x01,
-        0x73,
-        0x75,
-        0x01,
-        0x18, // IDAT CRC
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x49,
-        0x45,
-        0x4E,
-        0x44,
-        0xAE,
-        0x42,
-        0x60,
-        0x82, // IEND chunk
-      ]);
-
-      // Pad with additional bytes to make it larger than 10 bytes (it's already ~60 bytes)
-      const largeImageBase64 = encodeBase64(validPngBytes);
+      const blackPixelBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jINmGwAAAABJRU5ErkJggg==";
 
       const representations: RawOutputData = {
-        "image/png": largeImageBase64,
+        "image/png": blackPixelBase64,
       };
 
       agent.onExecution(async (execCtx) => {
@@ -406,11 +329,11 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
       // Check that URLs are properly constructed
       assertEquals(
         plainText,
-        "PNG artifact: https://artifacts.test/test-artifact-success-123",
+        "image/png artifact: https://artifacts.test/test-artifact-success-123",
       );
       assertEquals(
         markdownText,
-        "![png_test-artifact-success-123](https://artifacts.test/test-artifact-success-123)",
+        "![Artifact_test_artifact_success_123image_png](https://artifacts.test/test-artifact-success-123)",
       );
 
       // Clean up to prevent resource leaks

--- a/packages/lib/src/runtime-agent-text-representations.test.ts
+++ b/packages/lib/src/runtime-agent-text-representations.test.ts
@@ -1,14 +1,29 @@
 import { assertEquals } from "@std/assert";
 import { RuntimeAgent } from "./runtime-agent.ts";
 import { RuntimeConfig } from "./config.ts";
-import type { MediaContainer } from "@runt/schema";
-import type { RuntimeCapabilities } from "./types.ts";
+import { events, type MediaContainer } from "@runt/schema";
+import type {
+  IArtifactClient,
+  RawOutputData,
+  RuntimeCapabilities,
+} from "./types.ts";
 import { queryDb, Schema, sql } from "npm:@livestore/livestore";
+import { encodeBase64 } from "@std/encoding/base64";
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Tests for RuntimeAgent text representation generation behavior:
+ * 1. Small inline images don't get automatic text representations
+ * 2. Large images attempt artifacting but fall back to inline when service unavailable
+ * 3. Existing text/plain representations are preserved without modification
+ */
 Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
   await t.step(
-    "should not override existing text/plain representations",
-    () => {
+    "should preserve existing text/plain for small inline images",
+    async () => {
       const capabilities: RuntimeCapabilities = {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -27,12 +42,15 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
 
       const agent = new RuntimeAgent(config, capabilities);
 
+      await agent.start();
+
       // Create representations with existing text/plain
       const representations: Record<string, MediaContainer> = {
         "image/png": {
-          type: "artifact",
-          artifactId: "test-artifact-123",
-          metadata: { originalSizeBytes: 50000 },
+          type: "inline",
+          data:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jINmGwAAAABJRU5ErkJggg==",
+          metadata: {},
         },
         "text/plain": {
           type: "inline",
@@ -46,21 +64,44 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         return { success: true };
       });
 
+      // Create a cell first
+      const cellId = "test-cell-123";
+      agent.store.commit(events.cellCreated({
+        id: cellId,
+        cellType: "code",
+        position: 0,
+        createdBy: "test-user",
+      }));
+
+      // Request execution
+      const queueId = crypto.randomUUID();
+      agent.store.commit(events.executionRequested({
+        queueId,
+        cellId,
+        executionCount: 1,
+        requestedBy: "test-user",
+      }));
+
+      await sleep(500); // Increased timeout for execution to complete
+
       const results = agent.store.query(queryDb(
         {
           query:
-            sql`SELECT id, cellid, json_extract(representations, '$."image/png".type') as "image/png:type", json_extract(representations, '$."image/png".artifactId') as "image/png:artifactId", json_extract(representations, '$."image/png".metadata.originalSizeBytes') as "image/png:originalSizeBytes", json_extract(representations, '$."text/plain".type') as "text/plain:type", json_extract(representations, '$."text/plain".data') as "text/plain:data", json_extract(representations, '$."text/markdown".type') as "text/markdown:type", json_extract(representations, '$."text/markdown".data') as "text/markdown:data" FROM outputs WHERE mimetype='image/png';`,
+            sql`SELECT id, cellId, json_extract(representations, '$."image/png".type') as "image/png:type", json_extract(representations, '$."image/png".artifactId') as "image/png:artifactId", json_extract(representations, '$."image/png".metadata.originalSizeBytes') as "image/png:originalSizeBytes", json_extract(representations, '$."text/plain".type') as "text/plain:type", json_extract(representations, '$."text/plain".data') as "text/plain:data", json_extract(representations, '$."text/markdown".type') as "text/markdown:type", json_extract(representations, '$."text/markdown".data') as "text/markdown:data" FROM outputs WHERE mimeType='image/png';`,
           schema: Schema.Array(
             Schema.Struct({
               id: Schema.String,
-              cellid: Schema.String,
-              "image/png:type": Schema.optional(Schema.String),
-              "image/png:artifactId": Schema.optional(Schema.String),
-              "image/png:originalSizeBytes": Schema.optional(Schema.Number),
-              "text/plain:type": Schema.optional(Schema.String),
-              "text/plain:data": Schema.optional(Schema.String),
-              "text/markdown:type": Schema.optional(Schema.String),
-              "text/markdown:data": Schema.optional(Schema.String),
+              cellId: Schema.String,
+              "image/png:type": Schema.Union(Schema.String, Schema.Null),
+              "image/png:artifactId": Schema.Union(Schema.String, Schema.Null),
+              "image/png:originalSizeBytes": Schema.Union(
+                Schema.Number,
+                Schema.Null,
+              ),
+              "text/plain:type": Schema.Union(Schema.String, Schema.Null),
+              "text/plain:data": Schema.Union(Schema.String, Schema.Null),
+              "text/markdown:type": Schema.Union(Schema.String, Schema.Null),
+              "text/markdown:data": Schema.Union(Schema.String, Schema.Null),
             }),
           ),
         },
@@ -68,13 +109,312 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
 
       assertEquals(results.length, 1);
 
-      assertEquals(results[0]["image/png:type"], "artifact");
-      assertEquals(results[0]["image/png:artifactId"], "test-artifact-123");
-      assertEquals(results[0]["image/png:originalSizeBytes"], 50000);
+      assertEquals(results[0]["image/png:type"], "inline");
+      assertEquals(results[0]["image/png:artifactId"], null);
+      assertEquals(results[0]["image/png:originalSizeBytes"], null);
       assertEquals(results[0]["text/plain:type"], "inline");
-      assertEquals(results[0]["text/plain:data"], "<Axes: >");
+      assertEquals(
+        results[0]["text/plain:data"],
+        '{"type":"inline","data":"<Axes: >","metadata":{}}',
+      );
+      assertEquals(results[0]["text/markdown:type"], null);
+      assertEquals(results[0]["text/markdown:data"], null);
+
+      // Clean up to prevent resource leaks
+      await agent.shutdown();
+    },
+  );
+
+  await t.step(
+    "should fall back to inline when artifact service unavailable",
+    async () => {
+      const capabilities: RuntimeCapabilities = {
+        canExecuteCode: true,
+        canExecuteSql: false,
+        canExecuteAi: false,
+      };
+
+      const config = new RuntimeConfig({
+        runtimeId: "test-runtime",
+        runtimeType: "test",
+        notebookId: "test-notebook",
+        syncUrl: "ws://localhost:8080",
+        authToken: "test-token",
+        capabilities,
+        environmentOptions: {},
+        imageArtifactThresholdBytes: 10, // Very low threshold to trigger artifacting
+      });
+
+      const agent = new RuntimeAgent(config, capabilities);
+
+      await agent.start();
+
+      // Create a larger image that will exceed the 10-byte threshold
+      // Repeat the black pixel PNG data to make it larger
+      const blackPixelBase64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChAI9jINmGwAAAABJRU5ErkJggg==";
+      const largeImageBase64 = blackPixelBase64.repeat(10); // Much larger than 10 bytes
+
+      const representations: RawOutputData = {
+        "image/png": largeImageBase64,
+      };
+
+      agent.onExecution(async (execCtx) => {
+        await execCtx.display(representations);
+        return { success: true };
+      });
+
+      // Create a cell first
+      const cellId = "test-cell-456";
+      agent.store.commit(events.cellCreated({
+        id: cellId,
+        cellType: "code",
+        position: 0,
+        createdBy: "test-user",
+      }));
+
+      // Request execution
+      const queueId = crypto.randomUUID();
+      agent.store.commit(events.executionRequested({
+        queueId,
+        cellId,
+        executionCount: 1,
+        requestedBy: "test-user",
+      }));
+
+      await sleep(1000); // Wait longer for artifact upload to complete
+
+      const results = agent.store.query(queryDb(
+        {
+          query:
+            sql`SELECT id, cellId, json_extract(representations, '$."image/png".type') as "image/png:type", json_extract(representations, '$."image/png".artifactId') as "image/png:artifactId", json_extract(representations, '$."text/plain".type') as "text/plain:type", json_extract(representations, '$."text/plain".data') as "text/plain:data", json_extract(representations, '$."text/markdown".type') as "text/markdown:type", json_extract(representations, '$."text/markdown".data') as "text/markdown:data" FROM outputs WHERE mimeType='image/png';`,
+          schema: Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              cellId: Schema.String,
+              "image/png:type": Schema.Union(Schema.String, Schema.Null),
+              "image/png:artifactId": Schema.Union(Schema.String, Schema.Null),
+              "text/plain:type": Schema.Union(Schema.String, Schema.Null),
+              "text/plain:data": Schema.Union(Schema.String, Schema.Null),
+              "text/markdown:type": Schema.Union(Schema.String, Schema.Null),
+              "text/markdown:data": Schema.Union(Schema.String, Schema.Null),
+            }),
+          ),
+        },
+      ));
+
+      assertEquals(results.length, 1);
+
+      // Verify image fell back to inline when artifact upload failed
+      assertEquals(results[0]["image/png:type"], "inline");
+      assertEquals(results[0]["image/png:artifactId"], null);
+
+      // Verify no text representations were generated (only for successful artifacts)
+      assertEquals(results[0]["text/plain:type"], null);
+      assertEquals(results[0]["text/plain:data"], null);
+      assertEquals(results[0]["text/markdown:type"], null);
+      assertEquals(results[0]["text/markdown:data"], null);
+
+      // Clean up to prevent resource leaks
+      await agent.shutdown();
+    },
+  );
+
+  await t.step(
+    "should generate text representations for successful artifacts",
+    async () => {
+      // Create mock artifact client for successful uploads
+      const mockArtifactClient: IArtifactClient = {
+        submitContent: (_data, _options) => {
+          return Promise.resolve({ artifactId: "test-artifact-success-123" });
+        },
+        getArtifactUrl: (artifactId) => {
+          return `https://artifacts.test/${artifactId}`;
+        },
+      };
+
+      const capabilities: RuntimeCapabilities = {
+        canExecuteCode: true,
+        canExecuteSql: false,
+        canExecuteAi: false,
+      };
+
+      const config = new RuntimeConfig({
+        runtimeId: "test-runtime",
+        runtimeType: "test",
+        notebookId: "test-notebook",
+        syncUrl: "ws://localhost:8080",
+        authToken: "test-token",
+        capabilities,
+        environmentOptions: {},
+        imageArtifactThresholdBytes: 10, // Very low threshold to trigger artifacting
+        artifactClient: mockArtifactClient,
+      });
+
+      const agent = new RuntimeAgent(config, capabilities);
+
+      await agent.start();
+
+      // Create a larger valid PNG that will exceed the 10-byte threshold
+      // Start with the valid black pixel PNG data and pad it to make it larger
+      const validPngBytes = new Uint8Array([
+        0x89,
+        0x50,
+        0x4E,
+        0x47,
+        0x0D,
+        0x0A,
+        0x1A,
+        0x0A, // PNG signature
+        0x00,
+        0x00,
+        0x00,
+        0x0D,
+        0x49,
+        0x48,
+        0x44,
+        0x52, // IHDR chunk start
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x01, // 1x1 image
+        0x08,
+        0x02,
+        0x00,
+        0x00,
+        0x00,
+        0x90,
+        0x77,
+        0x53,
+        0xDE, // IHDR data + CRC
+        0x00,
+        0x00,
+        0x00,
+        0x0C,
+        0x49,
+        0x44,
+        0x41,
+        0x54, // IDAT chunk start
+        0x08,
+        0x99,
+        0x01,
+        0x01,
+        0x00,
+        0x03,
+        0x00,
+        0xFC,
+        0xFF,
+        0x00,
+        0x00,
+        0x00, // IDAT data
+        0x02,
+        0x00,
+        0x01,
+        0x73,
+        0x75,
+        0x01,
+        0x18, // IDAT CRC
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x49,
+        0x45,
+        0x4E,
+        0x44,
+        0xAE,
+        0x42,
+        0x60,
+        0x82, // IEND chunk
+      ]);
+
+      // Pad with additional bytes to make it larger than 10 bytes (it's already ~60 bytes)
+      const largeImageBase64 = encodeBase64(validPngBytes);
+
+      const representations: RawOutputData = {
+        "image/png": largeImageBase64,
+      };
+
+      agent.onExecution(async (execCtx) => {
+        await execCtx.display(representations);
+        return { success: true };
+      });
+
+      // Create a cell first
+      const cellId = "test-cell-789";
+      agent.store.commit(events.cellCreated({
+        id: cellId,
+        cellType: "code",
+        position: 0,
+        createdBy: "test-user",
+      }));
+
+      // Request execution
+      const queueId = crypto.randomUUID();
+      agent.store.commit(events.executionRequested({
+        queueId,
+        cellId,
+        executionCount: 1,
+        requestedBy: "test-user",
+      }));
+
+      await sleep(500); // Wait for execution to complete
+
+      const results = agent.store.query(queryDb(
+        {
+          query:
+            sql`SELECT id, cellId, json_extract(representations, '$."image/png".type') as "image/png:type", json_extract(representations, '$."image/png".artifactId') as "image/png:artifactId", json_extract(representations, '$."text/plain".type') as "text/plain:type", json_extract(representations, '$."text/plain".data') as "text/plain:data", json_extract(representations, '$."text/markdown".type') as "text/markdown:type", json_extract(representations, '$."text/markdown".data') as "text/markdown:data" FROM outputs WHERE mimeType='image/png';`,
+          schema: Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              cellId: Schema.String,
+              "image/png:type": Schema.Union(Schema.String, Schema.Null),
+              "image/png:artifactId": Schema.Union(Schema.String, Schema.Null),
+              "text/plain:type": Schema.Union(Schema.String, Schema.Null),
+              "text/plain:data": Schema.Union(Schema.String, Schema.Null),
+              "text/markdown:type": Schema.Union(Schema.String, Schema.Null),
+              "text/markdown:data": Schema.Union(Schema.String, Schema.Null),
+            }),
+          ),
+        },
+      ));
+
+      assertEquals(results.length, 1);
+
+      // Verify image was stored as artifact
+      assertEquals(results[0]["image/png:type"], "artifact");
+      assertEquals(
+        results[0]["image/png:artifactId"],
+        "test-artifact-success-123",
+      );
+
+      // Verify text representations were generated
+      assertEquals(results[0]["text/plain:type"], "inline");
       assertEquals(results[0]["text/markdown:type"], "inline");
-      assertEquals(results[0]["text/markdown:data"], "<Axes: >");
+
+      // Verify text content contains artifact references
+      const plainText = results[0]["text/plain:data"];
+      const markdownText = results[0]["text/markdown:data"];
+
+      assertEquals(typeof plainText, "string");
+      assertEquals(typeof markdownText, "string");
+
+      // Check that URLs are properly constructed
+      assertEquals(
+        plainText,
+        "PNG artifact: https://artifacts.test/test-artifact-success-123",
+      );
+      assertEquals(
+        markdownText,
+        "![png_test-artifact-success-123](https://artifacts.test/test-artifact-success-123)",
+      );
+
+      // Clean up to prevent resource leaks
+      await agent.shutdown();
     },
   );
 });

--- a/packages/lib/src/runtime-agent-text-representations.test.ts
+++ b/packages/lib/src/runtime-agent-text-representations.test.ts
@@ -8,7 +8,6 @@ import type {
   RuntimeCapabilities,
 } from "./types.ts";
 import { queryDb, Schema, sql } from "npm:@livestore/livestore";
-import { encodeBase64 } from "@std/encoding/base64";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/lib/src/runtime-agent-text-representations.test.ts
+++ b/packages/lib/src/runtime-agent-text-representations.test.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "@std/assert";
+import { RuntimeAgent } from "./runtime-agent.ts";
+import { RuntimeConfig } from "./config.ts";
+import type { InlineContainer, MediaContainer } from "@runt/schema";
+import type { RuntimeCapabilities } from "./types.ts";
+import { queryDb, Schema, sql } from "npm:@livestore/livestore";
+import { assert } from "@std/assert/assert";
+
+Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
+  await t.step(
+    "should not override existing text/plain representations",
+    () => {
+      const capabilities: RuntimeCapabilities = {
+        canExecuteCode: true,
+        canExecuteSql: false,
+        canExecuteAi: false,
+      };
+
+      const config = new RuntimeConfig({
+        runtimeId: "test-runtime",
+        runtimeType: "test",
+        notebookId: "test-notebook",
+        syncUrl: "ws://localhost:8080",
+        authToken: "test-token",
+        capabilities,
+        environmentOptions: {},
+      });
+
+      const agent = new RuntimeAgent(config, capabilities);
+
+      // Create representations with existing text/plain
+      const representations: Record<string, MediaContainer> = {
+        "image/png": {
+          type: "artifact",
+          artifactId: "test-artifact-123",
+          metadata: { originalSizeBytes: 50000 },
+        },
+        "text/plain": {
+          type: "inline",
+          data: "<Axes: >",
+          metadata: {},
+        },
+      };
+
+      agent.onExecution(async (execCtx) => {
+        await execCtx.display(representations);
+        return { success: true };
+      });
+
+      const results = agent.store.query(queryDb(
+        {
+          query:
+            sql`SELECT id, cellid, json_extract(representations, '$."image/png".type') as "image/png:type", json_extract(representations, '$."image/png".artifactId') as "image/png:artifactId", json_extract(representations, '$."image/png".metadata.originalSizeBytes') as "image/png:originalSizeBytes", json_extract(representations, '$."text/plain".type') as "text/plain:type", json_extract(representations, '$."text/plain".data') as "text/plain:data", json_extract(representations, '$."text/markdown".type') as "text/markdown:type", json_extract(representations, '$."text/markdown".data') as "text/markdown:data" FROM outputs WHERE mimetype='image/png';`,
+          schema: Schema.Array(
+            Schema.Struct({
+              id: Schema.String,
+              cellid: Schema.String,
+              "image/png:type": Schema.optional(Schema.String),
+              "image/png:artifactId": Schema.optional(Schema.String),
+              "image/png:originalSizeBytes": Schema.optional(Schema.Number),
+              "text/plain:type": Schema.optional(Schema.String),
+              "text/plain:data": Schema.optional(Schema.String),
+              "text/markdown:type": Schema.optional(Schema.String),
+              "text/markdown:data": Schema.optional(Schema.String),
+            }),
+          ),
+        },
+      ));
+
+      assertEquals(results.length, 1);
+
+      assertEquals(results[0]["image/png:type"], "artifact");
+      assertEquals(results[0]["image/png:artifactId"], "test-artifact-123");
+      assertEquals(results[0]["image/png:originalSizeBytes"], 50000);
+      assertEquals(results[0]["text/plain:type"], "inline");
+      assertEquals(results[0]["text/plain:data"], "<Axes: >");
+      assertEquals(results[0]["text/markdown:type"], "inline");
+      assertEquals(results[0]["text/markdown:data"], "<Axes: >");
+    },
+  );
+});

--- a/packages/lib/src/runtime-agent-text-representations.test.ts
+++ b/packages/lib/src/runtime-agent-text-representations.test.ts
@@ -1,10 +1,9 @@
 import { assertEquals } from "@std/assert";
 import { RuntimeAgent } from "./runtime-agent.ts";
 import { RuntimeConfig } from "./config.ts";
-import type { InlineContainer, MediaContainer } from "@runt/schema";
+import type { MediaContainer } from "@runt/schema";
 import type { RuntimeCapabilities } from "./types.ts";
 import { queryDb, Schema, sql } from "npm:@livestore/livestore";
-import { assert } from "@std/assert/assert";
 
 Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
   await t.step(

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -22,22 +22,21 @@ import { makeSchema, State } from "npm:@livestore/livestore";
 const state = State.SQLite.makeState({ tables, materializers });
 const schema = makeSchema({ events, state });
 import type {
+  ArtifactSubmissionOptions,
   CancellationHandler,
   CellData,
   ExecutionContext,
   ExecutionHandler,
   ExecutionQueueData,
   ExecutionResult,
+  IArtifactClient,
   RawOutputData,
   RuntimeAgentEventHandlers,
   RuntimeCapabilities,
   RuntimeSessionData,
 } from "./types.ts";
 import type { RuntimeConfig } from "./config.ts";
-import {
-  ArtifactClient,
-  type ArtifactSubmissionOptions,
-} from "./artifact-client.ts";
+
 import { decodeBase64 } from "@std/encoding/base64";
 
 /**
@@ -52,16 +51,14 @@ export class RuntimeAgent {
   private activeExecutions = new Map<string, AbortController>();
   private cancellationHandlers: CancellationHandler[] = [];
   private signalHandlers = new Map<string, () => void>();
-  private artifactClient: ArtifactClient;
+  private artifactClient: IArtifactClient;
 
   constructor(
     public config: RuntimeConfig,
     private capabilities: RuntimeCapabilities,
     private handlers: RuntimeAgentEventHandlers = {},
   ) {
-    // Convert sync URL to artifact service URL
-    const artifactBaseUrl = this.getArtifactServiceUrl(config.syncUrl);
-    this.artifactClient = new ArtifactClient(artifactBaseUrl);
+    this.artifactClient = config.artifactClient;
   }
 
   /**
@@ -993,7 +990,7 @@ export class RuntimeAgent {
       };
 
       // TODO: Support multipart uploads for large images in the future
-      const result = await this.artifactClient.submitPng(
+      const result = await this.artifactClient.submitContent(
         imageData,
         submissionOptions,
       );
@@ -1063,30 +1060,6 @@ export class RuntimeAgent {
           };
         }
       }
-    }
-  }
-
-  /**
-   * Convert sync URL to artifact service URL
-   * Transforms WebSocket URLs to HTTP(S) URLs for the artifact service
-   */
-  private getArtifactServiceUrl(syncUrl: string): string {
-    try {
-      const url = new URL(syncUrl);
-      // Convert wss:// to https:// and ws:// to http://
-      const protocol = url.protocol === "wss:" ? "https:" : "http:";
-      return `${protocol}//${url.host}`;
-    } catch (error) {
-      // Fallback to default if URL parsing fails
-      const logger = createLogger("runtime-agent");
-      logger.warn(
-        "Failed to parse sync URL for artifact service, using default",
-        {
-          syncUrl,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
-      return "https://api.runt.run";
     }
   }
 

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -633,6 +633,9 @@ export class RuntimeAgent {
           }
         }
 
+        // Add text representations for image artifacts
+        this.generateTextRepresentationsForArtifacts(representations);
+
         this.store.commit(events.multimediaDisplayOutputAdded({
           id: crypto.randomUUID(),
           cellId: cell.id,
@@ -670,6 +673,9 @@ export class RuntimeAgent {
           }
         }
 
+        // Add text representations for image artifacts
+        this.generateTextRepresentationsForArtifacts(representations);
+
         this.store.commit(events.multimediaDisplayOutputUpdated({
           displayId,
           representations,
@@ -702,6 +708,9 @@ export class RuntimeAgent {
             };
           }
         }
+
+        // Add text representations for image artifacts
+        this.generateTextRepresentationsForArtifacts(representations);
 
         this.store.commit(events.multimediaResultOutputAdded({
           id: crypto.randomUUID(),
@@ -1015,6 +1024,45 @@ export class RuntimeAgent {
         data: content,
         metadata,
       };
+    }
+  }
+
+  /**
+   * Generate appropriate text representations for image artifacts
+   */
+  private generateTextRepresentationsForArtifacts(
+    representations: Record<string, MediaContainer>,
+  ): void {
+    // Check for image artifacts and add text representations
+    for (const [mimeType, container] of Object.entries(representations)) {
+      if (isImageMimeType(mimeType) && container.type === "artifact") {
+        // Don't override existing text representations
+        if (!representations["text/plain"]) {
+          const artifactUrl = this.artifactClient.getArtifactUrl(
+            container.artifactId,
+          );
+          const extension = mimeType.split("/")[1]?.toUpperCase() || "Image";
+          representations["text/plain"] = {
+            type: "inline",
+            data: `${extension} artifact: ${artifactUrl}`,
+            metadata: { generatedFor: mimeType },
+          };
+        }
+
+        if (!representations["text/markdown"]) {
+          const artifactUrl = this.artifactClient.getArtifactUrl(
+            container.artifactId,
+          );
+          const extension = mimeType.split("/")[1]?.toUpperCase() || "Image";
+          const filename = container.metadata?.filename ||
+            `${extension.toLowerCase()}_${container.artifactId}`;
+          representations["text/markdown"] = {
+            type: "inline",
+            data: `![${filename}](${artifactUrl})`,
+            metadata: { generatedFor: mimeType },
+          };
+        }
+      }
     }
   }
 

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -1030,18 +1030,19 @@ export class RuntimeAgent {
   private generateTextRepresentationsForArtifacts(
     representations: Record<string, MediaContainer>,
   ): void {
-    // Check for image artifacts and add text representations
     for (const [mimeType, container] of Object.entries(representations)) {
       if (isImageMimeType(mimeType) && container.type === "artifact") {
-        // Don't override existing text representations
+        // NOTE: This will use the "last" artifact to set in the text/plain representation
+        //       without regard for the display order of the receiving client(s).
+        //
+        //       However, this is mainly a fallback for clients that do not support images/html.
         if (!representations["text/plain"]) {
           const artifactUrl = this.artifactClient.getArtifactUrl(
             container.artifactId,
           );
-          const extension = mimeType.split("/")[1]?.toUpperCase() || "Image";
           representations["text/plain"] = {
             type: "inline",
-            data: `${extension} artifact: ${artifactUrl}`,
+            data: `${mimeType} artifact: ${artifactUrl}`,
             metadata: { generatedFor: mimeType },
           };
         }
@@ -1050,12 +1051,16 @@ export class RuntimeAgent {
           const artifactUrl = this.artifactClient.getArtifactUrl(
             container.artifactId,
           );
-          const extension = mimeType.split("/")[1]?.toUpperCase() || "Image";
-          const filename = container.metadata?.filename ||
-            `${extension.toLowerCase()}_${container.artifactId}`;
+
+          // Convert name shown to something displayable in markdown (escapsing as necessary) relying on
+          // the mimetype and or artifact ID
+          const name = "Artifact_" +
+            container.artifactId.replace(/[^a-zA-Z0-9]/g, "_") +
+            mimeType.replace(/[^a-zA-Z0-9]/g, "_");
+
           representations["text/markdown"] = {
             type: "inline",
-            data: `![${filename}](${artifactUrl})`,
+            data: `![${name}](${artifactUrl})`,
             metadata: { generatedFor: mimeType },
           };
         }

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -22,6 +22,33 @@ export interface RawOutputData {
 }
 
 /**
+ * Interface for artifact client dependency injection
+ */
+export interface IArtifactClient {
+  /** Submit content data to artifact service */
+  submitContent(
+    data: Uint8Array,
+    options: ArtifactSubmissionOptions,
+  ): Promise<ArtifactSubmissionResult>;
+
+  /** Get artifact URL by ID */
+  getArtifactUrl(artifactId: string): string;
+}
+
+/** Artifact submission options */
+export interface ArtifactSubmissionOptions {
+  notebookId: string;
+  authToken: string;
+  mimeType?: string;
+  filename?: string;
+}
+
+/** Artifact submission result */
+export interface ArtifactSubmissionResult {
+  artifactId: string;
+}
+
+/**
  * Configuration options for runtime agents
  */
 export interface RuntimeAgentOptions {
@@ -39,6 +66,8 @@ export interface RuntimeAgentOptions {
   readonly notebookId: string;
   /** Threshold in bytes for uploading images as artifacts (default: 1MB) */
   readonly imageArtifactThresholdBytes?: number;
+  /** Artifact client for dependency injection (optional) */
+  readonly artifactClient?: IArtifactClient;
   /** Environment-related options for the runtime */
   readonly environmentOptions: Readonly<{
     /** Path to the python executable to use (default: "python3") */

--- a/packages/pyodide-runtime-agent/src/ipython-setup.py
+++ b/packages/pyodide-runtime-agent/src/ipython-setup.py
@@ -17,6 +17,16 @@ import os
 import sys
 import io
 import json
+from dataclasses import dataclass
+from typing import Any
+from typing import Callable
+import time
+import builtins
+import signal
+
+
+import micropip
+
 
 from IPython.core.interactiveshell import InteractiveShell
 from IPython.core.displayhook import DisplayHook
@@ -325,10 +335,10 @@ def default_clear_callback(wait=False):
 
 
 async def bootstrap_micropip_packages():
+    """Note: this _must_ be run on start of this ipython session"""
     try:
-        import micropip
-
         await micropip.install("seaborn")
+        await micropip.install("openai-function-calling")
 
         print("Installed seaborn via micropip")
     except Exception as e:
@@ -336,13 +346,7 @@ async def bootstrap_micropip_packages():
 
 
 def setup_interrupt_patches():
-    """Patch Python functions to make them interrupt-aware"""
-    import time
-    import builtins
-    import signal
-    import sys
-    import threading
-
+    """Patch Python functions to make them interrupt-aware. NOTE: This is largely fixed in newer pyodide releases, but we're stuck with this as those releases don't support pyarrow, duckdb, and other binary builds at this time."""
     # Store original functions
     _original_sleep = time.sleep
     _original_input = builtins.input if hasattr(builtins, "input") else None
@@ -383,6 +387,7 @@ def setup_interrupt_patches():
             raise
         except Exception as e:
             # Don't spam errors, just continue
+            print(f"Error checking interrupt: {e}", flush=True)
             pass
 
     def interrupt_aware_sleep(duration):
@@ -450,17 +455,6 @@ js_clear_callback = default_clear_callback
 
 # Set up interrupt patches
 setup_interrupt_patches()
-
-# Setup tool registry
-import json
-import warnings
-from dataclasses import dataclass
-from typing import Any
-from typing import Callable
-
-import micropip
-
-await micropip.install("openai-function-calling")
 
 
 class ToolNotFoundError(Exception):


### PR DESCRIPTION
As I found out this morning, I was submitting png base64 encoded data as `text/plain` in the event log. The code for ensuring a `text/plain` fallback was in the output was letting `image/png` data seep through. Not a good fallback. Amusingly, I didn't notice this until I saw the big blob of base64 encoded gunk in the `@runt/tui` while connected to a notebook for a plot.

To make testing a bit easier, this adds a way to dependency inject an artifact client so that "uploads" can happen in tests that allow us to create all the same events. `packages/lib/src/runtime-agent-text-representations.test.ts` is worth a look as a decent way to test this stuff.

<img width="3083" height="915" alt="image" src="https://github.com/user-attachments/assets/39e65943-59a5-4fa1-b96a-1bdac4b7781e" />



https://github.com/user-attachments/assets/ac376480-408d-489f-89f9-d5efa0d077d3


