### PR TITLE
Better sync url default for development

### DIFF
--- a/packages/lib/lib.test.ts
+++ b/packages/lib/lib.test.ts
@@ -17,7 +17,7 @@ Deno.test("Library exports are available", () => {
 Deno.test("DEFAULT_CONFIG has expected values", () => {
   assertEquals(
     DEFAULT_CONFIG.syncUrl,
-    "wss://anode-docworker.rgbkrk.workers.dev",
+    "wss://localhost:8787",
   );
 });
 

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -16,7 +16,7 @@ import { ArtifactClient } from "./artifact-client.ts";
  * Default configuration values
  */
 export const DEFAULT_CONFIG = {
-  syncUrl: "wss://anode-docworker.rgbkrk.workers.dev",
+  syncUrl: "wss://localhost:8787",
   imageArtifactThresholdBytes: 6 * 1024, // 6KB threshold for uploading images as artifacts
 } as const;
 


### PR DESCRIPTION
Helps with anode development so you don't need to set the sync URL env var