### PR TITLE
Update runtime agents and TUI to use fractional indices

### DIFF
--- a/packages/ai/notebook-context.ts
+++ b/packages/ai/notebook-context.ts
@@ -34,7 +34,7 @@ export function gatherNotebookContext(
 ): NotebookContextData {
   // Query all cells in order
   const allCells = store.query(
-    tables.cells.select().orderBy("position", "asc"),
+    tables.cells.select().orderBy("fractionalIndex", "asc"),
   );
 
   // Get cells before current cell that should be included in AI context

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -1,4 +1,11 @@
-import { type CellData, events, materializers, tables } from "@runt/schema";
+import {
+  type CellData,
+  cellList$,
+  createCellBetween,
+  events,
+  materializers,
+  tables,
+} from "@runt/schema";
 import type { Logger } from "@runt/lib";
 import type { Store } from "npm:@livestore/livestore";
 import { makeSchema, State } from "npm:@livestore/livestore";
@@ -177,30 +184,6 @@ export async function getAllTools(): Promise<NotebookTool[]> {
  */
 export const NOTEBOOK_TOOLS_EXPORT = NOTEBOOK_TOOLS;
 
-function calculateNewCellPosition(
-  store: Store<typeof schema>,
-  currentCell: CellData,
-  placement: string,
-): number {
-  const allCells = store.query(
-    tables.cells.select().orderBy("position", "asc"),
-  ) as CellData[];
-
-  switch (placement) {
-    case "before_current":
-      return currentCell.position - 0.1;
-    case "at_end": {
-      const maxPosition = allCells.length > 0
-        ? Math.max(...allCells.map((c: CellData) => c.position))
-        : 0;
-      return maxPosition + 1;
-    }
-    case "after_current":
-    default:
-      return currentCell.position + 0.1;
-  }
-}
-
 export function createCell(
   store: Store<typeof schema>,
   logger: Logger,
@@ -212,31 +195,58 @@ export function createCell(
   const content = String(args.source || args.content || ""); // Check source first, then content
   const position = String(args.position || "after_current");
 
-  // Calculate position for new cell
-  const newPosition = calculateNewCellPosition(
-    store,
-    currentCell,
-    position,
-  );
+  // Get ordered cells with fractional indices
+  const cellList = store.query(cellList$);
+  const currentCellIndex = cellList.findIndex((c) => c.id === currentCell.id);
 
   // Generate unique cell ID
   const newCellId = `cell-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
+  let cellBefore = null;
+  let cellAfter = null;
+
+  switch (position) {
+    case "before_current":
+      cellBefore = currentCellIndex > 0
+        ? cellList[currentCellIndex - 1] || null
+        : null;
+      cellAfter = cellList[currentCellIndex] || null;
+      break;
+    case "at_end":
+      cellBefore = cellList.length > 0
+        ? cellList[cellList.length - 1] || null
+        : null;
+      cellAfter = null;
+      break;
+    case "after_current":
+    default:
+      cellBefore = cellList[currentCellIndex] || null;
+      cellAfter = currentCellIndex < cellList.length - 1
+        ? cellList[currentCellIndex + 1] || null
+        : null;
+      break;
+  }
+
   logger.info("Creating cell via AI tool call", {
     cellType,
-    position: newPosition,
+    placement: position,
     contentLength: content.length,
+    cellBefore: cellBefore?.id,
+    cellAfter: cellAfter?.id,
   });
 
-  // Create the new cell
-  store.commit(
-    events.cellCreated({
+  // Create the new cell with fractional index
+  const createEvent = createCellBetween(
+    {
       id: newCellId,
       cellType: cellType as "code" | "markdown" | "raw" | "sql" | "ai",
-      position: newPosition,
       createdBy: `ai-assistant-${sessionId}`,
-    }),
+    },
+    cellBefore,
+    cellAfter,
   );
+
+  store.commit(createEvent);
 
   // Set the cell source if provided
   if (content.length > 0) {

--- a/packages/lib/examples/streaming-demo.ts
+++ b/packages/lib/examples/streaming-demo.ts
@@ -6,7 +6,7 @@
 
 import { createRuntimeConfig, RuntimeAgent } from "@runt/lib";
 import type { ExecutionContext } from "@runt/lib";
-import { events, tables } from "@runt/schema";
+import { createCellBetween, events, tables } from "@runt/schema";
 
 class StreamingDemoAgent {
   private agent: RuntimeAgent;
@@ -63,12 +63,16 @@ class StreamingDemoAgent {
 
         // Create a cell with help command
         const cellId = crypto.randomUUID();
-        this.agent.store.commit(events.cellCreated({
-          id: cellId,
-          cellType: "code",
-          position: 0,
-          createdBy: "streaming-demo-runtime",
-        }));
+        const createEvent = createCellBetween(
+          {
+            id: cellId,
+            cellType: "code",
+            createdBy: "streaming-demo-runtime",
+          },
+          null, // cellBefore
+          null, // cellAfter
+        );
+        this.agent.store.commit(createEvent);
 
         // Update the cell with source content
         this.agent.store.commit(events.cellSourceChanged({

--- a/packages/lib/src/runtime-agent-text-representations.test.ts
+++ b/packages/lib/src/runtime-agent-text-representations.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import { RuntimeAgent } from "./runtime-agent.ts";
 import { RuntimeConfig } from "./config.ts";
-import { events, type MediaContainer } from "@runt/schema";
+import { createCellBetween, events, type MediaContainer } from "@runt/schema";
 import type {
   IArtifactClient,
   RawOutputData,
@@ -65,12 +65,16 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
 
       // Create a cell first
       const cellId = "test-cell-123";
-      agent.store.commit(events.cellCreated({
-        id: cellId,
-        cellType: "code",
-        position: 0,
-        createdBy: "test-user",
-      }));
+      const createEvent = createCellBetween(
+        {
+          id: cellId,
+          cellType: "code",
+          createdBy: "test-user",
+        },
+        null,
+        null,
+      );
+      agent.store.commit(createEvent);
 
       // Request execution
       const queueId = crypto.randomUUID();
@@ -165,12 +169,16 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
 
       // Create a cell first
       const cellId = "test-cell-456";
-      agent.store.commit(events.cellCreated({
-        id: cellId,
-        cellType: "code",
-        position: 0,
-        createdBy: "test-user",
-      }));
+      const createEvent = createCellBetween(
+        {
+          id: cellId,
+          cellType: "code",
+          createdBy: "test-user",
+        },
+        null,
+        null,
+      );
+      agent.store.commit(createEvent);
 
       // Request execution
       const queueId = crypto.randomUUID();
@@ -268,12 +276,16 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
 
       // Create a cell first
       const cellId = "test-cell-789";
-      agent.store.commit(events.cellCreated({
-        id: cellId,
-        cellType: "code",
-        position: 0,
-        createdBy: "test-user",
-      }));
+      const createEvent = createCellBetween(
+        {
+          id: cellId,
+          cellType: "code",
+          createdBy: "test-user",
+        },
+        null,
+        null,
+      );
+      agent.store.commit(createEvent);
 
       // Request execution
       const queueId = crypto.randomUUID();

--- a/packages/pyodide-runtime-agent/test/ai-cancellation.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cancellation.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertExists } from "jsr:@std/assert@1.0.13";
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
-import { events, tables } from "@runt/schema";
+import { createCellBetween, events, tables } from "@runt/schema";
 import { withQuietConsole } from "../../lib/test/test-config.ts";
 
 // Configure test environment for quiet logging
@@ -42,14 +42,16 @@ Deno.test({
 
       // Create an AI cell
       const aiCellId = "ai-cell-cancel-test";
-      agent.store.commit(
-        events.cellCreated({
+      const createAiCellEvent = createCellBetween(
+        {
           id: aiCellId,
           cellType: "ai",
-          position: 1,
           createdBy: "test",
-        }),
+        },
+        null,
+        null,
       );
+      agent.store.commit(createAiCellEvent);
 
       // Set a long-running AI prompt
       const prompt = "Explain quantum computing in great detail with examples";
@@ -63,14 +65,16 @@ Deno.test({
 
       // Create a code cell that should NOT execute if cancellation works
       const codeCellId = "code-cell-after-ai";
-      agent.store.commit(
-        events.cellCreated({
+      const createCodeCellEvent = createCellBetween(
+        {
           id: codeCellId,
           cellType: "code",
-          position: 2,
           createdBy: "test",
-        }),
+        },
+        null,
+        null,
       );
+      agent.store.commit(createCodeCellEvent);
 
       agent.store.commit(
         events.cellSourceChanged({

--- a/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, assertExists } from "jsr:@std/assert@1.0.13";
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
-import { events, tables } from "@runt/schema";
+import { createCellBetween, events, tables } from "@runt/schema";
 import { withQuietConsole } from "../../lib/test/test-config.ts";
 
 // Configure test environment for quiet logging
@@ -43,14 +43,16 @@ Deno.test({
 
       // Create an AI cell with empty content
       const aiCellId = "ai-cell-empty";
-      agent.store.commit(
-        events.cellCreated({
+      const createEvent = createCellBetween(
+        {
           id: aiCellId,
           cellType: "ai",
-          position: 1,
           createdBy: "test",
-        }),
+        },
+        null,
+        null,
       );
+      agent.store.commit(createEvent);
 
       // Don't set any source (empty cell)
 

--- a/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
@@ -8,7 +8,7 @@ import { assertEquals, assertExists } from "jsr:@std/assert";
 import { delay } from "jsr:@std/async/delay";
 import { crypto } from "jsr:@std/crypto";
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
-import { events, tables } from "@runt/schema";
+import { createCellBetween, events, tables } from "@runt/schema";
 
 import { withQuietConsole } from "../../lib/test/test-config.ts";
 
@@ -78,12 +78,16 @@ Deno.test({
 
       // Create a cell with Python arithmetic
       const cellId = `cell-${crypto.randomUUID()}`;
-      agent.store.commit(events.cellCreated({
-        id: cellId,
-        position: 0,
-        cellType: "code",
-        createdBy: "test-user",
-      }));
+      const createEvent = createCellBetween(
+        {
+          id: cellId,
+          cellType: "code",
+          createdBy: "test-user",
+        },
+        null,
+        null,
+      );
+      agent.store.commit(createEvent);
 
       // Test basic arithmetic
       const pythonCode = "3 * 7";

--- a/packages/tui/src/components/notebook/NotebookRenderer.tsx
+++ b/packages/tui/src/components/notebook/NotebookRenderer.tsx
@@ -315,7 +315,6 @@ export const NotebookRenderer: React.FC<NotebookRendererProps> = ({
     );
 
     // Create new cell after current one
-    const currentCell = cells.find((c) => c.id === cellId);
     const currentCellIndex = cells.findIndex((c) => c.id === cellId);
     const newCellId = `cell-${Date.now()}`;
 

--- a/packages/tui/src/components/notebook/NotebookRenderer.tsx
+++ b/packages/tui/src/components/notebook/NotebookRenderer.tsx
@@ -5,6 +5,7 @@ import { queryDb } from "@livestore/livestore";
 import {
   type CellData,
   type CellType,
+  createCellBetween,
   events,
   type OutputData,
   tables,
@@ -117,19 +118,22 @@ export const NotebookRenderer: React.FC<NotebookRendererProps> = ({
     if (!store) return;
 
     const newCellId = `cell-${Date.now()}`;
-    const newPosition = cells.length > 0
-      ? Math.max(...cells.map((c) => c.position)) + 1
-      : 0;
 
-    store.commit(
-      events.cellCreated({
+    // Place at end: after the last cell
+    const cellBefore = cells.length > 0 ? cells[cells.length - 1] : null;
+    const cellAfter = null;
+
+    const createEvent = createCellBetween(
+      {
         id: newCellId,
         cellType: "code",
-        position: newPosition,
         createdBy: "tui-client",
-        actorId: "tui-client",
-      }),
+      },
+      cellBefore,
+      cellAfter,
     );
+
+    store.commit(createEvent);
 
     // Select the new cell
     setSelectedCellIndex(cells.length);
@@ -144,31 +148,34 @@ export const NotebookRenderer: React.FC<NotebookRendererProps> = ({
     const selectedCell = cells[selectedCellIndex];
     const newCellId = `cell-${Date.now()}`;
 
-    let newPosition: number;
+    let cellBefore = null;
+    let cellAfter = null;
     let newSelectionIndex = selectedCellIndex;
 
     if (position === "above") {
-      newPosition = selectedCellIndex > 0
-        ? (cells[selectedCellIndex - 1].position + selectedCell.position) / 2
-        : selectedCell.position - 1;
-      // Don't change selection - new cell is above
+      cellBefore = selectedCellIndex > 0 ? cells[selectedCellIndex - 1] : null;
+      cellAfter = selectedCell;
+      newSelectionIndex = selectedCellIndex;
     } else {
       // position === "below"
-      newPosition = selectedCellIndex < cells.length - 1
-        ? (selectedCell.position + cells[selectedCellIndex + 1].position) / 2
-        : selectedCell.position + 1;
+      cellBefore = selectedCell;
+      cellAfter = selectedCellIndex < cells.length - 1
+        ? cells[selectedCellIndex + 1]
+        : null;
       newSelectionIndex = selectedCellIndex + 1;
     }
 
-    store.commit(
-      events.cellCreated({
+    const createEvent = createCellBetween(
+      {
         id: newCellId,
         cellType,
-        position: newPosition,
         createdBy: "tui-client",
-        actorId: "tui-client",
-      }),
+      },
+      cellBefore,
+      cellAfter,
     );
+
+    store.commit(createEvent);
 
     if (position === "below") {
       setSelectedCellIndex(newSelectionIndex);
@@ -307,24 +314,28 @@ export const NotebookRenderer: React.FC<NotebookRendererProps> = ({
       }),
     );
 
-    // 3. Create new cell after current one
+    // Create new cell after current one
+    const currentCell = cells.find((c) => c.id === cellId);
     const currentCellIndex = cells.findIndex((c) => c.id === cellId);
     const newCellId = `cell-${Date.now()}`;
-    const newPosition =
-      currentCellIndex >= 0 && currentCellIndex < cells.length - 1
-        ? (cells[currentCellIndex].position +
-          cells[currentCellIndex + 1].position) / 2
-        : (currentCell?.position || 0) + 1;
 
-    store.commit(
-      events.cellCreated({
+    const cellBefore = currentCell || null;
+    const cellAfter =
+      currentCellIndex >= 0 && currentCellIndex < cells.length - 1
+        ? cells[currentCellIndex + 1]
+        : null;
+
+    const createEvent = createCellBetween(
+      {
         id: newCellId,
         cellType: "code",
-        position: newPosition,
         createdBy: "tui-client",
-        actorId: "tui-client",
-      }),
+      },
+      cellBefore,
+      cellAfter,
     );
+
+    store.commit(createEvent);
 
     // 4. Exit editing mode and select the new cell
     setEditingCellId(null);
@@ -386,21 +397,24 @@ export const NotebookRenderer: React.FC<NotebookRendererProps> = ({
 
     // 2. Create new cell after current one
     const newCellId = `cell-${Date.now()}`;
-    const newPosition =
-      selectedCellIndex >= 0 && selectedCellIndex < cells.length - 1
-        ? (cells[selectedCellIndex].position +
-          cells[selectedCellIndex + 1].position) / 2
-        : (selectedCell.position || 0) + 1;
 
-    store.commit(
-      events.cellCreated({
+    const cellBefore = selectedCell;
+    const cellAfter =
+      selectedCellIndex >= 0 && selectedCellIndex < cells.length - 1
+        ? cells[selectedCellIndex + 1]
+        : null;
+
+    const createEvent = createCellBetween(
+      {
         id: newCellId,
         cellType: "code",
-        position: newPosition,
         createdBy: "tui-client",
-        actorId: "tui-client",
-      }),
+      },
+      cellBefore,
+      cellAfter,
     );
+
+    store.commit(createEvent);
 
     // 3. Select the new cell
     setSelectedCellIndex(selectedCellIndex + 1);

--- a/packages/tui/src/queries/index.ts
+++ b/packages/tui/src/queries/index.ts
@@ -10,7 +10,7 @@ import { queryDb } from "@livestore/livestore";
 
 // Core cell queries optimized for TUI display
 export const tuiCells$ = queryDb(
-  tables.cells.select().orderBy("position", "asc"),
+  tables.cells.select().orderBy("fractionalIndex", "asc"),
   { label: "tui.cells" },
 );
 


### PR DESCRIPTION
This PR updates all runtime agent and TUI code to use the new fractional indexing system exported from the schema package.

## Changes

- **AI Package**: Updated `tool-registry.ts` to use `createCellBetween()` instead of position calculations
- **TUI Package**: Updated queries to order by `fractionalIndex` and use `createCellBetween()` for cell creation
- **Test Updates**: All tests now use `createCellBetween()` with null before/after for initial cells
- **Query Updates**: Removed direct position-based ordering in favor of fractional indices

## Key Benefits

- Deterministic cell ordering across all clients
- Simpler cell creation API using `createCellBetween()` and `moveCellBetween()`
- No more position calculations or averages