### PR TITLE
Fix local package install

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -9,10 +9,14 @@
     ".": {
       "import": "./mod.ts",
       "types": "./mod.ts"
+    },
+    "./queries": {
+      "import": "./queries/index.ts",
+      "types": "./queries/index.ts"
     }
   },
   "files": [
-    "mod.ts",
+    "**/*.ts",
     "README.md"
   ],
   "dependencies": {


### PR DESCRIPTION
Depending on this package via file path like this stopped working:
```jsonc
// package.json
// ...
"@runt/schema": "file:../runt/packages/schema"
```

The problem was only `mod.ts` was available