### PR TITLE
feat: add afterId parameter to AI create_cell tool

### DIFF
--- a/packages/ai/examples/create-cell-after-id-demo.ts
+++ b/packages/ai/examples/create-cell-after-id-demo.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env -S deno run --allow-all
+
+/**
+ * Demo: Creating cells with afterId parameter
+ *
+ * This demonstrates how the AI's create_cell tool can now place cells
+ * after specific cell IDs, enabling precise notebook construction.
+ */
+
+import { NOTEBOOK_TOOLS_EXPORT } from "../tool-registry.ts";
+
+console.log("=== Create Cell Tool with afterId Support ===\n");
+
+// Find the create_cell tool
+const createCellTool = NOTEBOOK_TOOLS_EXPORT.find((t) =>
+  t.name === "create_cell"
+);
+
+if (!createCellTool) {
+  console.error("create_cell tool not found!");
+  Deno.exit(1);
+}
+
+// Display the tool definition
+console.log("Tool Definition:");
+console.log(JSON.stringify(createCellTool, null, 2));
+
+console.log("\n=== Example Usage Scenarios ===\n");
+
+// Scenario 1: Traditional positioning
+console.log("1. Traditional positioning (relative to AI cell):");
+console.log("   - position: 'after_current' - Places cell after the AI cell");
+console.log("   - position: 'before_current' - Places cell before the AI cell");
+console.log("   - position: 'at_end' - Places cell at the end of the notebook");
+
+// Scenario 2: Using afterId
+console.log("\n2. Using afterId for precise placement:");
+console.log("   Step 1: Create initial cell");
+console.log("   {");
+console.log("     cellType: 'code',");
+console.log("     source: 'import pandas as pd',");
+console.log("     position: 'after_current'");
+console.log("   }");
+console.log("   Returns: 'Created code cell: cell-1234567890-abc'");
+console.log("");
+console.log("   Step 2: Create next cell after the first one");
+console.log("   {");
+console.log("     cellType: 'code',");
+console.log("     source: 'df = pd.DataFrame({\"A\": [1, 2, 3]})',");
+console.log(
+  "     afterId: 'cell-1234567890-abc'  // <-- Using the ID from step 1",
+);
+console.log("   }");
+console.log("   Returns: 'Created code cell: cell-1234567890-def'");
+console.log("");
+console.log("   Step 3: Continue building the sequence");
+console.log("   {");
+console.log("     cellType: 'code',");
+console.log("     source: 'df.describe()',");
+console.log(
+  "     afterId: 'cell-1234567890-def'  // <-- Using the ID from step 2",
+);
+console.log("   }");
+
+// Scenario 3: Complex notebook construction
+console.log("\n3. Building a complex notebook structure:");
+console.log("   The AI can now:");
+console.log("   - Create a markdown header cell");
+console.log("   - Add code cells in sequence after it");
+console.log("   - Insert explanatory markdown between code cells");
+console.log("   - Build up a complete analysis step by step");
+
+console.log("\n=== Key Benefits ===\n");
+console.log("✓ Precise control over cell ordering");
+console.log("✓ Ability to build sequential workflows");
+console.log("✓ Insert cells at any position by referencing existing cell IDs");
+console.log("✓ Maintain logical flow in notebook construction");
+
+console.log("\n=== Implementation Notes ===\n");
+console.log("- afterId takes precedence over position when both are provided");
+console.log("- If afterId references a non-existent cell, an error is thrown");
+console.log(
+  "- The AI receives the cell ID in the response for future reference",
+);
+console.log(
+  "- This enables 'notebook mood' where AI builds cells sequentially",
+);
+
+// Show the actual parameters structure
+console.log("\n=== Parameter Details ===\n");
+const afterIdParam = createCellTool.parameters.properties.afterId;
+console.log("afterId parameter:");
+console.log(`  type: ${afterIdParam?.type}`);
+console.log(`  description: ${afterIdParam?.description}`);
+console.log(
+  `  required: ${
+    createCellTool.parameters.required?.includes("afterId") ? "yes" : "no"
+  }`,
+);

--- a/packages/ai/openai-client.ts
+++ b/packages/ai/openai-client.ts
@@ -838,8 +838,14 @@ Once configured, your AI cells will work with real OpenAI models!`;
       case "create_cell": {
         const cellType = String(args.cellType || "code");
         const position = String(args.position || "after_current");
+        const afterId = args.afterId ? String(args.afterId) : null;
         const content = String(args.content || "");
-        return `Created **${cellType}** cell at position **${position}**\n\n` +
+
+        const positionText = afterId
+          ? `after cell **${afterId}**`
+          : `at position **${position}**`;
+
+        return `Created **${cellType}** cell ${positionText}\n\n` +
           `Content preview:\n\`\`\`${
             cellType === "code" ? "python" : cellType
           }\n${content.slice(0, 200)}${

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -44,7 +44,7 @@ const NOTEBOOK_TOOLS: NotebookTool[] = [
   {
     name: "create_cell",
     description:
-      "Create a new cell in the notebook at a specified position. Use this when you want to add new code, markdown, or other content to help the user.",
+      "Create a new cell in the notebook. You can either specify a position relative to the current AI cell OR provide an afterId to place it after a specific cell. Use this when you want to add new code, markdown, or other content to help the user.",
     parameters: {
       type: "object",
       properties: {
@@ -61,8 +61,13 @@ const NOTEBOOK_TOOLS: NotebookTool[] = [
           type: "string",
           enum: ["after_current", "before_current", "at_end"],
           description:
-            'Where to place the new cell. Use "after_current" (default) to place right after the AI cell, "before_current" to place before it, or "at_end" only when specifically requested',
+            'Where to place the new cell relative to the current AI cell. Use "after_current" (default) to place right after the AI cell, "before_current" to place before it, or "at_end" only when specifically requested. Ignored if afterId is provided.',
           default: "after_current",
+        },
+        afterId: {
+          type: "string",
+          description:
+            "The ID of an existing cell to place the new cell after. When provided, this takes precedence over the position parameter. Use this to create cells in a specific sequence.",
         },
       },
       required: ["cellType", "source"],
@@ -194,6 +199,7 @@ export function createCell(
   const cellType = String(args.cellType || "code");
   const content = String(args.source || args.content || ""); // Check source first, then content
   const position = String(args.position || "after_current");
+  const afterId = args.afterId ? String(args.afterId) : null;
 
   // Get ordered cells with fractional indices
   const cellList = store.query(cellList$);
@@ -205,31 +211,44 @@ export function createCell(
   let cellBefore = null;
   let cellAfter = null;
 
-  switch (position) {
-    case "before_current":
-      cellBefore = currentCellIndex > 0
-        ? cellList[currentCellIndex - 1] || null
-        : null;
-      cellAfter = cellList[currentCellIndex] || null;
-      break;
-    case "at_end":
-      cellBefore = cellList.length > 0
-        ? cellList[cellList.length - 1] || null
-        : null;
-      cellAfter = null;
-      break;
-    case "after_current":
-    default:
-      cellBefore = cellList[currentCellIndex] || null;
-      cellAfter = currentCellIndex < cellList.length - 1
-        ? cellList[currentCellIndex + 1] || null
-        : null;
-      break;
+  // If afterId is provided, use that for positioning
+  if (afterId) {
+    const afterCellIndex = cellList.findIndex((c) => c.id === afterId);
+    if (afterCellIndex === -1) {
+      throw new Error(`Cell with ID ${afterId} not found`);
+    }
+    cellBefore = cellList[afterCellIndex] || null;
+    cellAfter = afterCellIndex < cellList.length - 1
+      ? cellList[afterCellIndex + 1] || null
+      : null;
+  } else {
+    // Otherwise use position parameter
+    switch (position) {
+      case "before_current":
+        cellBefore = currentCellIndex > 0
+          ? cellList[currentCellIndex - 1] || null
+          : null;
+        cellAfter = cellList[currentCellIndex] || null;
+        break;
+      case "at_end":
+        cellBefore = cellList.length > 0
+          ? cellList[cellList.length - 1] || null
+          : null;
+        cellAfter = null;
+        break;
+      case "after_current":
+      default:
+        cellBefore = cellList[currentCellIndex] || null;
+        cellAfter = currentCellIndex < cellList.length - 1
+          ? cellList[currentCellIndex + 1] || null
+          : null;
+        break;
+    }
   }
 
   logger.info("Creating cell via AI tool call", {
     cellType,
-    placement: position,
+    placement: afterId ? `after ${afterId}` : position,
     contentLength: content.length,
     cellBefore: cellBefore?.id,
     cellAfter: cellAfter?.id,


### PR DESCRIPTION
## Overview

This PR adds an `afterId` parameter to the AI's `create_cell` tool, enabling AI models to place cells after specific cell IDs rather than just relative to the current AI cell.

## Motivation

Previously, the AI could only create cells:
- `after_current` - after the AI cell
- `before_current` - before the AI cell  
- `at_end` - at the end of the notebook

This limited the AI's ability to build complex notebook structures or insert cells in specific sequences.

## Changes

### Tool Definition Update
- Added `afterId` parameter to `create_cell` tool
- Updated tool description to explain the new capability
- `afterId` takes precedence over `position` when both are provided

### Implementation
- Modified `createCell` function to handle positioning by cell ID
- Added error handling for non-existent cell IDs
- Maintains backward compatibility with existing `position` parameter

## Usage Example

The AI can now build sequential workflows:

```javascript
// Step 1: Create initial cell
{
  cellType: 'code',
  source: 'import pandas as pd',
  position: 'after_current'
}
// Returns: 'Created code cell: cell-1234567890-abc'

// Step 2: Create next cell after the first one
{
  cellType: 'code',
  source: 'df = pd.DataFrame({"A": [1, 2, 3]})',
  afterId: 'cell-1234567890-abc'  // Using the ID from step 1
}
// Returns: 'Created code cell: cell-1234567890-def'

// Step 3: Continue building the sequence
{
  cellType: 'code',
  source: 'df.describe()',
  afterId: 'cell-1234567890-def'  // Using the ID from step 2
}
```

## Benefits

- ✅ Precise control over cell ordering
- ✅ Ability to build sequential workflows
- ✅ Insert cells at any position by referencing existing cell IDs
- ✅ Enables "notebook mood" where AI builds complete analyses step by step
- ✅ Maintains backward compatibility

## Testing

- All existing tests pass
- Created demo script showing the new functionality
- Tested error handling for non-existent cell IDs