### PR TITLE
Always print the LIVESTORE_SYNC_URL

### DIFF
--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -13,8 +13,9 @@ export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 
 // Lots of common bugs are caused by not setting the LIVESTORE_SYNC_URL variable
 console.log(
-  "Using LIVESTORE_SYNC_URL:",
+  "\n\nUsing LIVESTORE_SYNC_URL:",
   Deno.env.toObject().LIVESTORE_SYNC_URL,
+  "\n\n",
 );
 
 // Run the agent if this file is executed directly

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -11,6 +11,12 @@ import { runner } from "@runt/lib";
 
 export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 
+// Lots of common bugs are caused by not setting the LIVESTORE_SYNC_URL variable
+console.log(
+  "Using LIVESTORE_SYNC_URL:",
+  Deno.env.toObject().LIVESTORE_SYNC_URL,
+);
+
 // Run the agent if this file is executed directly
 if (import.meta.main) {
   const agent = new PyodideRuntimeAgent();


### PR DESCRIPTION
```
❯ NOTEBOOK_ID=kbzyfpy65tyqm3wcb2xwatdns4 deno run --unstable-broadcast-channel --allow-all --env-file=./.env.production ../runt/packages/pyodide-runtime-agent/src/mod.ts


Using LIVESTORE_SYNC_URL: wss://app.runt.run/livestore 
```