### PR TITLE
fix: handle m0/m000 edge case in fractional indexing

### DIFF
--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/ai",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Runtime AI Clients",
   "license": "BSD-3-Clause",
   "repository": {
@@ -11,8 +11,8 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.9.0",
-    "@runt/schema": "jsr:@runt/schema@^0.9.1",
+    "@runt/lib": "jsr:@runt/lib@^0.9.2",
+    "@runt/schema": "jsr:@runt/schema@^0.9.2",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "@std/path": "jsr:@std/path@^1.0.0",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Runtime agent library for building Anode runtime agents",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.9.1",
+    "@runt/schema": "jsr:@runt/schema@^0.9.2",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/crypto": "jsr:@std/crypto@^1.0.0",

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,9 +14,9 @@
     "pyorunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/ai": "jsr:@runt/ai@^0.9.1",
-    "@runt/lib": "jsr:@runt/lib@^0.9.1",
-    "@runt/schema": "jsr:@runt/schema@^0.9.1",
+    "@runt/ai": "jsr:@runt/ai@^0.9.2",
+    "@runt/lib": "jsr:@runt/lib@^0.9.2",
+    "@runt/schema": "jsr:@runt/schema@^0.9.2",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/python-runtime-agent",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Stub Python runtime agent for Runt platform.",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,8 +14,8 @@
     "pyrunt": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.9.1",
-    "@runt/schema": "jsr:@runt/schema@^0.9.1"
+    "@runt/lib": "jsr:@runt/lib@^0.9.2",
+    "@runt/schema": "jsr:@runt/schema@^0.9.2"
   },
   "tasks": {
     "test": "deno test --allow-all",

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -1414,21 +1414,25 @@ function generateKeyBetween(
       }
     } else {
       // nextVal is 0, meaning b continues with "0" after a ends
-      // We need to find what can go between a and a+"0"
-      // Since there's nothing less than "0" in our alphabet,
-      // we must look deeper into b for space
+      // Check if we can insert something between them
       if (b.length > i + 1) {
-        // b continues past the "0", so we can work within that space
-        // For example, if b = "a00", we can generate something like "a" + "0" + something < "0"
-        // But since nothing is less than "0", we need to look even deeper
-        let j = i + 1;
+        // b continues past the initial "0"
+        // Count consecutive zeros after position i in b
+        let zeroCount = 0;
+        let j = i;
         while (j < b.length && b[j] === "0") {
+          zeroCount++;
           j++;
         }
 
-        if (j < b.length) {
-          // Found a non-zero character at position j
-          // We can insert between a+"0"*count and b
+        // If b is all zeros after the prefix, we can insert a string with fewer zeros
+        // For example: between "m" and "m000", we can use "m0" or "m00"
+        if (j === b.length && zeroCount > 1) {
+          // Use half the zeros (at least 1)
+          return a + "0".repeat(Math.floor(zeroCount / 2));
+        } else if (j < b.length) {
+          // b has a non-zero character at position j
+          // We can insert something before that position
           const prefix = a + "0".repeat(j - i);
           const nextChar = b[j];
           if (!nextChar) {
@@ -1439,17 +1443,11 @@ function generateKeyBetween(
             return prefix + valueToChar(Math.floor(nextVal / 2));
           }
         }
-        // All remaining characters are "0" or we've reached the end
-        // This means a and b are adjacent
-        throw new Error(
-          `No string exists between "${a}" and "${b}" in base36 encoding`,
-        );
-      } else {
-        // b = "a0" exactly, there's no string between "a" and "a0"
-        throw new Error(
-          `No string exists between "${a}" and "${b}" in base36 encoding`,
-        );
       }
+      // No space between a and b
+      throw new Error(
+        `No string exists between "${a}" and "${b}" in base36 encoding`,
+      );
     }
   }
 

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -1632,9 +1632,6 @@ export function generateFractionalIndices(
   // Generate n keys by repeatedly subdividing the range
   let prev = a;
   for (let i = 0; i < n; i++) {
-    // Calculate position in range (0 to 1)
-    const _position = (i + 1) / (n + 1);
-
     // For better distribution, we generate keys sequentially
     // This avoids clustering that can happen with binary subdivision
     const key = fractionalIndexBetween(prev, b, jitterProvider);

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "This package.json is solely here to make linking possible for npm users",
   "type": "module",
   "main": "./mod.ts",

--- a/packages/tui/deno.json
+++ b/packages/tui/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/tui",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A powerful terminal-based notebook interface for Runt runtime agents, enabling interactive editing, execution, and real-time collaboration.",
   "license": "BSD-3-Clause",
   "exports": {
@@ -22,9 +22,9 @@
     "lint": "deno lint"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.9.1",
-    "@runt/lib": "jsr:@runt/lib@^0.9.1",
-    "@runt/ai": "jsr:@runt/ai@^0.9.1",
+    "@runt/schema": "jsr:@runt/schema@^0.9.2",
+    "@runt/lib": "jsr:@runt/lib@^0.9.2",
+    "@runt/ai": "jsr:@runt/ai@^0.9.2",
     "@inkjs/ui": "npm:@inkjs/ui@^2.0.0",
     "@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/test-stability.ts
+++ b/test-stability.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env -S deno run --allow-run --allow-read
+
+/**
+ * Test stability script to verify fractional indexing improvements
+ * Runs critical tests multiple times to ensure consistency
+ */
+
+const ITERATIONS = 50;
+const CRITICAL_TESTS = [
+  {
+    name: "Fractional indexing concurrent operations",
+    file: "packages/schema/test/fractional-cell-index.test.ts",
+    filter: "concurrent",
+  },
+  {
+    name: "Extreme clustering",
+    file: "packages/schema/test/fractional-cell-index.test.ts",
+    filter: "clustering",
+  },
+  {
+    name: "v2.CellMoved concurrent movements",
+    file: "packages/schema/test.ts",
+    filter: "concurrent movements",
+  },
+  {
+    name: "Fractional indexing edge cases",
+    file: "packages/schema/test.ts",
+    filter: "edge cases",
+  },
+  {
+    name: "Jitter provider consistency",
+    file: "packages/schema/test/fractional-cell-index.test.ts",
+    filter: "JitterProvider",
+  },
+];
+
+interface TestResult {
+  test: string;
+  successes: number;
+  failures: number;
+  errors: string[];
+}
+
+async function runTest(file: string, filter: string): Promise<boolean> {
+  const cmd = new Deno.Command("deno", {
+    args: [
+      "test",
+      "--allow-all",
+      "--quiet",
+      "--filter",
+      filter,
+      file,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const { code, stdout, stderr } = await cmd.output();
+
+  if (code !== 0) {
+    const errorOutput = new TextDecoder().decode(stderr);
+    const stdOutput = new TextDecoder().decode(stdout);
+    console.error(`Test failed with output:\n${stdOutput}\n${errorOutput}`);
+    return false;
+  }
+
+  return true;
+}
+
+async function runTestMultipleTimes(
+  name: string,
+  file: string,
+  filter: string,
+  iterations: number,
+): Promise<TestResult> {
+  const result: TestResult = {
+    test: name,
+    successes: 0,
+    failures: 0,
+    errors: [],
+  };
+
+  console.log(`\n🔄 Running "${name}" ${iterations} times...`);
+
+  for (let i = 0; i < iterations; i++) {
+    process.stdout.write(`\r  Progress: ${i + 1}/${iterations}`);
+
+    try {
+      const success = await runTest(file, filter);
+      if (success) {
+        result.successes++;
+      } else {
+        result.failures++;
+        result.errors.push(`Failed on iteration ${i + 1}`);
+      }
+    } catch (error) {
+      result.failures++;
+      result.errors.push(`Error on iteration ${i + 1}: ${error}`);
+    }
+  }
+
+  console.log(); // New line after progress
+  return result;
+}
+
+async function main() {
+  console.log("🧪 Testing Fractional Indexing Stability");
+  console.log(
+    `Running ${CRITICAL_TESTS.length} critical tests ${ITERATIONS} times each`,
+  );
+  console.log("=" + "=".repeat(79));
+
+  const results: TestResult[] = [];
+
+  for (const test of CRITICAL_TESTS) {
+    const result = await runTestMultipleTimes(
+      test.name,
+      test.file,
+      test.filter,
+      ITERATIONS,
+    );
+    results.push(result);
+  }
+
+  // Print summary
+  console.log("\n" + "=".repeat(80));
+  console.log("📊 TEST STABILITY REPORT");
+  console.log("=".repeat(80));
+
+  let allPassed = true;
+
+  for (const result of results) {
+    const successRate = (result.successes / ITERATIONS * 100).toFixed(1);
+    const status = result.failures === 0 ? "✅" : "❌";
+
+    console.log(`\n${status} ${result.test}`);
+    console.log(
+      `   Success rate: ${successRate}% (${result.successes}/${ITERATIONS})`,
+    );
+
+    if (result.failures > 0) {
+      allPassed = false;
+      console.log(`   Failures: ${result.failures}`);
+      if (result.errors.length > 0 && result.errors.length <= 5) {
+        result.errors.forEach((err) => console.log(`     - ${err}`));
+      } else if (result.errors.length > 5) {
+        console.log(`     (${result.errors.length} errors - showing first 5)`);
+        result.errors.slice(0, 5).forEach((err) =>
+          console.log(`     - ${err}`)
+        );
+      }
+    }
+  }
+
+  console.log("\n" + "=".repeat(80));
+
+  if (allPassed) {
+    console.log("✅ All tests passed consistently!");
+    console.log("The fractional indexing implementation appears to be stable.");
+  } else {
+    console.log("❌ Some tests showed inconsistent behavior.");
+    console.log(
+      "This may indicate race conditions or non-deterministic behavior.",
+    );
+    Deno.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("Script failed:", error);
+    Deno.exit(1);
+  });
+}

--- a/test-stability.ts
+++ b/test-stability.ts
@@ -83,7 +83,9 @@ async function runTestMultipleTimes(
   console.log(`\n🔄 Running "${name}" ${iterations} times...`);
 
   for (let i = 0; i < iterations; i++) {
-    process.stdout.write(`\r  Progress: ${i + 1}/${iterations}`);
+    await Deno.stdout.write(
+      new TextEncoder().encode(`\r  Progress: ${i + 1}/${iterations}`),
+    );
 
     try {
       const success = await runTest(file, filter);


### PR DESCRIPTION
Fixes the CI failure seen in the fractional indexing tests and bumps version to 0.9.2.

## Changes

### Edge Case Fix
The algorithm was throwing an error when trying to insert between strings like "m0" and "m000", claiming they were adjacent when in fact "m00" fits between them.

Updated the algorithm to properly count zeros and recognize when we can insert a string with an intermediate number of zeros. For example:
- Between "m" and "m000", we can insert "m0" or "m00"
- Between "m0" and "m000", we can insert "m00"

### Version Bump to 0.9.2
- Update all package versions from 0.9.1 to 0.9.2
- Update all internal dependencies to use 0.9.2
- Fix unused `_position` variable lint error
- Fix `process.stdout.write` lint error in stability test

## Testing
- The failing test now passes
- All other tests continue to pass
- The fix properly handles the edge case that occurs with deterministic (no jitter) insertions
- Fixed TypeScript errors that would affect consumers using strict type checking