### PR TITLE
create_cell API uses after_id instead of position

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -56,23 +56,19 @@ From testing with models:
 - Sometimes models don't think carefully about the proper `after_id` and cells end up in weird order
 - This suggests we might want a sensible default behavior
 
-### Recommendation: Optional after_id with Smart Default
-Make `after_id` optional with this behavior:
-- **When provided**: Place cell after the specified cell ID
-- **When omitted**: Place cell after the current AI cell (the one making the call)
-
-This gives us:
-- Explicit control when needed
-- Natural default behavior (responses appear below the AI)
-- No need for special sentinels
-- Flexibility without complexity
+### Recommendation: Required after_id
+Make `after_id` required with no default behavior:
+- **Always explicit**: AI must always specify which cell to place the new cell after
+- **Forces intentional placement**: No ambiguity about where cells will appear
+- **Enables interspersed conversations**: AI can weave through the document by referencing specific cell IDs
+- **No assumptions**: System doesn't assume AI wants to place cells below itself
 
 ## Key Concepts
 
-### 1. AI Knows Its Own Cell ID
-- The AI cell that's making the tool call has access to its own cell ID
-- This replaces the need for `position: "after_current"`
-- The AI can simply use its own ID in `after_id`
+### 1. AI Has Context of All Cell IDs
+- The AI can see cell IDs for all cells in the notebook context
+- The AI must explicitly choose which cell to place new content after
+- No default assumptions about placement relative to the AI's own cell
 
 ### 2. Chaining Cells
 - When the AI creates a cell, it receives the new cell's ID in the response
@@ -131,7 +127,7 @@ export function createCell(
 AI: create_cell({
   cellType: "markdown",
   source: "# Data Analysis",
-  after_id: "cell-ai-123"  // Using own cell ID (or could omit for same effect)
+  after_id: "cell-ai-123"  // Must specify where to place it
 })
 // Returns: "Created markdown cell: cell-abc"
 
@@ -175,23 +171,23 @@ AI: create_cell({
 ## Migration Strategy
 
 1. Update tool definition to remove `position` parameter
-2. Make `after_id` optional, defaulting to current AI cell
-3. Ensure AI has access to its own cell ID in context
-4. Update any system prompts to explain the new approach
+2. Make `after_id` required with no default behavior
+3. Ensure AI has access to all relevant cell IDs in context
+4. Update any system prompts to explain explicit placement approach
 5. Emphasize using `modify_cell` for adding imports/dependencies
 
 ## Considerations
 
-- The AI must have its own cell ID available in the context
-- The AI should see cell IDs for cells above it to enable insertion
+- The AI must have access to relevant cell IDs in the notebook context
 - Error handling for non-existent cell IDs is critical
 - The response must include the created cell ID for chaining
 - Guide models to use `modify_cell` instead of trying to insert at the top
 - Consider adding examples in prompts to help models choose appropriate after_id values
+- Support interspersed conversation patterns where AI weaves through the document
 
 ## Success Criteria
 
-- AI can create cells below itself by using its own cell ID
+- AI can create cells at any position by referencing existing cell IDs
 - AI can chain multiple cells together in sequence
-- AI can insert cells at any position by referencing existing cell IDs
-- The API is simpler and more predictable for LLM usage
+- AI can create interspersed conversation patterns throughout the notebook
+- The API is explicit and predictable for LLM usage

--- a/PLAN.md
+++ b/PLAN.md
@@ -2,16 +2,20 @@
 
 ## Current State
 
-The `create_cell` tool currently uses a `position` parameter to place cells relative to the current AI cell:
+The `create_cell` tool currently uses a `position` parameter to place cells
+relative to the current AI cell:
+
 - `after_current`: places the cell after the AI cell (default)
 - `before_current`: places the cell before the AI cell
 - `at_end`: places the cell at the end of the notebook
 
-This approach limits the AI's ability to build complex notebook structures or place cells in specific sequences.
+This approach limits the AI's ability to build complex notebook structures or
+place cells in specific sequences.
 
 ## Proposed Change
 
-Replace the `position` parameter with `after_id` as the sole method for cell positioning.
+Replace the `position` parameter with `after_id` as the sole method for cell
+positioning.
 
 ### New API Design
 
@@ -46,36 +50,48 @@ Replace the `position` parameter with `after_id` as the sole method for cell pos
 From testing with models:
 
 ### The "Insert at Top" Problem
+
 - There's no cell ID before the first cell, so no way to insert at the top
-- Considered special sentinels (e.g., `runt:top`, `runt:last`) but this feels messy
-- **Better approach**: Use `modify_cell` when you need to add imports or dependencies to existing cells
+- Considered special sentinels (e.g., `runt:top`, `runt:last`) but this feels
+  messy
+- **Better approach**: Use `modify_cell` when you need to add imports or
+  dependencies to existing cells
 - Inserting at the top is rarely needed in practice
 
 ### Model Behavior Observations
+
 - Models generally work well with the `after_id` approach
-- Sometimes models don't think carefully about the proper `after_id` and cells end up in weird order
+- Sometimes models don't think carefully about the proper `after_id` and cells
+  end up in weird order
 - This suggests we might want a sensible default behavior
 
 ### Recommendation: Required after_id
+
 Make `after_id` required with no default behavior:
-- **Always explicit**: AI must always specify which cell to place the new cell after
+
+- **Always explicit**: AI must always specify which cell to place the new cell
+  after
 - **Forces intentional placement**: No ambiguity about where cells will appear
-- **Enables interspersed conversations**: AI can weave through the document by referencing specific cell IDs
+- **Enables interspersed conversations**: AI can weave through the document by
+  referencing specific cell IDs
 - **No assumptions**: System doesn't assume AI wants to place cells below itself
 
 ## Key Concepts
 
 ### 1. AI Has Context of All Cell IDs
+
 - The AI can see cell IDs for all cells in the notebook context
 - The AI must explicitly choose which cell to place new content after
 - No default assumptions about placement relative to the AI's own cell
 
 ### 2. Chaining Cells
+
 - When the AI creates a cell, it receives the new cell's ID in the response
 - The AI can then use this ID to create subsequent cells in sequence
 - This enables building complex notebook structures
 
 ### 3. Looking Up
+
 - The AI has context about cells above it
 - It can reference any visible cell ID to insert content at specific locations
 - This replaces the need for `position: "before_current"`
@@ -95,24 +111,24 @@ export function createCell(
   const cellType = String(args.cellType || "code");
   const content = String(args.source || args.content || "");
   const afterId = String(args.after_id); // Now required
-  
+
   // Get ordered cells with fractional indices
   const cellList = store.query(cellList$);
-  
+
   // Find the cell to insert after
   const afterCellIndex = cellList.findIndex((c) => c.id === afterId);
   if (afterCellIndex === -1) {
     throw new Error(`Cell with ID ${afterId} not found`);
   }
-  
+
   const cellBefore = cellList[afterCellIndex];
   const cellAfter = afterCellIndex < cellList.length - 1
     ? cellList[afterCellIndex + 1]
     : null;
-  
+
   // Generate unique cell ID
   const newCellId = `cell-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  
+
   // ... rest of implementation
 }
 ```
@@ -120,6 +136,7 @@ export function createCell(
 ## Usage Examples
 
 ### Example 1: Building a Simple Analysis
+
 ```javascript
 // AI's current cell ID: "cell-ai-123"
 
@@ -127,28 +144,29 @@ export function createCell(
 AI: create_cell({
   cellType: "markdown",
   source: "# Data Analysis",
-  after_id: "cell-ai-123"  // Must specify where to place it
-})
+  after_id: "cell-ai-123", // Must specify where to place it
+});
 // Returns: "Created markdown cell: cell-abc"
 
 // Step 2: Create import cell
 AI: create_cell({
   cellType: "code",
   source: "import pandas as pd\nimport numpy as np",
-  after_id: "cell-abc"  // Chaining after header
-})
+  after_id: "cell-abc", // Chaining after header
+});
 // Returns: "Created code cell: cell-def"
 
 // Step 3: Create data loading cell
 AI: create_cell({
   cellType: "code",
   source: "df = pd.read_csv('data.csv')",
-  after_id: "cell-def"  // Continuing the chain
-})
+  after_id: "cell-def", // Continuing the chain
+});
 // Returns: "Created code cell: cell-ghi"
 ```
 
 ### Example 2: Inserting Above
+
 ```javascript
 // User: "Add an explanation above the imports"
 // AI can see cell IDs in context
@@ -156,8 +174,8 @@ AI: create_cell({
 AI: create_cell({
   cellType: "markdown",
   source: "First, we need to import the necessary libraries:",
-  after_id: "cell-ai-123"  // Insert after AI cell but before imports
-})
+  after_id: "cell-ai-123", // Insert after AI cell but before imports
+});
 ```
 
 ## Benefits
@@ -182,8 +200,10 @@ AI: create_cell({
 - Error handling for non-existent cell IDs is critical
 - The response must include the created cell ID for chaining
 - Guide models to use `modify_cell` instead of trying to insert at the top
-- Consider adding examples in prompts to help models choose appropriate after_id values
-- Support interspersed conversation patterns where AI weaves through the document
+- Consider adding examples in prompts to help models choose appropriate after_id
+  values
+- Support interspersed conversation patterns where AI weaves through the
+  document
 
 ## Success Criteria
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,197 @@
+# Plan: Simplify create_cell API to after_id Only
+
+## Current State
+
+The `create_cell` tool currently uses a `position` parameter to place cells relative to the current AI cell:
+- `after_current`: places the cell after the AI cell (default)
+- `before_current`: places the cell before the AI cell
+- `at_end`: places the cell at the end of the notebook
+
+This approach limits the AI's ability to build complex notebook structures or place cells in specific sequences.
+
+## Proposed Change
+
+Replace the `position` parameter with `after_id` as the sole method for cell positioning.
+
+### New API Design
+
+```typescript
+{
+  name: "create_cell",
+  description: "Create a new cell in the notebook after a specific cell. The AI knows its own cell ID and can reference any previously created cell IDs.",
+  parameters: {
+    type: "object",
+    properties: {
+      cellType: {
+        type: "string",
+        enum: ["code", "markdown", "ai", "sql"],
+        description: "The type of cell to create"
+      },
+      source: {
+        type: "string",
+        description: "The content/source code for the cell"
+      },
+      after_id: {
+        type: "string",
+        description: "The ID of the cell to place this new cell after. Use your own cell ID to place cells below yourself, or use a previously created cell's ID to build sequences."
+      }
+    },
+    required: ["cellType", "source", "after_id"]  // Explicitly required
+  }
+}
+```
+
+## Real-World Insights
+
+From testing with models:
+
+### The "Insert at Top" Problem
+- There's no cell ID before the first cell, so no way to insert at the top
+- Considered special sentinels (e.g., `runt:top`, `runt:last`) but this feels messy
+- **Better approach**: Use `modify_cell` when you need to add imports or dependencies to existing cells
+- Inserting at the top is rarely needed in practice
+
+### Model Behavior Observations
+- Models generally work well with the `after_id` approach
+- Sometimes models don't think carefully about the proper `after_id` and cells end up in weird order
+- This suggests we might want a sensible default behavior
+
+### Recommendation: Optional after_id with Smart Default
+Make `after_id` optional with this behavior:
+- **When provided**: Place cell after the specified cell ID
+- **When omitted**: Place cell after the current AI cell (the one making the call)
+
+This gives us:
+- Explicit control when needed
+- Natural default behavior (responses appear below the AI)
+- No need for special sentinels
+- Flexibility without complexity
+
+## Key Concepts
+
+### 1. AI Knows Its Own Cell ID
+- The AI cell that's making the tool call has access to its own cell ID
+- This replaces the need for `position: "after_current"`
+- The AI can simply use its own ID in `after_id`
+
+### 2. Chaining Cells
+- When the AI creates a cell, it receives the new cell's ID in the response
+- The AI can then use this ID to create subsequent cells in sequence
+- This enables building complex notebook structures
+
+### 3. Looking Up
+- The AI has context about cells above it
+- It can reference any visible cell ID to insert content at specific locations
+- This replaces the need for `position: "before_current"`
+
+## Implementation Details
+
+### Changes to `createCell` function
+
+```typescript
+export function createCell(
+  store: Store<typeof schema>,
+  logger: Logger,
+  sessionId: string,
+  currentCell: CellData,
+  args: Record<string, unknown>,
+) {
+  const cellType = String(args.cellType || "code");
+  const content = String(args.source || args.content || "");
+  const afterId = String(args.after_id); // Now required
+  
+  // Get ordered cells with fractional indices
+  const cellList = store.query(cellList$);
+  
+  // Find the cell to insert after
+  const afterCellIndex = cellList.findIndex((c) => c.id === afterId);
+  if (afterCellIndex === -1) {
+    throw new Error(`Cell with ID ${afterId} not found`);
+  }
+  
+  const cellBefore = cellList[afterCellIndex];
+  const cellAfter = afterCellIndex < cellList.length - 1
+    ? cellList[afterCellIndex + 1]
+    : null;
+  
+  // Generate unique cell ID
+  const newCellId = `cell-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  
+  // ... rest of implementation
+}
+```
+
+## Usage Examples
+
+### Example 1: Building a Simple Analysis
+```javascript
+// AI's current cell ID: "cell-ai-123"
+
+// Step 1: Create header
+AI: create_cell({
+  cellType: "markdown",
+  source: "# Data Analysis",
+  after_id: "cell-ai-123"  // Using own cell ID (or could omit for same effect)
+})
+// Returns: "Created markdown cell: cell-abc"
+
+// Step 2: Create import cell
+AI: create_cell({
+  cellType: "code",
+  source: "import pandas as pd\nimport numpy as np",
+  after_id: "cell-abc"  // Chaining after header
+})
+// Returns: "Created code cell: cell-def"
+
+// Step 3: Create data loading cell
+AI: create_cell({
+  cellType: "code",
+  source: "df = pd.read_csv('data.csv')",
+  after_id: "cell-def"  // Continuing the chain
+})
+// Returns: "Created code cell: cell-ghi"
+```
+
+### Example 2: Inserting Above
+```javascript
+// User: "Add an explanation above the imports"
+// AI can see cell IDs in context
+
+AI: create_cell({
+  cellType: "markdown",
+  source: "First, we need to import the necessary libraries:",
+  after_id: "cell-ai-123"  // Insert after AI cell but before imports
+})
+```
+
+## Benefits
+
+1. **Simpler Mental Model**: Only one way to position cells
+2. **Explicit Control**: Always know exactly where a cell will go
+3. **Natural Chaining**: Build sequences by referencing previous cell IDs
+4. **Flexible Insertion**: Can insert anywhere by referencing any cell ID
+5. **No Ambiguity**: No confusion between `position` and `afterId`
+
+## Migration Strategy
+
+1. Update tool definition to remove `position` parameter
+2. Make `after_id` optional, defaulting to current AI cell
+3. Ensure AI has access to its own cell ID in context
+4. Update any system prompts to explain the new approach
+5. Emphasize using `modify_cell` for adding imports/dependencies
+
+## Considerations
+
+- The AI must have its own cell ID available in the context
+- The AI should see cell IDs for cells above it to enable insertion
+- Error handling for non-existent cell IDs is critical
+- The response must include the created cell ID for chaining
+- Guide models to use `modify_cell` instead of trying to insert at the top
+- Consider adding examples in prompts to help models choose appropriate after_id values
+
+## Success Criteria
+
+- AI can create cells below itself by using its own cell ID
+- AI can chain multiple cells together in sequence
+- AI can insert cells at any position by referencing existing cell IDs
+- The API is simpler and more predictable for LLM usage

--- a/packages/ai/openai-client.ts
+++ b/packages/ai/openai-client.ts
@@ -837,9 +837,9 @@ Once configured, your AI cells will work with real OpenAI models!`;
     switch (toolName) {
       case "create_cell": {
         const cellType = String(args.cellType || "code");
-        const position = String(args.position || "after_current");
+        const afterId = String(args.after_id || "");
         const content = String(args.content || "");
-        return `Created **${cellType}** cell at position **${position}**\n\n` +
+        return `Created **${cellType}** cell after **${afterId}**\n\n` +
           `Content preview:\n\`\`\`${
             cellType === "code" ? "python" : cellType
           }\n${content.slice(0, 200)}${

--- a/packages/ai/test/tool-registry.test.ts
+++ b/packages/ai/test/tool-registry.test.ts
@@ -1,0 +1,97 @@
+import { assertEquals } from "jsr:@std/assert@1.0.13";
+import { NOTEBOOK_TOOLS_EXPORT } from "../tool-registry.ts";
+
+Deno.test({
+  name: "Tool Registry - create_cell API changes",
+}, async (t) => {
+  await t.step("create_cell tool should use after_id parameter", () => {
+    const createCellTool = NOTEBOOK_TOOLS_EXPORT.find((tool) =>
+      tool.name === "create_cell"
+    );
+
+    // Tool should exist
+    assertEquals(createCellTool?.name, "create_cell");
+
+    // Should require after_id parameter
+    assertEquals(
+      createCellTool?.parameters?.required?.includes("after_id"),
+      true,
+      "after_id should be a required parameter",
+    );
+
+    // after_id should be string type
+    assertEquals(
+      createCellTool?.parameters?.properties?.after_id?.type,
+      "string",
+      "after_id should be a string parameter",
+    );
+
+    // Should not have position parameter anymore
+    assertEquals(
+      "position" in (createCellTool?.parameters?.properties || {}),
+      false,
+      "position parameter should be removed",
+    );
+
+    // Should still have cellType and source as required
+    assertEquals(
+      createCellTool?.parameters?.required?.includes("cellType"),
+      true,
+      "cellType should remain required",
+    );
+    assertEquals(
+      createCellTool?.parameters?.required?.includes("source"),
+      true,
+      "source should remain required",
+    );
+  });
+
+  await t.step("create_cell tool should have updated description", () => {
+    const createCellTool = NOTEBOOK_TOOLS_EXPORT.find((tool) =>
+      tool.name === "create_cell"
+    );
+
+    // Description should mention "after a specific cell"
+    assertEquals(
+      createCellTool?.description?.includes("after a specific cell"),
+      true,
+      "Description should mention placement after specific cell",
+    );
+
+    // Description should mention cell ID
+    assertEquals(
+      createCellTool?.description?.includes("cell ID"),
+      true,
+      "Description should mention cell ID usage",
+    );
+
+    // Should not mention old position terms
+    assertEquals(
+      createCellTool?.description?.includes("after_current"),
+      false,
+      "Description should not mention old position terms",
+    );
+  });
+
+  await t.step("after_id parameter should have correct description", () => {
+    const createCellTool = NOTEBOOK_TOOLS_EXPORT.find((tool) =>
+      tool.name === "create_cell"
+    );
+
+    const afterIdParam = createCellTool?.parameters?.properties?.after_id;
+
+    assertEquals(
+      afterIdParam?.description?.includes(
+        "ID of the cell to place this new cell after",
+      ),
+      true,
+      "after_id description should explain placement",
+    );
+
+    assertEquals(
+      afterIdParam?.description?.includes("your own cell ID"),
+      true,
+      "after_id description should mention using own cell ID",
+    );
+  });
+});

--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -44,7 +44,7 @@ const NOTEBOOK_TOOLS: NotebookTool[] = [
   {
     name: "create_cell",
     description:
-      "Create a new cell in the notebook at a specified position. Use this when you want to add new code, markdown, or other content to help the user.",
+      "Create a new cell in the notebook after a specific cell. The AI knows its own cell ID and can reference any previously created cell IDs.",
     parameters: {
       type: "object",
       properties: {
@@ -57,15 +57,13 @@ const NOTEBOOK_TOOLS: NotebookTool[] = [
           type: "string",
           description: "The content/source code for the cell",
         },
-        position: {
+        after_id: {
           type: "string",
-          enum: ["after_current", "before_current", "at_end"],
           description:
-            'Where to place the new cell. Use "after_current" (default) to place right after the AI cell, "before_current" to place before it, or "at_end" only when specifically requested',
-          default: "after_current",
+            "The ID of the cell to place this new cell after. Use your own cell ID to place cells below yourself, or use a previously created cell's ID to build sequences.",
         },
       },
-      required: ["cellType", "source"],
+      required: ["cellType", "source", "after_id"],
     },
   },
   {
@@ -188,48 +186,33 @@ export function createCell(
   store: Store<typeof schema>,
   logger: Logger,
   sessionId: string,
-  currentCell: CellData,
+  _currentCell: CellData,
   args: Record<string, unknown>,
 ) {
   const cellType = String(args.cellType || "code");
   const content = String(args.source || args.content || ""); // Check source first, then content
-  const position = String(args.position || "after_current");
+  const afterId = String(args.after_id); // Now required
 
   // Get ordered cells with fractional indices
   const cellList = store.query(cellList$);
-  const currentCellIndex = cellList.findIndex((c) => c.id === currentCell.id);
+
+  // Find the cell to insert after
+  const afterCellIndex = cellList.findIndex((c) => c.id === afterId);
+  if (afterCellIndex === -1) {
+    throw new Error(`Cell with ID ${afterId} not found`);
+  }
 
   // Generate unique cell ID
   const newCellId = `cell-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
-  let cellBefore = null;
-  let cellAfter = null;
-
-  switch (position) {
-    case "before_current":
-      cellBefore = currentCellIndex > 0
-        ? cellList[currentCellIndex - 1] || null
-        : null;
-      cellAfter = cellList[currentCellIndex] || null;
-      break;
-    case "at_end":
-      cellBefore = cellList.length > 0
-        ? cellList[cellList.length - 1] || null
-        : null;
-      cellAfter = null;
-      break;
-    case "after_current":
-    default:
-      cellBefore = cellList[currentCellIndex] || null;
-      cellAfter = currentCellIndex < cellList.length - 1
-        ? cellList[currentCellIndex + 1] || null
-        : null;
-      break;
-  }
+  const cellBefore = cellList[afterCellIndex]!; // Safe because we checked afterCellIndex !== -1
+  const cellAfter = afterCellIndex < cellList.length - 1
+    ? cellList[afterCellIndex + 1] || null
+    : null;
 
   logger.info("Creating cell via AI tool call", {
     cellType,
-    placement: position,
+    afterId,
     contentLength: content.length,
     cellBefore: cellBefore?.id,
     cellAfter: cellAfter?.id,


### PR DESCRIPTION
Replace position parameter with after_id in create_cell tool.

- Make after_id required parameter
- Remove position-based placement logic
- Update tool description and response formatting
- Add test coverage for API changes

Breaking change for AI agents only.