### PR TITLE
fix: add proper schema validation for MCP tool parameters

### DIFF
--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -27,6 +27,9 @@ interface ToolParameter {
   enum?: string[];
   description?: string;
   default?: string;
+  items?: ToolParameter; // For array types
+  properties?: Record<string, ToolParameter>; // For object types
+  required?: string[]; // For object types
 }
 
 // Define available notebook tools
@@ -97,6 +100,42 @@ const NOTEBOOK_TOOLS: NotebookTool[] = [
 ];
 
 /**
+ * Convert MCP parameter schema to ToolParameter format
+ */
+function convertMcpParameterToToolParameter(
+  mcpParam: Record<string, unknown>,
+): ToolParameter {
+  const baseParam: ToolParameter = {
+    type: (mcpParam.type as string) || "string",
+    description: mcpParam.description as string,
+    enum: mcpParam.enum as string[],
+    default: mcpParam.default as string,
+  };
+
+  // Handle array types with items
+  if (mcpParam.type === "array" && mcpParam.items) {
+    baseParam.items = convertMcpParameterToToolParameter(
+      mcpParam.items as Record<string, unknown>,
+    );
+  }
+
+  // Handle object types with properties
+  if (mcpParam.type === "object" && mcpParam.properties) {
+    baseParam.properties = Object.fromEntries(
+      Object.entries(mcpParam.properties as Record<string, unknown>).map(
+        ([key, value]) => [
+          key,
+          convertMcpParameterToToolParameter(value as Record<string, unknown>),
+        ],
+      ),
+    );
+    baseParam.required = mcpParam.required as string[];
+  }
+
+  return baseParam;
+}
+
+/**
  * Get all available tools including both notebook tools and MCP tools
  */
 export async function getAllTools(): Promise<NotebookTool[]> {
@@ -115,14 +154,9 @@ export async function getAllTools(): Promise<NotebookTool[]> {
             [key, value],
           ) => [
             key,
-            {
-              type: (value as Record<string, unknown>)?.type as string ||
-                "string",
-              description: (value as Record<string, unknown>)
-                ?.description as string,
-              enum: (value as Record<string, unknown>)?.enum as string[],
-              default: (value as Record<string, unknown>)?.default as string,
-            } as ToolParameter,
+            convertMcpParameterToToolParameter(
+              value as Record<string, unknown>,
+            ),
           ]),
         ),
         required: mcpTool.parameters.required || [],


### PR DESCRIPTION
Asked AI to fix this error: in `openai-client.ts` with context: `OpenAI Error: 400 Invalid schema
In context=('properties', 'paths'), array schema missing items.`

<img width="957" height="366" alt="Screenshot 2025-07-28 at 3 45 49 PM" src="https://github.com/user-attachments/assets/f89bca83-69d5-479a-b84a-6d960c86aea0" />

Now it looks like it works!

<img width="864" height="902" alt="Screenshot 2025-07-28 at 3 40 14 PM" src="https://github.com/user-attachments/assets/e10c06bf-867e-4c64-aa51-e45cfaf893f2" />

This is my  `~/.runt/mcp.json`:

```json
{
  "mcpServers": {
    "filesystem": {
      "command": "npx",
      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
      "name": "Filesystem Server",
      "description": "Access and manipulate files and directories"
    }
  }
}
```

---

🤖 THE REST OF THIS IS AI GENERATED

This PR fixes the OpenAI API Error 400 that was occurring with MCP tools like mcp_github_push_files due to missing schema validation for array and object types.

Changes:
- Added items property for array types
- Added properties and required for object types  
- Improved convertMcpParameterToToolParameter function to handle complex schemas
- Enhanced AI system prompt with available output types

The error was: OpenAIError: OpenAI API Error: 400 Invalid schema for function 'mcp_github_push_files': In context=('properties', 'files'), array schema missing items.

This occurred because the MCP tool schema conversion wasn't properly handling array types that require an items property to define the schema of array elements.