### PR TITLE
Runtime agents use RUNT_API_KEY for authentication

### DIFF
--- a/packages/lib/examples/echo-agent.ts
+++ b/packages/lib/examples/echo-agent.ts
@@ -22,11 +22,11 @@ try {
   console.error(error instanceof Error ? error.message : String(error));
   console.error("\nExample usage:");
   console.error(
-    "  deno run --allow-all --env-file=.env echo-agent.ts --notebook my-notebook --auth-token your-token",
+    "  deno run --allow-all --env-file=.env echo-agent.ts --notebook my-notebook --auth-token your-runt-api-key",
   );
   console.error("\nOr set environment variables:");
   console.error("  NOTEBOOK_ID=my-notebook");
-  console.error("  AUTH_TOKEN=your-token");
+  console.error("  RUNT_API_KEY=your-runt-api-key");
   Deno.exit(1);
 }
 

--- a/packages/lib/examples/enhanced-output-example.ts
+++ b/packages/lib/examples/enhanced-output-example.ts
@@ -24,11 +24,11 @@ class ExamplePythonRuntime {
       console.error(error instanceof Error ? error.message : String(error));
       console.error("\nExample usage:");
       console.error(
-        "  deno run --allow-all --env-file=.env enhanced-output-example.ts --notebook my-notebook --auth-token your-token",
+        "  deno run --allow-all --env-file=.env enhanced-output-example.ts --notebook my-notebook --auth-token your-runt-api-key",
       );
       console.error("\nOr set environment variables in .env:");
       console.error("  NOTEBOOK_ID=my-notebook");
-      console.error("  AUTH_TOKEN=your-token");
+      console.error("  RUNT_API_KEY=your-runt-api-key");
       Deno.exit(1);
     }
 

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -89,7 +89,8 @@ export class RuntimeConfig {
     if (!this.authToken) {
       missing.push({
         field: "authToken",
-        suggestion: "--auth-token <token> or AUTH_TOKEN env var",
+        suggestion:
+          "--auth-token <token> or RUNT_API_KEY env var (AUTH_TOKEN as fallback)",
       });
     }
     if (!this.notebookId) {
@@ -202,8 +203,9 @@ Examples:
   deno run --allow-net --allow-env main.ts --notebook=test --auth-token=abc123
 
 Environment Variables (fallback):
-  NOTEBOOK_ID, AUTH_TOKEN, LIVESTORE_SYNC_URL, RUNTIME_ID, RUNTIME_TYPE
+  NOTEBOOK_ID, RUNT_API_KEY, LIVESTORE_SYNC_URL, RUNTIME_ID, RUNTIME_TYPE
   IMAGE_ARTIFACT_THRESHOLD_BYTES
+  AUTH_TOKEN (legacy fallback for service-level authentication)
 
 Logging Configuration:
   RUNT_LOG_LEVEL             Set to DEBUG, INFO, WARN, or ERROR (default: INFO)
@@ -225,7 +227,9 @@ Logging Configuration:
     };
   }
 
-  const authToken = parsed["auth-token"] || Deno.env.get("AUTH_TOKEN");
+  const authToken = parsed["auth-token"] ||
+    Deno.env.get("RUNT_API_KEY") ||
+    Deno.env.get("AUTH_TOKEN");
   if (authToken) {
     result = {
       ...result,

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -92,11 +92,11 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       console.error(error instanceof Error ? error.message : String(error));
       console.error("\nExample usage:");
       console.error(
-        '  deno run --allow-all "jsr:@runt/pyodide-runtime-agent" --notebook my-notebook --auth-token your-token',
+        '  deno run --allow-all "jsr:@runt/pyodide-runtime-agent" --notebook my-notebook --auth-token your-runt-api-key',
       );
       console.error("\nOr set environment variables in .env:");
       console.error("  NOTEBOOK_ID=my-notebook");
-      console.error("  AUTH_TOKEN=your-token");
+      console.error("  RUNT_API_KEY=your-runt-api-key");
       console.error("\nOr install globally:");
       console.error(
         "  deno install -gf --allow-all jsr:@runt/pyodide-runtime-agent",

--- a/packages/pyodide-runtime-agent/test/simple-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/simple-integration.test.ts
@@ -143,6 +143,26 @@ Deno.test("PyodideRuntimeAgent - Configuration", async (t) => {
       Deno.env.delete("AUTH_TOKEN");
     }
   });
+
+  await t.step("prioritizes RUNT_API_KEY over AUTH_TOKEN", () => {
+    Deno.env.set("RUNTIME_ID", "env-runtime");
+    Deno.env.set("NOTEBOOK_ID", "env-notebook");
+    Deno.env.set("AUTH_TOKEN", "fallback-token");
+    Deno.env.set("RUNT_API_KEY", "api-key-token");
+
+    try {
+      const agent = new PyodideRuntimeAgent([]);
+
+      assertEquals(agent.config.runtimeId, "env-runtime");
+      assertEquals(agent.config.notebookId, "env-notebook");
+      assertEquals(agent.config.authToken, "api-key-token"); // Should use RUNT_API_KEY
+    } finally {
+      Deno.env.delete("RUNTIME_ID");
+      Deno.env.delete("NOTEBOOK_ID");
+      Deno.env.delete("AUTH_TOKEN");
+      Deno.env.delete("RUNT_API_KEY");
+    }
+  });
 });
 
 Deno.test("PyodideRuntimeAgent - Methods", async (t) => {

--- a/packages/python-runtime-agent/src/python-runtime-agent.ts
+++ b/packages/python-runtime-agent/src/python-runtime-agent.ts
@@ -23,11 +23,11 @@ export class PythonRuntimeAgent extends RuntimeAgent {
       console.error(error instanceof Error ? error.message : String(error));
       console.error("\nExample usage:");
       console.error(
-        '  deno run --allow-all "jsr:@runt/python-runtime-agent" --notebook my-notebook --auth-token your-token',
+        '  deno run --allow-all "jsr:@runt/python-runtime-agent" --notebook my-notebook --auth-token your-runt-api-key',
       );
       console.error("\nOr set environment variables in .env:");
       console.error("  NOTEBOOK_ID=my-notebook");
-      console.error("  AUTH_TOKEN=your-token");
+      console.error("  RUNT_API_KEY=your-runt-api-key");
       console.error("\nOr install globally:");
       console.error(
         "  deno install -gf --allow-all jsr:@runt/python-runtime-agent",

--- a/packages/python-runtime-agent/test/simple-integration.test.ts
+++ b/packages/python-runtime-agent/test/simple-integration.test.ts
@@ -7,7 +7,7 @@ Deno.test("PythonRuntimeAgent - Basic Functionality (Stub)", async (t) => {
   const env = {
     RUNTIME_ID: "test-runtime",
     NOTEBOOK_ID: "test-notebook",
-    AUTH_TOKEN: "test-token",
+    RUNT_API_KEY: "test-token",
   };
   for (const [k, v] of Object.entries(env)) {
     Deno.env.set(k, v);

--- a/packages/schema/mod.ts
+++ b/packages/schema/mod.ts
@@ -30,7 +30,7 @@ export * from "./queries/index.ts";
  * - Runtime agents: clientId = runtimeId (e.g. "python-runtime-123")
  * - Notebook runners: clientId = "automation-client" (headless execution)
  * - TUI clients: clientId = "tui-client" (terminal interface)
- * - Service clients use AUTH_TOKEN for authentication
+ * - Service clients use RUNT_API_KEY for user authentication (AUTH_TOKEN as service fallback)
  * - ClientId must be non-numeric to prevent user impersonation
  *
  * USER CLIENTS (runtime: false/undefined):


### PR DESCRIPTION
**Changes:**
- Runtime agents now prioritize `RUNT_API_KEY` over `AUTH_TOKEN`
- Updated examples and documentation to reflect new authentication method
- Added test coverage for environment variable priority
- Maintains `AUTH_TOKEN` fallback for service-level authentication

**Testing:**
- All tests passing (133 passed)
- Verified priority: CLI arg → `RUNT_API_KEY` → `AUTH_TOKEN`

**Status:** Ready for review. Tested with preview deployment.