### PR TITLE
Release 0.11.0

### DIFF
--- a/packages/ai/deno.json
+++ b/packages/ai/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/ai",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Runtime AI Clients",
   "license": "BSD-3-Clause",
   "repository": {
@@ -11,8 +11,8 @@
     ".": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.10.0",
-    "@runt/schema": "jsr:@runt/schema@^0.10.0",
+    "@runt/lib": "jsr:@runt/lib@^0.11.0",
+    "@runt/schema": "jsr:@runt/schema@^0.11.0",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "@std/path": "jsr:@std/path@^1.0.0",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/lib",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Runtime agent library for building Anode runtime agents",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,7 +14,7 @@
     "./types": "./src/types.ts"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.10.0",
+    "@runt/schema": "jsr:@runt/schema@^0.11.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "@std/assert": "jsr:@std/assert@^1.0.0",
     "@std/crypto": "jsr:@std/crypto@^1.0.0",

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/pyodide-runtime-agent",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Python runtime agent using Pyodide with IPython integration",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,9 +14,9 @@
     "pyorunt": "./src/mod.ts"
   },
   "imports": {
-    "@runt/ai": "jsr:@runt/ai@^0.10.0",
-    "@runt/lib": "jsr:@runt/lib@^0.10.0",
-    "@runt/schema": "jsr:@runt/schema@^0.10.0",
+    "@runt/ai": "jsr:@runt/ai@^0.11.0",
+    "@runt/lib": "jsr:@runt/lib@^0.11.0",
+    "@runt/schema": "jsr:@runt/schema@^0.11.0",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/python-runtime-agent",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Stub Python runtime agent for Runt platform.",
   "license": "BSD-3-Clause",
   "repository": {
@@ -14,8 +14,8 @@
     "pyrunt": "./mod.ts"
   },
   "imports": {
-    "@runt/lib": "jsr:@runt/lib@^0.10.0",
-    "@runt/schema": "jsr:@runt/schema@^0.10.0"
+    "@runt/lib": "jsr:@runt/lib@^0.11.0",
+    "@runt/schema": "jsr:@runt/schema@^0.11.0"
   },
   "tasks": {
     "test": "deno test --allow-all",

--- a/packages/schema/deno.json
+++ b/packages/schema/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Anode schema for runtime agents and clients",
   "license": "BSD-3-Clause",
   "repository": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/schema",
-  "version": "0.9.2",
+  "version": "0.11.0",
   "description": "This package.json is solely here to make linking possible for npm users",
   "type": "module",
   "main": "./mod.ts",

--- a/packages/tui/deno.json
+++ b/packages/tui/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@runt/tui",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A powerful terminal-based notebook interface for Runt runtime agents, enabling interactive editing, execution, and real-time collaboration.",
   "license": "BSD-3-Clause",
   "exports": {
@@ -22,9 +22,9 @@
     "lint": "deno lint"
   },
   "imports": {
-    "@runt/schema": "jsr:@runt/schema@^0.10.0",
-    "@runt/lib": "jsr:@runt/lib@^0.10.0",
-    "@runt/ai": "jsr:@runt/ai@^0.10.0",
+    "@runt/schema": "jsr:@runt/schema@^0.11.0",
+    "@runt/lib": "jsr:@runt/lib@^0.11.0",
+    "@runt/ai": "jsr:@runt/ai@^0.11.0",
     "@inkjs/ui": "npm:@inkjs/ui@^2.0.0",
     "@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
     "@livestore/livestore": "npm:@livestore/livestore@^0.3.1",


### PR DESCRIPTION
## Release 0.11.0

Version bump for all packages in the monorepo following the cell creation improvements in #180.

## Package Version Updates

All packages updated from **0.10.0** → **0.11.0**:

- `@runt/schema` (deno.json + package.json)
- `@runt/lib` 
- `@runt/ai`
- `@runt/pyodide-runtime-agent`
- `@runt/python-runtime-agent` 
- `@runt/tui`

## Dependency Updates

Updated all internal package dependencies to use `^0.11.0` versions:
- lib → schema: `^0.10.0` → `^0.11.0`
- ai → lib, schema: `^0.10.0` → `^0.11.0`
- pyodide-runtime-agent → ai, lib, schema: `^0.10.0` → `^0.11.0`
- python-runtime-agent → lib, schema: `^0.10.0` → `^0.11.0`
- tui → ai, lib, schema: `^0.10.0` → `^0.11.0`

## Breaking Changes in 0.11.0

From PR #180 - Cell creation soft-lock fixes:

- **`createCellBetween()`** now requires `allCells` parameter
- Returns `CellOperationResult` with event arrays instead of single events
- Automatic rebalancing prevents fractional index exhaustion
- All consumers (TUI, AI, Lib, Pyodide) updated to use new API

## Migration Required

```typescript
// Before 0.11.0:
const event = createCellBetween(cellData, before, after);
store.commit(event);

// After 0.11.0:
const result = createCellBetween(cellData, before, after, allCells);
result.events.forEach(store.commit);
```

Ready for JSR publishing.