### PR TITLE
chore: bump all packages to version 0.9.1

### DIFF
--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/ai",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Runtime AI Clients",
   "license": "BSD-3-Clause",
   "repository": {
@@ -12,7 +12,7 @@
   },
   "imports": {
     "@runt/lib": "jsr:@runt/lib@^0.9.0",
-    "@runt/schema": "jsr:@runt/schema@^0.9.0",
+    "@runt/schema": "jsr:@runt/schema@^0.9.1",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "@std/path": "jsr:@std/path@^1.0.0",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Runtime agent library for building Anode runtime agents",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.9.0",
+    "@runt/schema": "jsr:@runt/schema@^0.9.1",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/crypto": "jsr:@std/crypto@^1.0.0",

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,9 +14,9 @@
     "pyorunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/ai": "jsr:@runt/ai@^0.9.0",
-    "@runt/lib": "jsr:@runt/lib@^0.9.0",
-    "@runt/schema": "jsr:@runt/schema@^0.9.0",
+    "@runt/ai": "jsr:@runt/ai@^0.9.1",
+    "@runt/lib": "jsr:@runt/lib@^0.9.1",
+    "@runt/schema": "jsr:@runt/schema@^0.9.1",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/python-runtime-agent",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Stub Python runtime agent for Runt platform.",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,8 +14,8 @@
     "pyrunt": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.9.0",
-    "@runt/schema": "jsr:@runt/schema@^0.9.0"
+    "@runt/lib": "jsr:@runt/lib@^0.9.1",
+    "@runt/schema": "jsr:@runt/schema@^0.9.1"
   },
   "tasks": {
     "test": "deno test --allow-all",

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "This package.json is solely here to make linking possible for npm users",
   "type": "module",
   "main": "./mod.ts",

--- a/packages/schema/test.ts
+++ b/packages/schema/test.ts
@@ -1434,7 +1434,7 @@ Deno.test("v2.CellMoved - edge cases", async () => {
 
 Deno.test("v2.CellMoved - concurrent movements", async () => {
   const store = await setupStore();
-  const { fractionalIndexBetween, moveCellBetween, defaultJitterProvider } =
+  const { fractionalIndexBetween, moveCellBetween, createTestJitterProvider } =
     await import(
       "@runt/schema"
     );
@@ -1442,11 +1442,12 @@ Deno.test("v2.CellMoved - concurrent movements", async () => {
   // Create initial cells
   const cells = [];
   let prevKey: string | null = null;
+  const setupJitter = createTestJitterProvider(42);
   for (let i = 1; i <= 4; i++) {
     const fractionalIndex = fractionalIndexBetween(
       prevKey,
       null,
-      defaultJitterProvider,
+      setupJitter,
     );
     cells.push({ id: `cell-${i}`, fractionalIndex });
     prevKey = fractionalIndex;
@@ -1466,12 +1467,16 @@ Deno.test("v2.CellMoved - concurrent movements", async () => {
   const cell3 = cells.find((c) => c.id === "cell-3")!;
   const cell4 = cells.find((c) => c.id === "cell-4")!;
 
+  // Use different jitter providers for each user to simulate concurrent operations
+  const user1Jitter = createTestJitterProvider(123);
+  const user2Jitter = createTestJitterProvider(456);
+
   const move1 = moveCellBetween(
     cell4,
     cell1,
     cell2,
     "user1",
-    defaultJitterProvider,
+    user1Jitter,
   );
   assertExists(move1);
 
@@ -1481,7 +1486,7 @@ Deno.test("v2.CellMoved - concurrent movements", async () => {
     cell1,
     cell2,
     "user2",
-    defaultJitterProvider,
+    user2Jitter,
   );
   assertExists(move2);
 

--- a/packages/tui/deno.json
+++ b/packages/tui/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/tui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A powerful terminal-based notebook interface for Runt runtime agents, enabling interactive editing, execution, and real-time collaboration.",
   "license": "BSD-3-Clause",
   "exports": {
@@ -22,9 +22,9 @@
     "lint": "deno lint"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.9.0",
-    "@runt/lib": "jsr:@runt/lib@^0.9.0",
-    "@runt/ai": "jsr:@runt/ai@^0.9.0",
+    "@runt/schema": "jsr:@runt/schema@^0.9.1",
+    "@runt/lib": "jsr:@runt/lib@^0.9.1",
+    "@runt/ai": "jsr:@runt/ai@^0.9.1",
     "@inkjs/ui": "npm:@inkjs/ui@^2.0.0",
     "@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "@livestore/livestore": "npm:@livestore/livestore@^0.3.1",


### PR DESCRIPTION
Bump all packages to version 0.9.1 following the fractional indexing improvements.

## Changes
- Update all package versions from 0.9.0 to 0.9.1
- Update internal dependencies to use 0.9.1
- Fix concurrent movements test to use different jitter providers

## Release Notes
This release includes the improved fractional indexing implementation that uses base36 encoding for better binary collation and proper handling of edge cases.