### PR TITLE
Fix fractional-indexing dependency

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "@livestore/livestore": "^0.3.1",
-    "fractional-indexing-jittered": "^1.0.0"
+    "fractional-indexing": "^3.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes incorrect dependency name and version in schema package.json. Changes fractional-indexing-jittered to fractional-indexing ^3.2.0 to match deno.json.