### PR TITLE
Add cellType to CellReference and consolidate queries

### DIFF
--- a/packages/ai/tool-registry.ts
+++ b/packages/ai/tool-registry.ts
@@ -1,6 +1,6 @@
 import {
   type CellData,
-  cellList$,
+  cellReferences$,
   createCellBetween,
   events,
   materializers,
@@ -194,7 +194,7 @@ export function createCell(
   const afterId = String(args.after_id); // Now required
 
   // Get ordered cells with fractional indices
-  const cellList = store.query(cellList$);
+  const cellList = store.query(cellReferences$);
 
   // Find the cell to insert after
   const afterCellIndex = cellList.findIndex((c) => c.id === afterId);

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -1696,6 +1696,7 @@ export function validateFractionalIndexOrder(
 export type CellReference = {
   id: string;
   fractionalIndex: string | null;
+  cellType: CellType;
 };
 
 /**

--- a/packages/schema/queries/index.ts
+++ b/packages/schema/queries/index.ts
@@ -9,13 +9,16 @@ export const cellIDs$ = queryDb(
   { label: "notebook.cellIds" },
 );
 
-// Fine-grained query for cell list with fractional indices
-export const cellList$ = queryDb(
+// Primary query for cell references - returns CellReference objects
+export const cellReferences$ = queryDb(
   tables.cells
-    .select("id", "fractionalIndex")
+    .select("id", "fractionalIndex", "cellType")
     .orderBy("fractionalIndex", "asc"),
-  { label: "notebook.cellList" },
+  { label: "notebook.cellReferences" },
 );
+
+// @deprecated Use cellReferences$ instead
+export const cellList$ = cellReferences$;
 
 // Query for getting a specific cell's fractional index
 export const cellFractionalIndex = (cellId: string) =>
@@ -32,17 +35,8 @@ export const cellFractionalIndex = (cellId: string) =>
     },
   );
 
-// Query for getting adjacent cells (useful for cell insertion)
-export const adjacentCells = (cellId: string) =>
-  queryDb(
-    tables.cells
-      .select("id", "fractionalIndex")
-      .orderBy("fractionalIndex", "asc"),
-    {
-      deps: [cellId],
-      label: `adjacentCells.${cellId}`,
-    },
-  );
+// @deprecated Use cellReferences$ instead - this returns all cells anyway
+export const adjacentCells = (cellId: string) => cellReferences$;
 
 export const notebookMetadata$ = queryDb(
   tables.notebookMetadata.select("key", "value"),

--- a/packages/schema/queries/index.ts
+++ b/packages/schema/queries/index.ts
@@ -36,7 +36,7 @@ export const cellFractionalIndex = (cellId: string) =>
   );
 
 // @deprecated Use cellReferences$ instead - this returns all cells anyway
-export const adjacentCells = (cellId: string) => cellReferences$;
+export const adjacentCells = (_cellId: string) => cellReferences$;
 
 export const notebookMetadata$ = queryDb(
   tables.notebookMetadata.select("key", "value"),

--- a/packages/schema/test.ts
+++ b/packages/schema/test.ts
@@ -1274,9 +1274,9 @@ Deno.test("v2.CellMoved - basic cell movement", async () => {
   const cell3Index = fractionalIndexBetween(cell2Index, null);
 
   const cells = [
-    { id: "cell-1", fractionalIndex: cell1Index },
-    { id: "cell-2", fractionalIndex: cell2Index },
-    { id: "cell-3", fractionalIndex: cell3Index },
+    { id: "cell-1", fractionalIndex: cell1Index, cellType: "code" as const },
+    { id: "cell-2", fractionalIndex: cell2Index, cellType: "code" as const },
+    { id: "cell-3", fractionalIndex: cell3Index, cellType: "code" as const },
   ];
 
   // Create cells in the store
@@ -1343,7 +1343,7 @@ Deno.test("v2.CellMoved - move to position", async () => {
   let prevKey: string | null = null;
   for (let i = 1; i <= 5; i++) {
     const fractionalIndex = fractionalIndexBetween(prevKey, null);
-    cells.push({ id: `cell-${i}`, fractionalIndex });
+    cells.push({ id: `cell-${i}`, fractionalIndex, cellType: "code" as const });
     prevKey = fractionalIndex;
 
     store.commit(events.cellCreated2({
@@ -1416,9 +1416,21 @@ Deno.test("v2.CellMoved - edge cases", async () => {
   );
 
   // Test with non-existent cell
-  const cell1 = { id: "cell-1", fractionalIndex: "a0" };
-  const cell2 = { id: "cell-2", fractionalIndex: "a1" };
-  const nonExistentCell = { id: "cell-999", fractionalIndex: null };
+  const cell1 = {
+    id: "cell-1",
+    fractionalIndex: "a0",
+    cellType: "code" as const,
+  };
+  const cell2 = {
+    id: "cell-2",
+    fractionalIndex: "a1",
+    cellType: "code" as const,
+  };
+  const nonExistentCell = {
+    id: "non-existent",
+    fractionalIndex: null,
+    cellType: "code" as const,
+  };
 
   // Moving cell without fractional index
   const invalidMove = moveCellBetween(nonExistentCell, cell1, cell2);
@@ -1449,7 +1461,7 @@ Deno.test("v2.CellMoved - concurrent movements", async () => {
       null,
       setupJitter,
     );
-    cells.push({ id: `cell-${i}`, fractionalIndex });
+    cells.push({ id: `cell-${i}`, fractionalIndex, cellType: "code" as const });
     prevKey = fractionalIndex;
 
     store.commit(events.cellCreated2({
@@ -1536,7 +1548,7 @@ Deno.test("v2.CellMoved - no-op when already in position", async () => {
   let prevKey: string | null = null;
   for (let i = 1; i <= 4; i++) {
     const fractionalIndex = fractionalIndexBetween(prevKey, null);
-    cells.push({ id: `cell-${i}`, fractionalIndex });
+    cells.push({ id: `cell-${i}`, fractionalIndex, cellType: "code" as const });
     prevKey = fractionalIndex;
 
     store.commit(events.cellCreated2({
@@ -1611,18 +1623,22 @@ Deno.test("v2.CellMoved - moveCellBetween API", async () => {
   const cell1: CellReference = {
     id: "cell-1",
     fractionalIndex: fractionalIndexBetween(null, null),
+    cellType: "code",
   };
   const cell2: CellReference = {
     id: "cell-2",
     fractionalIndex: fractionalIndexBetween(cell1.fractionalIndex, null),
+    cellType: "code",
   };
   const cell3: CellReference = {
     id: "cell-3",
     fractionalIndex: fractionalIndexBetween(cell2.fractionalIndex, null),
+    cellType: "code",
   };
   const cell4: CellReference = {
     id: "cell-4",
     fractionalIndex: fractionalIndexBetween(cell3.fractionalIndex, null),
+    cellType: "code",
   };
 
   // Create cells in the store
@@ -1672,14 +1688,28 @@ Deno.test("v2.CellMoved - moveCellBetween API", async () => {
   const noOp1 = moveCellBetween(cell2, cell3, cell4, "user1");
   assertEquals(noOp1, null); // Already between cell-3 and cell-4
 
-  const noOp2 = moveCellBetween(cell3, null, cell2, "user1");
+  const noOp2 = moveCellBetween(
+    { ...cell3, cellType: "code" as const },
+    null,
+    { ...cell2, cellType: "code" as const },
+    "user1",
+  );
   assertEquals(noOp2, null); // Already at the beginning
 
-  const noOp3 = moveCellBetween(cell1, cell4, null, "user1");
+  const noOp3 = moveCellBetween(
+    { ...cell1, cellType: "code" as const },
+    { ...cell4, cellType: "code" as const },
+    null,
+    "user1",
+  );
   assertEquals(noOp3, null); // Already at the end
 
   // Test 5: Invalid cell (no fractional index)
-  const invalidCell: CellReference = { id: "invalid", fractionalIndex: null };
+  const invalidCell: CellReference = {
+    id: "invalid",
+    fractionalIndex: null,
+    cellType: "code",
+  };
   const invalidMove = moveCellBetween(invalidCell, cell2, cell3);
   assertEquals(invalidMove, null);
 
@@ -1697,10 +1727,12 @@ Deno.test("v2.CellCreated - createCellBetween API", async () => {
   const cell1: CellReference = {
     id: "existing-1",
     fractionalIndex: fractionalIndexBetween(null, null),
+    cellType: "code",
   };
   const cell2: CellReference = {
     id: "existing-2",
     fractionalIndex: fractionalIndexBetween(cell1.fractionalIndex, null),
+    cellType: "code",
   };
 
   // Create cells in the store
@@ -1766,7 +1798,11 @@ Deno.test("v2.CellCreated - createCellBetween API", async () => {
       cellType: "sql",
       createdBy: "user1",
     },
-    { id: "new-1", fractionalIndex: newCell1.args.fractionalIndex },
+    {
+      id: "new-1",
+      fractionalIndex: newCell1.args.fractionalIndex,
+      cellType: "code" as const,
+    },
     cell1,
   );
   store.commit(newCell4);

--- a/packages/schema/test/fractional-cell-index.test.ts
+++ b/packages/schema/test/fractional-cell-index.test.ts
@@ -212,10 +212,10 @@ Deno.test("Fractional Indexing - Cell Integration", async (t: Deno.TestContext) 
   await t.step("should move cells correctly using moveCellBetween", () => {
     // Create initial cells
     const cells: CellReference[] = [
-      { id: "cell-1", fractionalIndex: "a" },
-      { id: "cell-2", fractionalIndex: "m" },
-      { id: "cell-3", fractionalIndex: "t" },
-      { id: "cell-4", fractionalIndex: "z" },
+      { id: "cell-1", fractionalIndex: "a", cellType: "code" },
+      { id: "cell-2", fractionalIndex: "m", cellType: "code" },
+      { id: "cell-3", fractionalIndex: "t", cellType: "code" },
+      { id: "cell-4", fractionalIndex: "z", cellType: "code" },
     ];
 
     // Move cell-4 between cell-1 and cell-2
@@ -264,7 +264,8 @@ Deno.test("Fractional Indexing - Cell Integration", async (t: Deno.TestContext) 
 
       cells.push({
         id: `cell-${i}`,
-        fractionalIndex: index,
+        fractionalIndex: index!,
+        cellType: "code",
       });
     }
 
@@ -311,9 +312,9 @@ Deno.test("Fractional Indexing - Cell Integration", async (t: Deno.TestContext) 
   await t.step("should detect when cell is already in position", () => {
     // Create three cells
     const cells: CellReference[] = [
-      { id: "cell-1", fractionalIndex: "a" },
-      { id: "cell-2", fractionalIndex: "m" },
-      { id: "cell-3", fractionalIndex: "z" },
+      { id: "cell-1", fractionalIndex: "a", cellType: "code" },
+      { id: "cell-2", fractionalIndex: "m", cellType: "code" },
+      { id: "cell-3", fractionalIndex: "z", cellType: "code" },
     ];
 
     // Try to move cell-2 to where it already is (between cell-1 and cell-3)
@@ -330,8 +331,8 @@ Deno.test("Fractional Indexing - Cell Integration", async (t: Deno.TestContext) 
 
   await t.step("should create cells between existing cells", () => {
     const cells: CellReference[] = [
-      { id: "cell-1", fractionalIndex: "a" },
-      { id: "cell-2", fractionalIndex: "z" },
+      { id: "cell-1", fractionalIndex: "a", cellType: "code" },
+      { id: "cell-2", fractionalIndex: "z", cellType: "code" },
     ];
 
     // Create a cell between cell-1 and cell-2


### PR DESCRIPTION
Adds cellType to CellReference for faster rendering decisions without full cell queries.

Key changes:
- CellReference now includes cellType field
- New cellReferences$ query as primary source of cell ordering
- Deprecated cellList$ and adjacentCells in favor of cellReferences$
- Updated AI tool registry and all tests

This enables components to make cell-type-based rendering decisions efficiently.