### PR TITLE
refactor: simplify cell creation API with createCellBetween

### DIFF
--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -1846,167 +1846,6 @@ export type CellReference = {
  * This ensures stable, deterministic ordering even in the unlikely event of index collisions.
  * We generate 20 candidate indices and pick one randomly to minimize collision probability.
  */
-export function createCellAfter(
-  afterCellId: string | null,
-  cells: Array<{ id: string; fractionalIndex: string | null }>,
-  cellData: {
-    id: string;
-    cellType: CellType;
-    createdBy: string;
-  },
-): ReturnType<typeof events.cellCreated2> {
-  // Only consider cells with valid fractionalIndex for ordering
-  const cellsWithIndex = cells.filter((c) => c.fractionalIndex);
-  const sortedCells = cellsWithIndex.sort((a, b) => {
-    // Primary sort by fractional index
-    if (a.fractionalIndex! < b.fractionalIndex!) return -1;
-    if (a.fractionalIndex! > b.fractionalIndex!) return 1;
-    // Secondary sort by ID if fractional indices are equal
-    return a.id.localeCompare(b.id);
-  });
-
-  let previousKey: string | null = null;
-  let nextKey: string | null = null;
-
-  if (afterCellId) {
-    // Find the cell we want to insert after
-    const targetCell = cells.find((c) => c.id === afterCellId);
-    if (targetCell && targetCell.fractionalIndex) {
-      // If the target cell has a fractionalIndex, use it
-      previousKey = targetCell.fractionalIndex;
-
-      // Find the next cell in sorted order
-      const targetIndex = sortedCells.findIndex((c) => c.id === afterCellId);
-      if (targetIndex >= 0 && targetIndex < sortedCells.length - 1) {
-        const nextCell = sortedCells[targetIndex + 1];
-        if (nextCell) {
-          nextKey = nextCell.fractionalIndex!;
-        }
-      }
-    }
-  } else {
-    // When afterCellId is null, insert at the end
-    if (sortedCells.length > 0) {
-      const lastCell = sortedCells[sortedCells.length - 1];
-      if (lastCell) {
-        previousKey = lastCell.fractionalIndex!;
-      }
-    }
-    // If no cells with fractionalIndex exist, previousKey and nextKey remain null
-    // This will create the first fractionalIndex
-  }
-
-  const fractionalIndex = fractionalIndexBetween(previousKey, nextKey);
-
-  return events.cellCreated2({
-    ...cellData,
-    fractionalIndex,
-  });
-}
-
-export function createCellBefore(
-  beforeCellId: string | null,
-  cells: Array<{ id: string; fractionalIndex: string | null }>,
-  cellData: {
-    id: string;
-    cellType: CellType;
-    createdBy: string;
-  },
-): ReturnType<typeof events.cellCreated2> {
-  // Only consider cells with valid fractionalIndex for ordering
-  const cellsWithIndex = cells.filter((c) => c.fractionalIndex);
-  const sortedCells = cellsWithIndex.sort((a, b) => {
-    // Primary sort by fractional index
-    if (a.fractionalIndex! < b.fractionalIndex!) return -1;
-    if (a.fractionalIndex! > b.fractionalIndex!) return 1;
-    // Secondary sort by ID if fractional indices are equal
-    return a.id.localeCompare(b.id);
-  });
-
-  let previousKey: string | null = null;
-  let nextKey: string | null = null;
-
-  if (beforeCellId) {
-    // Find the cell we want to insert before
-    const targetCell = cells.find((c) => c.id === beforeCellId);
-    if (targetCell && targetCell.fractionalIndex) {
-      // If the target cell has a fractionalIndex, use it
-      nextKey = targetCell.fractionalIndex;
-
-      // Find the previous cell in sorted order
-      const targetIndex = sortedCells.findIndex((c) => c.id === beforeCellId);
-      if (targetIndex > 0) {
-        const prevCell = sortedCells[targetIndex - 1];
-        if (prevCell) {
-          previousKey = prevCell.fractionalIndex!;
-        }
-      }
-    }
-  } else {
-    // When beforeCellId is null, also insert at the end (same as createCellAfter with null)
-    if (sortedCells.length > 0) {
-      const lastCell = sortedCells[sortedCells.length - 1];
-      if (lastCell) {
-        previousKey = lastCell.fractionalIndex!;
-      }
-    }
-    // If no cells with fractionalIndex exist, previousKey and nextKey remain null
-    // This will create the first fractionalIndex
-  }
-
-  const fractionalIndex = fractionalIndexBetween(previousKey, nextKey);
-
-  return events.cellCreated2({
-    ...cellData,
-    fractionalIndex,
-  });
-}
-
-export function createCellAtPosition(
-  position: number,
-  cells: Array<{ id: string; fractionalIndex: string | null }>,
-  cellData: {
-    id: string;
-    cellType: CellType;
-    createdBy: string;
-  },
-): ReturnType<typeof events.cellCreated2> {
-  const sortedCells = cells
-    .filter((c) => c.fractionalIndex)
-    .sort((a, b) => {
-      // Primary sort by fractional index
-      if (a.fractionalIndex! < b.fractionalIndex!) return -1;
-      if (a.fractionalIndex! > b.fractionalIndex!) return 1;
-      // Secondary sort by ID if fractional indices are equal
-      return a.id.localeCompare(b.id);
-    });
-
-  // Clamp position to valid range
-  const clampedPosition = Math.max(0, Math.min(position, sortedCells.length));
-
-  let previousKey: string | null = null;
-  let nextKey: string | null = null;
-
-  if (clampedPosition > 0) {
-    const prevCell = sortedCells[clampedPosition - 1];
-    if (prevCell) {
-      previousKey = prevCell.fractionalIndex!;
-    }
-  }
-  if (clampedPosition < sortedCells.length) {
-    const nextCell = sortedCells[clampedPosition];
-    if (nextCell) {
-      nextKey = nextCell.fractionalIndex!;
-    }
-  }
-
-  const fractionalIndex = fractionalIndexBetween(previousKey, nextKey);
-
-  return events.cellCreated2({
-    ...cellData,
-    fractionalIndex,
-  });
-}
 
 /**
  * Move a cell between two other cells using fractional indices
@@ -2061,6 +1900,37 @@ export function moveCellBetween(
     id: cell.id,
     fractionalIndex,
     actorId,
+  });
+}
+
+/**
+ * Create a cell between two other cells using fractional indices
+ *
+ * @param cellData - The cell data (id, cellType, createdBy)
+ * @param cellBefore - The cell that should come before (null for beginning)
+ * @param cellAfter - The cell that should come after (null for end)
+ *
+ * Note: It's the caller's responsibility to provide accurate before/after cells.
+ * If both cellBefore and cellAfter are provided, they must be adjacent cells.
+ */
+export function createCellBetween(
+  cellData: {
+    id: string;
+    cellType: CellType;
+    createdBy: string;
+  },
+  cellBefore: CellReference | null,
+  cellAfter: CellReference | null,
+): ReturnType<typeof events.cellCreated2> {
+  // Determine the fractional indices for before and after
+  const previousKey = cellBefore?.fractionalIndex || null;
+  const nextKey = cellAfter?.fractionalIndex || null;
+
+  const fractionalIndex = fractionalIndexBetween(previousKey, nextKey);
+
+  return events.cellCreated2({
+    ...cellData,
+    fractionalIndex,
   });
 }
 

--- a/packages/schema/test.ts
+++ b/packages/schema/test.ts
@@ -1658,3 +1658,119 @@ Deno.test("v2.CellMoved - moveCellBetween API", async () => {
 
   store.shutdown();
 });
+
+Deno.test("v2.CellCreated - createCellBetween API", async () => {
+  const store = await setupStore();
+  const { fractionalIndexBetween, createCellBetween } = await import(
+    "@runt/schema"
+  );
+  type CellReference = import("@runt/schema").CellReference;
+
+  // Create initial cells to insert between
+  const cell1: CellReference = {
+    id: "existing-1",
+    fractionalIndex: fractionalIndexBetween(null, null),
+  };
+  const cell2: CellReference = {
+    id: "existing-2",
+    fractionalIndex: fractionalIndexBetween(cell1.fractionalIndex, null),
+  };
+
+  // Create cells in the store
+  for (const cell of [cell1, cell2]) {
+    store.commit(events.cellCreated2({
+      id: cell.id,
+      fractionalIndex: cell.fractionalIndex!,
+      cellType: "code",
+      createdBy: "user1",
+    }));
+  }
+
+  // Test 1: Create cell at the beginning (before cell1)
+  const newCell1 = createCellBetween(
+    {
+      id: "new-1",
+      cellType: "markdown",
+      createdBy: "user1",
+    },
+    null,
+    cell1,
+  );
+  store.commit(newCell1);
+
+  // Verify it's before cell1
+  assert(newCell1.args.fractionalIndex < cell1.fractionalIndex!);
+
+  // Test 2: Create cell between cell1 and cell2
+  const newCell2 = createCellBetween(
+    {
+      id: "new-2",
+      cellType: "code",
+      createdBy: "user2",
+    },
+    cell1,
+    cell2,
+  );
+  store.commit(newCell2);
+
+  // Verify it's between cell1 and cell2
+  assert(newCell2.args.fractionalIndex > cell1.fractionalIndex!);
+  assert(newCell2.args.fractionalIndex < cell2.fractionalIndex!);
+
+  // Test 3: Create cell at the end (after cell2)
+  const newCell3 = createCellBetween(
+    {
+      id: "new-3",
+      cellType: "ai",
+      createdBy: "user3",
+    },
+    cell2,
+    null,
+  );
+  store.commit(newCell3);
+
+  // Verify it's after cell2
+  assert(newCell3.args.fractionalIndex > cell2.fractionalIndex!);
+
+  // Test 4: Create between two cells that were just created
+  const newCell4 = createCellBetween(
+    {
+      id: "new-4",
+      cellType: "sql",
+      createdBy: "user1",
+    },
+    { id: "new-1", fractionalIndex: newCell1.args.fractionalIndex },
+    cell1,
+  );
+  store.commit(newCell4);
+
+  // Verify ordering
+  assert(newCell4.args.fractionalIndex > newCell1.args.fractionalIndex);
+  assert(newCell4.args.fractionalIndex < cell1.fractionalIndex!);
+
+  // Test 5: Create first cell in empty notebook
+  const firstCell = createCellBetween(
+    {
+      id: "first",
+      cellType: "markdown",
+      createdBy: "user1",
+    },
+    null,
+    null,
+  );
+  assertExists(firstCell.args.fractionalIndex);
+
+  // Verify all cells maintain proper ordering
+  const allCells = store.query(
+    tables.cells.select().orderBy("fractionalIndex", "asc"),
+  ).filter((c) => c.fractionalIndex !== null);
+
+  // Check that ordering is strictly increasing
+  for (let i = 1; i < allCells.length; i++) {
+    const prev = allCells[i - 1].fractionalIndex!;
+    const curr = allCells[i].fractionalIndex!;
+    assert(prev < curr, `Ordering violated: ${prev} should be < ${curr}`);
+  }
+
+  store.shutdown();
+});


### PR DESCRIPTION
Refactors cell creation to match the clean API pattern established in #162 for cell movement.

## Changes
- Add `createCellBetween(cellData, cellBefore?, cellAfter?)` as the single API for cell creation
- Remove `createCellAfter`, `createCellBefore`, `createCellAtPosition` (not yet released)
- Consistent with `moveCellBetween` pattern - only need specific cells, not entire array
- Add comprehensive tests for new API

## Benefits
- More efficient: no sorting of entire cell array
- Cleaner API: caller provides only the cells involved
- Consistent pattern between creation and movement

All tests pass.