### PR TITLE
Runtime agent adapter injection

### DIFF
--- a/packages/lib/mod.ts
+++ b/packages/lib/mod.ts
@@ -25,6 +25,7 @@ export type {
   ModelCapability,
   OutputType,
   RawOutputData,
+  RuntimeAgentConstructorOptions,
   RuntimeAgentEventHandlers,
   RuntimeAgentOptions,
   RuntimeCapabilities,

--- a/packages/lib/mod.ts
+++ b/packages/lib/mod.ts
@@ -25,7 +25,6 @@ export type {
   ModelCapability,
   OutputType,
   RawOutputData,
-  RuntimeAgentConstructorOptions,
   RuntimeAgentEventHandlers,
   RuntimeAgentOptions,
   RuntimeCapabilities,

--- a/packages/lib/mod.ts
+++ b/packages/lib/mod.ts
@@ -30,6 +30,10 @@ export type {
   RuntimeCapabilities,
   RuntimeSessionData,
 } from "./src/types.ts";
+
+// Authentication utilities
+export { discoverUserIdentity, generateRuntimeClientId } from "./src/auth.ts";
+export type { DiscoverUserIdentityOptions, UserInfo } from "./src/auth.ts";
 export type { LoggerConfig } from "./src/logging.ts";
 
 // Media types and utilities for rich content handling

--- a/packages/lib/src/auth.ts
+++ b/packages/lib/src/auth.ts
@@ -1,0 +1,156 @@
+// Authentication utilities for Anode runtime agents
+//
+// This module provides utilities for authenticating with the Anode API
+// and discovering user identity. These should be used by CLI tools
+// before creating runtime agents.
+
+import { createLogger } from "./logging.ts";
+
+/**
+ * Options for user identity discovery
+ */
+export interface DiscoverUserIdentityOptions {
+  /** Authentication token for API requests */
+  authToken: string;
+  /** Sync URL to derive API endpoint from */
+  syncUrl: string;
+  /** Skip authentication in test environments */
+  skipInTests?: boolean;
+}
+
+/**
+ * User information returned from identity discovery
+ */
+export interface UserInfo {
+  id: string;
+  email: string;
+  name?: string;
+}
+
+/**
+ * Discover authenticated user identity via /api/me endpoint
+ *
+ * This should be called before creating runtime agents to get the clientId.
+ *
+ * @param options - Configuration for identity discovery
+ * @returns Promise resolving to user ID
+ * @throws Error if authentication fails
+ */
+export async function discoverUserIdentity(
+  options: DiscoverUserIdentityOptions,
+): Promise<string> {
+  const { authToken, syncUrl, skipInTests = true } = options;
+  const logger = createLogger("auth");
+
+  // Skip authentication in test environments if enabled
+  if (skipInTests) {
+    const isTestEnvironment = Deno.env.get("DENO_TESTING") === "true" ||
+      Deno.args.some((arg) => arg.includes("test")) ||
+      // Detect when running via deno test command
+      Deno.args.some((arg) => arg.endsWith(".test.ts")) ||
+      // Detect test files by checking if they end with .test.ts
+      (typeof Deno !== "undefined" && Deno.mainModule &&
+        Deno.mainModule.includes(".test.ts")) ||
+      // Check if auth token looks like a test token
+      authToken === "test-token";
+
+    if (isTestEnvironment) {
+      logger.debug("Skipping authentication in test environment");
+      return "test-user-id";
+    }
+  }
+
+  // Convert sync URL to API base URL
+  const parsedSyncUrl = new URL(syncUrl);
+  // Convert WebSocket URLs to HTTP URLs
+  const protocol = parsedSyncUrl.protocol === "wss:" ? "https:" : "http:";
+  const apiBaseUrl = `${protocol}//${parsedSyncUrl.host}`;
+  const meEndpoint = `${apiBaseUrl}/api/me`;
+
+  try {
+    const response = await fetch(meEndpoint, {
+      headers: {
+        "Authorization": `Bearer ${authToken}`,
+        "User-Agent": "runt-runtime-agent/1.0",
+      },
+    });
+
+    if (!response.ok) {
+      let errorBody = "";
+      try {
+        errorBody = await response.text();
+      } catch (_) {
+        errorBody = "Unable to read response body";
+      }
+
+      logger.error("Authentication request failed", {
+        endpoint: meEndpoint,
+        status: response.status,
+        statusText: response.statusText,
+        responseBody: errorBody,
+      });
+
+      throw new Error(
+        `HTTP ${response.status} ${response.statusText}: ${errorBody}`,
+      );
+    }
+
+    const userInfo = await response.json() as UserInfo;
+
+    if (!userInfo.id) {
+      logger.error("Invalid user info response", {
+        endpoint: meEndpoint,
+        responseBody: JSON.stringify(userInfo),
+      });
+      throw new Error("User ID not found in response");
+    }
+
+    logger.debug("User identity discovered", {
+      userId: userInfo.id,
+      email: userInfo.email,
+      name: userInfo.name,
+    });
+
+    return userInfo.id;
+  } catch (error) {
+    // If we haven't already logged the error above, log it here
+    if (!(error instanceof Error && error.message.startsWith("HTTP "))) {
+      logger.error("Network or parsing error during identity discovery", {
+        endpoint: meEndpoint,
+        errorMessage: error instanceof Error ? error.message : String(error),
+        errorType: error instanceof Error
+          ? error.constructor.name
+          : typeof error,
+      });
+    }
+
+    // Pretty console output for authentication failure
+    const hostname = parsedSyncUrl.hostname;
+
+    console.log(`\n❌ \x1b[31mAuthentication Failed\x1b[0m`);
+    console.log(`   \x1b[36mEndpoint:\x1b[0m https://${hostname}`);
+    console.log(
+      `   \x1b[36mError:\x1b[0m    ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    console.log(
+      `\n\x1b[33m💡 Check your RUNT_API_KEY and network connection\x1b[0m\n`,
+    );
+
+    throw new Error(
+      `Authentication failed: Could not verify identity with ${meEndpoint}. ` +
+        `Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/**
+ * Generate a client ID for runtime agents
+ *
+ * @param runtimeId - The runtime ID
+ * @returns Generated client ID in the format "runtime-{runtimeId}"
+ */
+export function generateRuntimeClientId(runtimeId: string): string {
+  return `runtime-${runtimeId}`;
+}

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -12,7 +12,6 @@ import type {
   RuntimeCapabilities,
 } from "./types.ts";
 import { ArtifactClient } from "./artifact-client.ts";
-import { generateRuntimeClientId } from "./auth.ts";
 
 /**
  * Default configuration values
@@ -453,15 +452,10 @@ export function createRuntimeConfig(
       cleanCliConfig.runtimeType || mergedDefaults.runtimeType
     }-runtime-${Deno.pid}`;
 
-  // Generate clientId if not provided in defaults
-  const clientId = mergedDefaults.clientId ||
-    generateRuntimeClientId(runtimeId);
-
   const config: RuntimeAgentOptions = {
     ...mergedDefaults,
     ...cleanCliConfig,
     runtimeId,
-    clientId,
     environmentOptions: {
       ...mergedDefaults.environmentOptions,
       ...(cleanCliConfig.environmentOptions ?? {}),

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -5,6 +5,7 @@
 
 import { parseArgs } from "@std/cli/parse-args";
 import { createLogger } from "./logging.ts";
+import type { Adapter } from "npm:@livestore/livestore";
 import type {
   IArtifactClient,
   RuntimeAgentOptions,
@@ -42,6 +43,8 @@ export class RuntimeConfig {
   public readonly mountReadonly: boolean;
   public readonly outputDir: string | undefined;
   public readonly aiMaxIterations: number;
+  public readonly adapter?: Adapter;
+  public readonly clientId?: string;
 
   constructor(options: RuntimeAgentOptions) {
     this.runtimeId = options.runtimeId;
@@ -59,6 +62,8 @@ export class RuntimeConfig {
     this.mountReadonly = options.mountReadonly ?? false;
     this.outputDir = options.outputDir;
     this.aiMaxIterations = options.aiMaxIterations ?? 10;
+    this.adapter = options.adapter;
+    this.clientId = options.clientId;
 
     // Use injected artifact client or create default one
     this.artifactClient = options.artifactClient ??

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -12,6 +12,7 @@ import type {
   RuntimeCapabilities,
 } from "./types.ts";
 import { ArtifactClient } from "./artifact-client.ts";
+import { generateRuntimeClientId } from "./auth.ts";
 
 /**
  * Default configuration values
@@ -43,8 +44,8 @@ export class RuntimeConfig {
   public readonly mountReadonly: boolean;
   public readonly outputDir: string | undefined;
   public readonly aiMaxIterations: number;
-  public readonly adapter?: Adapter;
-  public readonly clientId?: string;
+  public readonly adapter: Adapter | undefined;
+  public readonly clientId: string;
 
   constructor(options: RuntimeAgentOptions) {
     this.runtimeId = options.runtimeId;
@@ -452,10 +453,15 @@ export function createRuntimeConfig(
       cleanCliConfig.runtimeType || mergedDefaults.runtimeType
     }-runtime-${Deno.pid}`;
 
+  // Generate clientId if not provided in defaults
+  const clientId = mergedDefaults.clientId ||
+    generateRuntimeClientId(runtimeId);
+
   const config: RuntimeAgentOptions = {
     ...mergedDefaults,
     ...cleanCliConfig,
     runtimeId,
+    clientId,
     environmentOptions: {
       ...mergedDefaults.environmentOptions,
       ...(cleanCliConfig.environmentOptions ?? {}),

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -83,35 +83,9 @@ export class RuntimeAgent {
         notebookId: this.config.notebookId,
       });
 
-      // Handle adapter/clientId options with smart resolution
-      let clientId: string;
-
-      // Strategy 1: Use provided clientId
-      if (this.config.clientId) {
-        this.logger.info("Using provided clientId", {
-          clientId: this.config.clientId,
-        });
-        clientId = this.config.clientId;
-      } // Strategy 2: Generate default for custom adapters
-      else if (this.config.adapter) {
-        clientId = `runtime-${this.config.runtimeId}`;
-        this.logger.info("Generated clientId for custom adapter", {
-          clientId,
-        });
-      } // Strategy 3: Discover identity for default adapter (existing behavior)
-      else {
-        clientId = await this.discoverUserIdentity();
-        this.logger.info("Discovered user identity", { clientId });
-
-        // Pretty console output for successful authentication (only for default setup)
-        const syncUrl = new URL(this.config.syncUrl);
-        const protocol = syncUrl.protocol === "wss:" ? "https:" : "http:";
-        const apiHost = `${protocol}//${syncUrl.host}`;
-
-        console.log(`\n🔐 \x1b[32m✅ Successfully authenticated\x1b[0m`);
-        console.log(`   \x1b[36mEndpoint:\x1b[0m ${apiHost}`);
-        console.log(`   \x1b[36mUser ID:\x1b[0m  ${clientId}`);
-      }
+      // Use provided clientId (now required)
+      const clientId = this.config.clientId;
+      this.logger.info("Using clientId", { clientId });
 
       // Create store with appropriate adapter and sync payload
       const adapter = this.config.adapter || this.createDefaultAdapter();
@@ -209,119 +183,6 @@ export class RuntimeAgent {
         onSyncError: "ignore",
       },
     });
-  }
-
-  /**
-   * Discover authenticated user identity via /api/me endpoint
-   */
-  private async discoverUserIdentity(): Promise<string> {
-    const logger = createLogger(`${this.config.runtimeType}-agent`);
-
-    // Skip authentication in test environments
-    const isTestEnvironment = Deno.env.get("DENO_TESTING") === "true" ||
-      Deno.args.some((arg) => arg.includes("test")) ||
-      // Detect when running via deno test command
-      Deno.args.some((arg) => arg.endsWith(".test.ts")) ||
-      // Detect test files by checking if they end with .test.ts
-      (typeof Deno !== "undefined" && Deno.mainModule &&
-        Deno.mainModule.includes(".test.ts")) ||
-      // Check if auth token looks like a test token
-      this.config.authToken === "test-token";
-
-    if (isTestEnvironment) {
-      logger.debug("Skipping authentication in test environment");
-      return "test-user-id";
-    }
-
-    // Convert sync URL to API base URL
-    const syncUrl = new URL(this.config.syncUrl);
-    // Convert WebSocket URLs to HTTP URLs
-    const protocol = syncUrl.protocol === "wss:" ? "https:" : "http:";
-    const apiBaseUrl = `${protocol}//${syncUrl.host}`;
-    const meEndpoint = `${apiBaseUrl}/api/me`;
-
-    try {
-      const response = await fetch(meEndpoint, {
-        headers: {
-          "Authorization": `Bearer ${this.config.authToken}`,
-          "User-Agent": "runt-runtime-agent/1.0",
-        },
-      });
-
-      if (!response.ok) {
-        let errorBody = "";
-        try {
-          errorBody = await response.text();
-        } catch (_) {
-          errorBody = "Unable to read response body";
-        }
-
-        logger.error("Authentication request failed", {
-          endpoint: meEndpoint,
-          status: response.status,
-          statusText: response.statusText,
-          responseBody: errorBody,
-        });
-
-        throw new Error(
-          `HTTP ${response.status} ${response.statusText}: ${errorBody}`,
-        );
-      }
-
-      const userInfo = await response.json() as {
-        id: string;
-        email: string;
-        name?: string;
-      };
-
-      if (!userInfo.id) {
-        logger.error("Invalid user info response", {
-          endpoint: meEndpoint,
-          responseBody: JSON.stringify(userInfo),
-        });
-        throw new Error("User ID not found in response");
-      }
-
-      logger.debug("User identity discovered", {
-        userId: userInfo.id,
-        email: userInfo.email,
-        name: userInfo.name,
-      });
-
-      return userInfo.id;
-    } catch (error) {
-      // If we haven't already logged the error above, log it here
-      if (!(error instanceof Error && error.message.startsWith("HTTP "))) {
-        logger.error("Network or parsing error during identity discovery", {
-          endpoint: meEndpoint,
-          errorMessage: error instanceof Error ? error.message : String(error),
-          errorType: error instanceof Error
-            ? error.constructor.name
-            : typeof error,
-        });
-      }
-
-      // Pretty console output for authentication failure
-      const syncUrl = new URL(this.config.syncUrl);
-      const hostname = syncUrl.hostname;
-
-      console.log(`\n❌ \x1b[31mAuthentication Failed\x1b[0m`);
-      console.log(`   \x1b[36mEndpoint:\x1b[0m https://${hostname}`);
-      console.log(`   \x1b[36mNotebook:\x1b[0m ${this.config.notebookId}`);
-      console.log(
-        `   \x1b[36mError:\x1b[0m    ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-      console.log(
-        `\n\x1b[33m💡 Check your RUNT_API_KEY and network connection\x1b[0m\n`,
-      );
-
-      throw new Error(
-        `Authentication failed: Could not verify identity with ${meEndpoint}. ` +
-          `Error: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
   }
 
   /**

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -31,7 +31,6 @@ import type {
   ExecutionResult,
   IArtifactClient,
   RawOutputData,
-  RuntimeAgentConstructorOptions,
   RuntimeAgentEventHandlers,
   RuntimeCapabilities,
   RuntimeSessionData,
@@ -54,16 +53,13 @@ export class RuntimeAgent {
   private cancellationHandlers: CancellationHandler[] = [];
   private signalHandlers = new Map<string, () => void>();
   private artifactClient: IArtifactClient;
-  private options: RuntimeAgentConstructorOptions;
 
   constructor(
     public config: RuntimeConfig,
     private capabilities: RuntimeCapabilities,
     private handlers: RuntimeAgentEventHandlers = {},
-    options: RuntimeAgentConstructorOptions = {},
   ) {
     this.artifactClient = config.artifactClient;
-    this.options = options;
   }
 
   /**
@@ -87,57 +83,51 @@ export class RuntimeAgent {
         notebookId: this.config.notebookId,
       });
 
-      // Handle store/adapter/clientId options with smart resolution
+      // Handle adapter/clientId options with smart resolution
       let clientId: string;
 
-      // Strategy 1: Use custom store (no sync payload needed)
-      if (this.options.store) {
-        this.logger.info("Using pre-configured LiveStore instance");
-        this.#store = this.options.store;
-      } else {
-        // Strategy 2: Use provided clientId
-        if (this.options.clientId) {
-          this.logger.info("Using provided clientId", {
-            clientId: this.options.clientId,
-          });
-          clientId = this.options.clientId;
-        } // Strategy 3: Generate default for custom adapters
-        else if (this.options.adapter) {
-          clientId = `runtime-${this.config.runtimeId}`;
-          this.logger.info("Generated clientId for custom adapter", {
-            clientId,
-          });
-        } // Strategy 4: Discover identity for default adapter (existing behavior)
-        else {
-          clientId = await this.discoverUserIdentity();
-          this.logger.info("Discovered user identity", { clientId });
-
-          // Pretty console output for successful authentication (only for default setup)
-          const syncUrl = new URL(this.config.syncUrl);
-          const protocol = syncUrl.protocol === "wss:" ? "https:" : "http:";
-          const apiHost = `${protocol}//${syncUrl.host}`;
-
-          console.log(`\n🔐 \x1b[32m✅ Successfully authenticated\x1b[0m`);
-          console.log(`   \x1b[36mEndpoint:\x1b[0m ${apiHost}`);
-          console.log(`   \x1b[36mUser ID:\x1b[0m  ${clientId}`);
-        }
-
-        // Create store with appropriate adapter and sync payload
-        const adapter = this.options.adapter || this.createDefaultAdapter();
-
-        this.#store = await createStorePromise({
-          adapter,
-          schema,
-          storeId: this.config.notebookId,
-          syncPayload: {
-            authToken: this.config.authToken,
-            runtime: true,
-            runtimeId: this.config.runtimeId,
-            sessionId: this.config.sessionId,
-            clientId,
-          },
+      // Strategy 1: Use provided clientId
+      if (this.config.clientId) {
+        this.logger.info("Using provided clientId", {
+          clientId: this.config.clientId,
         });
+        clientId = this.config.clientId;
+      } // Strategy 2: Generate default for custom adapters
+      else if (this.config.adapter) {
+        clientId = `runtime-${this.config.runtimeId}`;
+        this.logger.info("Generated clientId for custom adapter", {
+          clientId,
+        });
+      } // Strategy 3: Discover identity for default adapter (existing behavior)
+      else {
+        clientId = await this.discoverUserIdentity();
+        this.logger.info("Discovered user identity", { clientId });
+
+        // Pretty console output for successful authentication (only for default setup)
+        const syncUrl = new URL(this.config.syncUrl);
+        const protocol = syncUrl.protocol === "wss:" ? "https:" : "http:";
+        const apiHost = `${protocol}//${syncUrl.host}`;
+
+        console.log(`\n🔐 \x1b[32m✅ Successfully authenticated\x1b[0m`);
+        console.log(`   \x1b[36mEndpoint:\x1b[0m ${apiHost}`);
+        console.log(`   \x1b[36mUser ID:\x1b[0m  ${clientId}`);
       }
+
+      // Create store with appropriate adapter and sync payload
+      const adapter = this.config.adapter || this.createDefaultAdapter();
+
+      this.#store = await createStorePromise({
+        adapter,
+        schema,
+        storeId: this.config.notebookId,
+        syncPayload: {
+          authToken: this.config.authToken,
+          runtime: true,
+          runtimeId: this.config.runtimeId,
+          sessionId: this.config.sessionId,
+          clientId,
+        },
+      });
 
       // Register global debug access
       // @ts-expect-error: Global debug access
@@ -147,8 +137,7 @@ export class RuntimeAgent {
 
       this.logger.info("LiveStore initialized", {
         storeId: this.config.notebookId,
-        hasCustomAdapter: !!this.options.adapter,
-        hasCustomStore: !!this.options.store,
+        hasCustomAdapter: !!this.config.adapter,
       });
 
       // Register runtime session
@@ -378,8 +367,8 @@ export class RuntimeAgent {
       // Clean up signal handlers
       this.cleanupSignalHandlers();
 
-      // Close LiveStore connection (only if we created it, not custom stores)
-      if (this.#store && !this.options.store) {
+      // Close LiveStore connection
+      if (this.#store) {
         await this.store.shutdown?.();
       }
     } catch (error) {

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -31,6 +31,7 @@ import type {
   ExecutionResult,
   IArtifactClient,
   RawOutputData,
+  RuntimeAgentConstructorOptions,
   RuntimeAgentEventHandlers,
   RuntimeCapabilities,
   RuntimeSessionData,
@@ -53,13 +54,16 @@ export class RuntimeAgent {
   private cancellationHandlers: CancellationHandler[] = [];
   private signalHandlers = new Map<string, () => void>();
   private artifactClient: IArtifactClient;
+  private options: RuntimeAgentConstructorOptions;
 
   constructor(
     public config: RuntimeConfig,
     private capabilities: RuntimeCapabilities,
     private handlers: RuntimeAgentEventHandlers = {},
+    options: RuntimeAgentConstructorOptions = {},
   ) {
     this.artifactClient = config.artifactClient;
+    this.options = options;
   }
 
   /**
@@ -83,39 +87,68 @@ export class RuntimeAgent {
         notebookId: this.config.notebookId,
       });
 
-      // Discover authenticated user identity
-      const userId = await this.discoverUserIdentity();
-      this.logger.info("Authenticated as user", { userId });
+      // Handle store/adapter/clientId options with smart resolution
+      let clientId: string;
 
-      // Pretty console output for successful authentication
-      const syncUrl = new URL(this.config.syncUrl);
-      const protocol = syncUrl.protocol === "wss:" ? "https:" : "http:";
-      const apiHost = `${protocol}//${syncUrl.host}`;
+      // Strategy 1: Use custom store (no sync payload needed)
+      if (this.options.store) {
+        this.logger.info("Using pre-configured LiveStore instance");
+        this.#store = this.options.store;
+      } else {
+        // Strategy 2: Use provided clientId
+        if (this.options.clientId) {
+          this.logger.info("Using provided clientId", {
+            clientId: this.options.clientId,
+          });
+          clientId = this.options.clientId;
+        } // Strategy 3: Generate default for custom adapters
+        else if (this.options.adapter) {
+          clientId = `runtime-${this.config.runtimeId}`;
+          this.logger.info("Generated clientId for custom adapter", {
+            clientId,
+          });
+        } // Strategy 4: Discover identity for default adapter (existing behavior)
+        else {
+          clientId = await this.discoverUserIdentity();
+          this.logger.info("Discovered user identity", { clientId });
 
-      console.log(`\n🔐 \x1b[32m✅ Successfully authenticated\x1b[0m`);
-      console.log(`   \x1b[36mEndpoint:\x1b[0m ${apiHost}`);
-      console.log(`   \x1b[36mUser ID:\x1b[0m  ${userId}`);
+          // Pretty console output for successful authentication (only for default setup)
+          const syncUrl = new URL(this.config.syncUrl);
+          const protocol = syncUrl.protocol === "wss:" ? "https:" : "http:";
+          const apiHost = `${protocol}//${syncUrl.host}`;
 
-      // Create LiveStore adapter for real-time collaboration
-      const adapter = makeAdapter({
-        storage: { type: "in-memory" },
-        sync: {
-          backend: makeCfSync({ url: this.config.syncUrl }),
-          onSyncError: "ignore",
-        },
-      });
+          console.log(`\n🔐 \x1b[32m✅ Successfully authenticated\x1b[0m`);
+          console.log(`   \x1b[36mEndpoint:\x1b[0m ${apiHost}`);
+          console.log(`   \x1b[36mUser ID:\x1b[0m  ${clientId}`);
+        }
 
-      this.#store = await createStorePromise({
-        adapter,
-        schema,
+        // Create store with appropriate adapter and sync payload
+        const adapter = this.options.adapter || this.createDefaultAdapter();
+
+        this.#store = await createStorePromise({
+          adapter,
+          schema,
+          storeId: this.config.notebookId,
+          syncPayload: {
+            authToken: this.config.authToken,
+            runtime: true,
+            runtimeId: this.config.runtimeId,
+            sessionId: this.config.sessionId,
+            clientId,
+          },
+        });
+      }
+
+      // Register global debug access
+      // @ts-expect-error: Global debug access
+      globalThis.__debugLiveStore = globalThis.__debugLiveStore || {};
+      // @ts-expect-error: Global debug access
+      globalThis.__debugLiveStore[this.config.notebookId] = this.#store;
+
+      this.logger.info("LiveStore initialized", {
         storeId: this.config.notebookId,
-        syncPayload: {
-          authToken: this.config.authToken,
-          runtime: true,
-          runtimeId: this.config.runtimeId,
-          sessionId: this.config.sessionId,
-          clientId: userId,
-        },
+        hasCustomAdapter: !!this.options.adapter,
+        hasCustomStore: !!this.options.store,
       });
 
       // Register runtime session
@@ -174,6 +207,19 @@ export class RuntimeAgent {
       await this.handlers.onDisconnected?.(error as Error);
       throw error;
     }
+  }
+
+  /**
+   * Create the default adapter with Cloudflare sync
+   */
+  private createDefaultAdapter() {
+    return makeAdapter({
+      storage: { type: "in-memory" },
+      sync: {
+        backend: makeCfSync({ url: this.config.syncUrl }),
+        onSyncError: "ignore",
+      },
+    });
   }
 
   /**
@@ -332,8 +378,8 @@ export class RuntimeAgent {
       // Clean up signal handlers
       this.cleanupSignalHandlers();
 
-      // Close LiveStore connection
-      if (this.#store) {
+      // Close LiveStore connection (only if we created it, not custom stores)
+      if (this.#store && !this.options.store) {
         await this.store.shutdown?.();
       }
     } catch (error) {

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -93,8 +93,8 @@ export interface RuntimeAgentOptions {
   readonly aiMaxIterations?: number;
   /** Custom LiveStore adapter to use instead of default */
   readonly adapter?: Adapter;
-  /** Override clientId for sync payload (defaults to discovered user ID) */
-  readonly clientId?: string;
+  /** Client ID for sync payload (must be provided) */
+  readonly clientId: string;
 }
 
 /**

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -91,18 +91,10 @@ export interface RuntimeAgentOptions {
   }>;
   /** Maximum iterations for AI agent tool calling loops (default: 10) */
   readonly aiMaxIterations?: number;
-}
-
-/**
- * Constructor options for RuntimeAgent allowing adapter/store injection
- */
-export interface RuntimeAgentConstructorOptions {
   /** Custom LiveStore adapter to use instead of default */
-  adapter?: Adapter;
-  /** Pre-configured LiveStore instance to use (takes precedence over adapter) */
-  store?: Store<typeof schema>;
+  readonly adapter?: Adapter;
   /** Override clientId for sync payload (defaults to discovered user ID) */
-  clientId?: string;
+  readonly clientId?: string;
 }
 
 /**

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -4,7 +4,7 @@
 // the runtime agent library, importing existing types from @runt/schema
 // and adding runtime-specific extensions.
 
-import type { Store } from "npm:@livestore/livestore";
+import type { Adapter, Store } from "npm:@livestore/livestore";
 import type { CellData, ExecutionQueueData, OutputType } from "@runt/schema";
 import { events, materializers, tables } from "@runt/schema";
 import { makeSchema, State } from "npm:@livestore/livestore";
@@ -91,6 +91,18 @@ export interface RuntimeAgentOptions {
   }>;
   /** Maximum iterations for AI agent tool calling loops (default: 10) */
   readonly aiMaxIterations?: number;
+}
+
+/**
+ * Constructor options for RuntimeAgent allowing adapter/store injection
+ */
+export interface RuntimeAgentConstructorOptions {
+  /** Custom LiveStore adapter to use instead of default */
+  adapter?: Adapter;
+  /** Pre-configured LiveStore instance to use (takes precedence over adapter) */
+  store?: Store<typeof schema>;
+  /** Override clientId for sync payload (defaults to discovered user ID) */
+  clientId?: string;
 }
 
 /**

--- a/packages/lib/test/config.test.ts
+++ b/packages/lib/test/config.test.ts
@@ -20,6 +20,7 @@ function makeBaseConfig(overrides: Partial<Record<string, unknown>> = {}) {
     syncUrl: "url",
     authToken: "token",
     notebookId: "nb",
+    clientId: "test-client",
     capabilities: {
       canExecuteCode: true,
       canExecuteSql: false,

--- a/packages/lib/test/integration.test.ts
+++ b/packages/lib/test/integration.test.ts
@@ -57,6 +57,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       notebookId: "test-notebook-integration",
       syncUrl: "ws://localhost:8787",
       authToken: "test-integration-token",
+      clientId: "test-integration-client",
       environmentOptions: {},
       capabilities,
     });
@@ -146,6 +147,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
         notebookId: "test-notebook",
         syncUrl: "ws://localhost:8787",
         authToken: "valid-token",
+        clientId: "valid-client",
         capabilities: capabilities,
         environmentOptions: {},
       });
@@ -166,6 +168,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
           notebookId: "test",
           syncUrl: "ws://localhost:8787",
           authToken: "token",
+          clientId: "test-client",
           capabilities: capabilities,
           environmentOptions: {},
         });
@@ -233,21 +236,23 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
 Deno.test("RuntimeConfig", async (t) => {
   await t.step("should create valid config with all required fields", () => {
     const config = new RuntimeConfig({
-      runtimeId: "test-runtime",
-      runtimeType: "python",
+      runtimeId: "test-runtime-3",
+      runtimeType: "test",
       notebookId: "test-notebook",
       syncUrl: "ws://localhost:8787",
       authToken: "test-token",
+      clientId: "test-client-3",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
-        canExecuteAi: true,
+        canExecuteAi: false,
       },
       environmentOptions: {},
     });
 
-    assertEquals(config.runtimeId, "test-runtime");
-    assertEquals(config.runtimeType, "python");
+    // Verify all required fields are set correctly
+    assertEquals(config.runtimeId, "test-runtime-3");
+    assertEquals(config.runtimeType, "test");
     assertEquals(config.notebookId, "test-notebook");
     assertEquals(config.syncUrl, "ws://localhost:8787");
     assertEquals(config.authToken, "test-token");
@@ -261,6 +266,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "notebook1",
       syncUrl: "ws://localhost:8787",
       authToken: "token1",
+      clientId: "client1",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -275,6 +281,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "notebook2",
       syncUrl: "ws://localhost:8787",
       authToken: "token2",
+      clientId: "client2",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -289,16 +296,16 @@ Deno.test("RuntimeConfig", async (t) => {
 
   await t.step("should allow custom heartbeat interval", () => {
     const _config = new RuntimeConfig({
-      runtimeId: "test-runtime",
-      runtimeType: "python",
-      notebookId: "test-notebook",
+      runtimeId: "test-ai-runtime",
+      runtimeType: "test-ai",
+      notebookId: "test-ai-notebook",
       syncUrl: "ws://localhost:8787",
-      authToken: "test-token",
-
+      authToken: "test-ai-token",
+      clientId: "test-client-ai",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
-        canExecuteAi: false,
+        canExecuteAi: true,
       },
       environmentOptions: {},
     });

--- a/packages/lib/test/integration.test.ts
+++ b/packages/lib/test/integration.test.ts
@@ -5,6 +5,7 @@
 // mocked dependencies to test the core integration points.
 
 import { assertEquals, assertExists } from "jsr:@std/assert";
+import { makeAdapter } from "npm:@livestore/adapter-node";
 
 import { RuntimeAgent } from "../src/runtime-agent.ts";
 import { RuntimeConfig } from "../src/config.ts";
@@ -51,13 +52,18 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       onExecutionError: createMockFunction(),
     };
 
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     config = new RuntimeConfig({
       runtimeId: "integration-test-runtime",
       runtimeType: "test",
       notebookId: "test-notebook-integration",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-integration-token",
       clientId: "test-integration-client",
+      adapter,
       environmentOptions: {},
       capabilities,
     });
@@ -141,13 +147,18 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
   await t.step("configuration validation", async (t) => {
     setup();
     await t.step("should accept valid configuration", () => {
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
+
       const validConfig = new RuntimeConfig({
         runtimeId: "valid-runtime",
         runtimeType: "test",
         notebookId: "test-notebook",
-        syncUrl: "ws://localhost:8787",
+        syncUrl: "ws://localhost:8787", // Not used with adapter
         authToken: "valid-token",
         clientId: "valid-client",
+        adapter,
         capabilities: capabilities,
         environmentOptions: {},
       });
@@ -162,13 +173,18 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       let error: Error | null = null;
 
       try {
+        const adapter = makeAdapter({
+          storage: { type: "in-memory" },
+        });
+
         const config = new RuntimeConfig({
           runtimeId: "", // Invalid empty runtime ID
           runtimeType: "test",
           notebookId: "test",
-          syncUrl: "ws://localhost:8787",
+          syncUrl: "ws://localhost:8787", // Not used with adapter
           authToken: "token",
           clientId: "test-client",
+          adapter,
           capabilities: capabilities,
           environmentOptions: {},
         });
@@ -235,13 +251,18 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
 
 Deno.test("RuntimeConfig", async (t) => {
   await t.step("should create valid config with all required fields", () => {
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     const config = new RuntimeConfig({
       runtimeId: "test-runtime-3",
       runtimeType: "test",
       notebookId: "test-notebook",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-token",
       clientId: "test-client-3",
+      adapter,
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -260,13 +281,18 @@ Deno.test("RuntimeConfig", async (t) => {
   });
 
   await t.step("should generate unique session IDs", () => {
+    const adapter1 = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     const config1 = new RuntimeConfig({
       runtimeId: "runtime1",
       runtimeType: "python",
       notebookId: "notebook1",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "token1",
       clientId: "client1",
+      adapter: adapter1,
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -275,13 +301,18 @@ Deno.test("RuntimeConfig", async (t) => {
       environmentOptions: {},
     });
 
+    const adapter2 = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     const config2 = new RuntimeConfig({
       runtimeId: "runtime2",
       runtimeType: "python",
       notebookId: "notebook2",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "token2",
       clientId: "client2",
+      adapter: adapter2,
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -295,13 +326,18 @@ Deno.test("RuntimeConfig", async (t) => {
   });
 
   await t.step("should allow custom heartbeat interval", () => {
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     const _config = new RuntimeConfig({
       runtimeId: "test-ai-runtime",
       runtimeType: "test-ai",
       notebookId: "test-ai-notebook",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-ai-token",
       clientId: "test-client-ai",
+      adapter,
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,

--- a/packages/lib/test/mod.test.ts
+++ b/packages/lib/test/mod.test.ts
@@ -31,6 +31,7 @@ Deno.test("RuntimeConfig validation works", () => {
       syncUrl: "ws://test",
       authToken: "", // Missing
       notebookId: "", // Missing
+      clientId: "test-client",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -52,8 +53,9 @@ Deno.test("RuntimeConfig validation works", () => {
     runtimeId: "test",
     runtimeType: "test",
     syncUrl: "ws://test",
-    authToken: "token",
-    notebookId: "notebook",
+    authToken: "test-token",
+    notebookId: "test-notebook",
+    clientId: "test-client",
     capabilities: {
       canExecuteCode: true,
       canExecuteSql: false,

--- a/packages/lib/test/runtime-agent-adapter-injection.test.ts
+++ b/packages/lib/test/runtime-agent-adapter-injection.test.ts
@@ -8,11 +8,7 @@ import { assertEquals, assertExists } from "jsr:@std/assert";
 
 import { crypto } from "jsr:@std/crypto";
 
-import {
-  RuntimeAgent,
-  type RuntimeAgentConstructorOptions,
-  type RuntimeCapabilities,
-} from "@runt/lib";
+import { RuntimeAgent, type RuntimeCapabilities } from "@runt/lib";
 import { createRuntimeConfig } from "../src/config.ts";
 import {
   createStorePromise,
@@ -54,12 +50,21 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
   );
 
   await t.step("should accept custom in-memory adapter", async () => {
+    // Create custom in-memory adapter
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+      // No sync backend needed for pure in-memory testing
+    });
+
     const config = createRuntimeConfig([
       "--notebook",
       "adapter-test",
       "--auth-token",
       "test-token",
-    ]);
+    ], {
+      adapter,
+      clientId: "test-client-123",
+    });
 
     const capabilities: RuntimeCapabilities = {
       canExecuteCode: true,
@@ -67,18 +72,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       canExecuteAi: false,
     };
 
-    // Create custom in-memory adapter
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-      // No sync backend needed for pure in-memory testing
-    });
-
-    const options: RuntimeAgentConstructorOptions = {
-      adapter,
-      clientId: "test-client-123",
-    };
-
-    const agent = new RuntimeAgent(config, capabilities, {}, options);
+    const agent = new RuntimeAgent(config, capabilities);
 
     assertExists(agent);
     assertEquals(agent.config.notebookId, "adapter-test");
@@ -92,54 +86,47 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
     await agent.shutdown();
   });
 
-  await t.step("should accept pre-configured store", async () => {
-    const config = createRuntimeConfig([
-      "--notebook",
-      "store-test",
-      "--auth-token",
-      "test-token",
-    ]);
+  await t.step(
+    "should accept custom adapter without explicit clientId",
+    async () => {
+      // Create custom in-memory adapter
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
 
-    const capabilities: RuntimeCapabilities = {
-      canExecuteCode: true,
-      canExecuteSql: false,
-      canExecuteAi: false,
-    };
+      const config = createRuntimeConfig([
+        "--notebook",
+        "adapter-test-2",
+        "--auth-token",
+        "test-token",
+      ], {
+        adapter,
+        // No explicit clientId - should generate one
+      });
 
-    // Create pre-configured store
+      const capabilities: RuntimeCapabilities = {
+        canExecuteCode: true,
+        canExecuteSql: false,
+        canExecuteAi: false,
+      };
+
+      const agent = new RuntimeAgent(config, capabilities);
+
+      await agent.start();
+
+      // Verify store was created successfully
+      assertExists(agent.store);
+
+      await agent.shutdown();
+    },
+  );
+
+  await t.step("should generate clientId for custom adapter", async () => {
+    const runtimeId = `runtime-${crypto.randomUUID()}`;
     const adapter = makeAdapter({
       storage: { type: "in-memory" },
     });
 
-    const store = await createStorePromise({
-      adapter,
-      schema,
-      storeId: "pre-configured-store",
-    });
-
-    const options: RuntimeAgentConstructorOptions = {
-      store,
-    };
-
-    const agent = new RuntimeAgent(config, capabilities, {}, options);
-
-    await agent.start();
-
-    // Verify it's using our pre-configured store
-    assertEquals(agent.store, store);
-
-    // Agent shutdown shouldn't shutdown the custom store
-    await agent.shutdown();
-
-    // Store should still be available
-    assertExists(store);
-
-    // Clean up the store ourselves
-    await store.shutdown();
-  });
-
-  await t.step("should generate clientId for custom adapter", async () => {
-    const runtimeId = `runtime-${crypto.randomUUID()}`;
     const config = createRuntimeConfig([
       "--notebook",
       "clientid-test",
@@ -147,7 +134,10 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       runtimeId,
       "--auth-token",
       "test-token",
-    ]);
+    ], {
+      adapter,
+      // No explicit clientId - should generate one
+    });
 
     const capabilities: RuntimeCapabilities = {
       canExecuteCode: true,
@@ -155,16 +145,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       canExecuteAi: false,
     };
 
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
-
-    const options: RuntimeAgentConstructorOptions = {
-      adapter,
-      // No explicit clientId - should generate one
-    };
-
-    const agent = new RuntimeAgent(config, capabilities, {}, options);
+    const agent = new RuntimeAgent(config, capabilities);
 
     await agent.start();
 
@@ -177,12 +158,21 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
   });
 
   await t.step("should use explicit clientId when provided", async () => {
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
+    const explicitClientId = "my-custom-client-id";
+
     const config = createRuntimeConfig([
       "--notebook",
       "explicit-clientid-test",
       "--auth-token",
       "test-token",
-    ]);
+    ], {
+      adapter,
+      clientId: explicitClientId,
+    });
 
     const capabilities: RuntimeCapabilities = {
       canExecuteCode: true,
@@ -190,18 +180,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       canExecuteAi: false,
     };
 
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
-
-    const explicitClientId = "my-custom-client-id";
-
-    const options: RuntimeAgentConstructorOptions = {
-      adapter,
-      clientId: explicitClientId,
-    };
-
-    const agent = new RuntimeAgent(config, capabilities, {}, options);
+    const agent = new RuntimeAgent(config, capabilities);
 
     await agent.start();
 
@@ -211,36 +190,36 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
     await agent.shutdown();
   });
 
-  await t.step("should handle multiple agents with shared store", async () => {
-    // Create shared store
+  await t.step("should handle multiple agents with same adapter", async () => {
+    // Create shared adapter
     const adapter = makeAdapter({
       storage: { type: "in-memory" },
     });
 
-    const sharedStore = await createStorePromise({
-      adapter,
-      schema,
-      storeId: "shared-notebook",
-    });
-
-    // Create two agents sharing the same store
+    // Create two agents using the same adapter
     const config1 = createRuntimeConfig([
       "--notebook",
-      "shared-notebook",
+      "shared-adapter-1",
       "--runtime-id",
       "agent-1",
       "--auth-token",
       "token1",
-    ]);
+    ], {
+      adapter,
+      clientId: "client-1",
+    });
 
     const config2 = createRuntimeConfig([
       "--notebook",
-      "shared-notebook",
+      "shared-adapter-2",
       "--runtime-id",
       "agent-2",
       "--auth-token",
       "token2",
-    ]);
+    ], {
+      adapter,
+      clientId: "client-2",
+    });
 
     const capabilities: RuntimeCapabilities = {
       canExecuteCode: true,
@@ -248,88 +227,21 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       canExecuteAi: false,
     };
 
-    const agent1 = new RuntimeAgent(config1, capabilities, {}, {
-      store: sharedStore,
-    });
-    const agent2 = new RuntimeAgent(config2, capabilities, {}, {
-      store: sharedStore,
-    });
+    const agent1 = new RuntimeAgent(config1, capabilities);
+    const agent2 = new RuntimeAgent(config2, capabilities);
 
     await agent1.start();
     await agent2.start();
 
-    // Both agents should have the same store instance
-    assertEquals(agent1.store, sharedStore);
-    assertEquals(agent2.store, sharedStore);
-    assertEquals(agent1.store, agent2.store);
+    // Both agents should have their own stores but use same adapter type
+    assertExists(agent1.store);
+    assertExists(agent2.store);
 
     await agent1.shutdown();
     await agent2.shutdown();
-
-    // Shared store should still be available
-    assertExists(sharedStore);
-
-    await sharedStore.shutdown();
   });
 
-  await t.step(
-    "should prioritize store over adapter when both provided",
-    async () => {
-      const config = createRuntimeConfig([
-        "--notebook",
-        "priority-test",
-        "--auth-token",
-        "test-token",
-      ]);
-
-      const capabilities: RuntimeCapabilities = {
-        canExecuteCode: true,
-        canExecuteSql: false,
-        canExecuteAi: false,
-      };
-
-      // Create both adapter and store
-      const adapter = makeAdapter({
-        storage: { type: "in-memory" },
-      });
-
-      const store = await createStorePromise({
-        adapter,
-        schema,
-        storeId: "priority-store",
-      });
-
-      const options: RuntimeAgentConstructorOptions = {
-        adapter, // This should be ignored
-        store, // This should take precedence
-      };
-
-      const agent = new RuntimeAgent(config, capabilities, {}, options);
-
-      await agent.start();
-
-      // Should use the provided store, not create one from adapter
-      assertEquals(agent.store, store);
-
-      await agent.shutdown();
-      await store.shutdown();
-    },
-  );
-
   await t.step("should work with file system adapter", async () => {
-    const config = createRuntimeConfig([
-      "--notebook",
-      "fs-test",
-      "--auth-token",
-      "test-token",
-    ]);
-
-    const capabilities: RuntimeCapabilities = {
-      canExecuteCode: true,
-      canExecuteSql: false,
-      canExecuteAi: false,
-    };
-
     // Create temporary directory for test
     const tempDir = `/tmp/runt-test-${crypto.randomUUID()}`;
 
@@ -340,12 +252,23 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       },
     });
 
-    const options: RuntimeAgentConstructorOptions = {
+    const config = createRuntimeConfig([
+      "--notebook",
+      "fs-test",
+      "--auth-token",
+      "test-token",
+    ], {
       adapter: fsAdapter,
       clientId: "fs-test-client",
+    });
+
+    const capabilities: RuntimeCapabilities = {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: false,
     };
 
-    const agent = new RuntimeAgent(config, capabilities, {}, options);
+    const agent = new RuntimeAgent(config, capabilities);
 
     await agent.start();
 

--- a/packages/lib/test/runtime-agent-adapter-injection.test.ts
+++ b/packages/lib/test/runtime-agent-adapter-injection.test.ts
@@ -23,7 +23,9 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
         "test-token",
         "--sync-url",
         "ws://fake-url:9999", // Will fail but that's expected
-      ]);
+      ], {
+        clientId: "test-client-backward-compat",
+      });
 
       const capabilities: RuntimeCapabilities = {
         canExecuteCode: true,
@@ -91,7 +93,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
         "test-token",
       ], {
         adapter,
-        // No explicit clientId - should generate one
+        clientId: "test-client-generated",
       });
 
       const capabilities: RuntimeCapabilities = {
@@ -126,7 +128,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       "test-token",
     ], {
       adapter,
-      // No explicit clientId - should generate one
+      clientId: `runtime-${runtimeId}`,
     });
 
     const capabilities: RuntimeCapabilities = {

--- a/packages/lib/test/runtime-agent-adapter-injection.test.ts
+++ b/packages/lib/test/runtime-agent-adapter-injection.test.ts
@@ -1,0 +1,363 @@
+/// <reference lib="deno.ns" />
+// RuntimeAgent adapter injection tests
+//
+// These tests verify the new adapter/store injection functionality
+// that allows passing custom LiveStore adapters and stores to RuntimeAgent.
+
+import { assertEquals, assertExists } from "jsr:@std/assert";
+
+import { crypto } from "jsr:@std/crypto";
+
+import {
+  RuntimeAgent,
+  type RuntimeAgentConstructorOptions,
+  type RuntimeCapabilities,
+} from "@runt/lib";
+import { createRuntimeConfig } from "../src/config.ts";
+import {
+  createStorePromise,
+  makeSchema,
+  State,
+} from "npm:@livestore/livestore";
+import { makeAdapter } from "npm:@livestore/adapter-node";
+import { events, materializers, tables } from "@runt/schema";
+
+// Create schema locally (same as runtime-agent.ts)
+const state = State.SQLite.makeState({ tables, materializers });
+const schema = makeSchema({ events, state });
+
+Deno.test("RuntimeAgent adapter injection", async (t) => {
+  await t.step(
+    "should work with default adapter (backward compatibility)",
+    () => {
+      const config = createRuntimeConfig([
+        "--notebook",
+        "test-notebook",
+        "--auth-token",
+        "test-token",
+        "--sync-url",
+        "ws://fake-url:9999", // Will fail but that's expected
+      ]);
+
+      const capabilities: RuntimeCapabilities = {
+        canExecuteCode: true,
+        canExecuteSql: false,
+        canExecuteAi: false,
+      };
+
+      const agent = new RuntimeAgent(config, capabilities);
+
+      // Should work exactly as before - no changes needed
+      assertExists(agent);
+      assertEquals(agent.config.notebookId, "test-notebook");
+    },
+  );
+
+  await t.step("should accept custom in-memory adapter", async () => {
+    const config = createRuntimeConfig([
+      "--notebook",
+      "adapter-test",
+      "--auth-token",
+      "test-token",
+    ]);
+
+    const capabilities: RuntimeCapabilities = {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: false,
+    };
+
+    // Create custom in-memory adapter
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+      // No sync backend needed for pure in-memory testing
+    });
+
+    const options: RuntimeAgentConstructorOptions = {
+      adapter,
+      clientId: "test-client-123",
+    };
+
+    const agent = new RuntimeAgent(config, capabilities, {}, options);
+
+    assertExists(agent);
+    assertEquals(agent.config.notebookId, "adapter-test");
+
+    // Test that we can start with custom adapter (won't try to sync)
+    await agent.start();
+
+    // Verify store is available
+    assertExists(agent.store);
+
+    await agent.shutdown();
+  });
+
+  await t.step("should accept pre-configured store", async () => {
+    const config = createRuntimeConfig([
+      "--notebook",
+      "store-test",
+      "--auth-token",
+      "test-token",
+    ]);
+
+    const capabilities: RuntimeCapabilities = {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: false,
+    };
+
+    // Create pre-configured store
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
+    const store = await createStorePromise({
+      adapter,
+      schema,
+      storeId: "pre-configured-store",
+    });
+
+    const options: RuntimeAgentConstructorOptions = {
+      store,
+    };
+
+    const agent = new RuntimeAgent(config, capabilities, {}, options);
+
+    await agent.start();
+
+    // Verify it's using our pre-configured store
+    assertEquals(agent.store, store);
+
+    // Agent shutdown shouldn't shutdown the custom store
+    await agent.shutdown();
+
+    // Store should still be available
+    assertExists(store);
+
+    // Clean up the store ourselves
+    await store.shutdown();
+  });
+
+  await t.step("should generate clientId for custom adapter", async () => {
+    const runtimeId = `runtime-${crypto.randomUUID()}`;
+    const config = createRuntimeConfig([
+      "--notebook",
+      "clientid-test",
+      "--runtime-id",
+      runtimeId,
+      "--auth-token",
+      "test-token",
+    ]);
+
+    const capabilities: RuntimeCapabilities = {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: false,
+    };
+
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
+    const options: RuntimeAgentConstructorOptions = {
+      adapter,
+      // No explicit clientId - should generate one
+    };
+
+    const agent = new RuntimeAgent(config, capabilities, {}, options);
+
+    await agent.start();
+
+    // The generated clientId should be "runtime-{runtimeId}"
+    // We can't directly verify this without accessing internals,
+    // but we can verify the store was created successfully
+    assertExists(agent.store);
+
+    await agent.shutdown();
+  });
+
+  await t.step("should use explicit clientId when provided", async () => {
+    const config = createRuntimeConfig([
+      "--notebook",
+      "explicit-clientid-test",
+      "--auth-token",
+      "test-token",
+    ]);
+
+    const capabilities: RuntimeCapabilities = {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: false,
+    };
+
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
+    const explicitClientId = "my-custom-client-id";
+
+    const options: RuntimeAgentConstructorOptions = {
+      adapter,
+      clientId: explicitClientId,
+    };
+
+    const agent = new RuntimeAgent(config, capabilities, {}, options);
+
+    await agent.start();
+
+    // Store should be created successfully with custom clientId
+    assertExists(agent.store);
+
+    await agent.shutdown();
+  });
+
+  await t.step("should handle multiple agents with shared store", async () => {
+    // Create shared store
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
+    const sharedStore = await createStorePromise({
+      adapter,
+      schema,
+      storeId: "shared-notebook",
+    });
+
+    // Create two agents sharing the same store
+    const config1 = createRuntimeConfig([
+      "--notebook",
+      "shared-notebook",
+      "--runtime-id",
+      "agent-1",
+      "--auth-token",
+      "token1",
+    ]);
+
+    const config2 = createRuntimeConfig([
+      "--notebook",
+      "shared-notebook",
+      "--runtime-id",
+      "agent-2",
+      "--auth-token",
+      "token2",
+    ]);
+
+    const capabilities: RuntimeCapabilities = {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: false,
+    };
+
+    const agent1 = new RuntimeAgent(config1, capabilities, {}, {
+      store: sharedStore,
+    });
+    const agent2 = new RuntimeAgent(config2, capabilities, {}, {
+      store: sharedStore,
+    });
+
+    await agent1.start();
+    await agent2.start();
+
+    // Both agents should have the same store instance
+    assertEquals(agent1.store, sharedStore);
+    assertEquals(agent2.store, sharedStore);
+    assertEquals(agent1.store, agent2.store);
+
+    await agent1.shutdown();
+    await agent2.shutdown();
+
+    // Shared store should still be available
+    assertExists(sharedStore);
+
+    await sharedStore.shutdown();
+  });
+
+  await t.step(
+    "should prioritize store over adapter when both provided",
+    async () => {
+      const config = createRuntimeConfig([
+        "--notebook",
+        "priority-test",
+        "--auth-token",
+        "test-token",
+      ]);
+
+      const capabilities: RuntimeCapabilities = {
+        canExecuteCode: true,
+        canExecuteSql: false,
+        canExecuteAi: false,
+      };
+
+      // Create both adapter and store
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
+
+      const store = await createStorePromise({
+        adapter,
+        schema,
+        storeId: "priority-store",
+      });
+
+      const options: RuntimeAgentConstructorOptions = {
+        adapter, // This should be ignored
+        store, // This should take precedence
+      };
+
+      const agent = new RuntimeAgent(config, capabilities, {}, options);
+
+      await agent.start();
+
+      // Should use the provided store, not create one from adapter
+      assertEquals(agent.store, store);
+
+      await agent.shutdown();
+      await store.shutdown();
+    },
+  );
+
+  await t.step("should work with file system adapter", async () => {
+    const config = createRuntimeConfig([
+      "--notebook",
+      "fs-test",
+      "--auth-token",
+      "test-token",
+    ]);
+
+    const capabilities: RuntimeCapabilities = {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: false,
+    };
+
+    // Create temporary directory for test
+    const tempDir = `/tmp/runt-test-${crypto.randomUUID()}`;
+
+    const fsAdapter = makeAdapter({
+      storage: {
+        type: "fs",
+        baseDirectory: tempDir,
+      },
+    });
+
+    const options: RuntimeAgentConstructorOptions = {
+      adapter: fsAdapter,
+      clientId: "fs-test-client",
+    };
+
+    const agent = new RuntimeAgent(config, capabilities, {}, options);
+
+    await agent.start();
+
+    assertExists(agent.store);
+
+    await agent.shutdown();
+
+    // Clean up temp directory
+    try {
+      await Deno.remove(tempDir, { recursive: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+});

--- a/packages/lib/test/runtime-agent-adapter-injection.test.ts
+++ b/packages/lib/test/runtime-agent-adapter-injection.test.ts
@@ -10,17 +10,7 @@ import { crypto } from "jsr:@std/crypto";
 
 import { RuntimeAgent, type RuntimeCapabilities } from "@runt/lib";
 import { createRuntimeConfig } from "../src/config.ts";
-import {
-  createStorePromise,
-  makeSchema,
-  State,
-} from "npm:@livestore/livestore";
 import { makeAdapter } from "npm:@livestore/adapter-node";
-import { events, materializers, tables } from "@runt/schema";
-
-// Create schema locally (same as runtime-agent.ts)
-const state = State.SQLite.makeState({ tables, materializers });
-const schema = makeSchema({ events, state });
 
 Deno.test("RuntimeAgent adapter injection", async (t) => {
   await t.step(

--- a/packages/lib/test/runtime-agent-artifact.test.ts
+++ b/packages/lib/test/runtime-agent-artifact.test.ts
@@ -71,6 +71,7 @@ const mockRuntimeOptions: RuntimeAgentOptions = {
   syncUrl: "wss://test.runt.run",
   authToken: "test-token",
   notebookId: "test-notebook",
+  clientId: "test-client",
   imageArtifactThresholdBytes: 6 * 1024, // 6KB threshold
   environmentOptions: {},
 };

--- a/packages/lib/test/runtime-agent-text-representations.test.ts
+++ b/packages/lib/test/runtime-agent-text-representations.test.ts
@@ -39,9 +39,10 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         runtimeId: "test-runtime",
         runtimeType: "test",
         notebookId: "test-notebook",
-        syncUrl: "ws://localhost:8080",
+        syncUrl: "ws://localhost:8787",
         authToken: "test-token",
-        capabilities,
+        clientId: "test-client",
+        capabilities: capabilities,
         environmentOptions: {},
       });
 
@@ -149,8 +150,9 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         runtimeId: "test-runtime",
         runtimeType: "test",
         notebookId: "test-notebook",
-        syncUrl: "ws://localhost:8080",
+        syncUrl: "ws://localhost:8787",
         authToken: "test-token",
+        clientId: "test-client",
         capabilities,
         environmentOptions: {},
         imageArtifactThresholdBytes: 10, // Very low threshold to trigger artifacting
@@ -260,8 +262,9 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         runtimeId: "test-runtime",
         runtimeType: "test",
         notebookId: "test-notebook",
-        syncUrl: "ws://localhost:8080",
+        syncUrl: "ws://localhost:8787",
         authToken: "test-token",
+        clientId: "test-client",
         capabilities,
         environmentOptions: {},
         imageArtifactThresholdBytes: 10, // Very low threshold to trigger artifacting

--- a/packages/lib/test/runtime-agent-text-representations.test.ts
+++ b/packages/lib/test/runtime-agent-text-representations.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="deno.ns" />
 import { assertEquals } from "@std/assert";
+import { makeAdapter } from "npm:@livestore/adapter-node";
 import { RuntimeAgent } from "../src/runtime-agent.ts";
 import { RuntimeConfig } from "../src/config.ts";
 import {
@@ -35,13 +36,18 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         canExecuteAi: false,
       };
 
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
+
       const config = new RuntimeConfig({
         runtimeId: "test-runtime",
         runtimeType: "test",
         notebookId: "test-notebook",
-        syncUrl: "ws://localhost:8787",
+        syncUrl: "ws://localhost:8787", // Not used with adapter
         authToken: "test-token",
         clientId: "test-client",
+        adapter,
         capabilities: capabilities,
         environmentOptions: {},
       });
@@ -146,13 +152,18 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         canExecuteAi: false,
       };
 
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
+
       const config = new RuntimeConfig({
         runtimeId: "test-runtime",
         runtimeType: "test",
         notebookId: "test-notebook",
-        syncUrl: "ws://localhost:8787",
+        syncUrl: "ws://localhost:8787", // Not used with adapter
         authToken: "test-token",
         clientId: "test-client",
+        adapter,
         capabilities,
         environmentOptions: {},
         imageArtifactThresholdBytes: 10, // Very low threshold to trigger artifacting
@@ -258,13 +269,18 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         canExecuteAi: false,
       };
 
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
+
       const config = new RuntimeConfig({
         runtimeId: "test-runtime",
         runtimeType: "test",
         notebookId: "test-notebook",
-        syncUrl: "ws://localhost:8787",
+        syncUrl: "ws://localhost:8787", // Not used with adapter
         authToken: "test-token",
         clientId: "test-client",
+        adapter,
         capabilities,
         environmentOptions: {},
         imageArtifactThresholdBytes: 10, // Very low threshold to trigger artifacting

--- a/packages/lib/test/runtime-agent.test.ts
+++ b/packages/lib/test/runtime-agent.test.ts
@@ -57,6 +57,7 @@ Deno.test("RuntimeAgent", async (t) => {
       notebookId: "test-notebook",
       syncUrl: "ws://localhost:8787",
       authToken: "test-token",
+      clientId: "test-client",
       capabilities,
       environmentOptions: {},
     });
@@ -170,6 +171,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "test-notebook",
       syncUrl: "ws://localhost:8787",
       authToken: "test-token",
+      clientId: "test-client",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -193,6 +195,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "notebook1",
       syncUrl: "ws://localhost:8787",
       authToken: "token1",
+      clientId: "client1",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -207,6 +210,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "notebook2",
       syncUrl: "ws://localhost:8787",
       authToken: "token2",
+      clientId: "client2",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -226,7 +230,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "test-notebook",
       syncUrl: "ws://localhost:8787",
       authToken: "test-token",
-
+      clientId: "test-client",
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,

--- a/packages/lib/test/runtime-agent.test.ts
+++ b/packages/lib/test/runtime-agent.test.ts
@@ -5,6 +5,7 @@
 // mock functions to ensure reliable, fast unit testing.
 
 import { assertEquals, assertExists, assertInstanceOf } from "jsr:@std/assert";
+import { makeAdapter } from "npm:@livestore/adapter-node";
 
 import { RuntimeAgent } from "../src/runtime-agent.ts";
 import { RuntimeConfig } from "../src/config.ts";
@@ -51,13 +52,18 @@ Deno.test("RuntimeAgent", async (t) => {
       onExecutionError: createMockFunction(),
     };
 
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     config = new RuntimeConfig({
       runtimeId: "test-runtime",
       runtimeType: "test",
       notebookId: "test-notebook",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-token",
       clientId: "test-client",
+      adapter,
       capabilities,
       environmentOptions: {},
     });
@@ -165,13 +171,18 @@ Deno.test("RuntimeAgent", async (t) => {
 
 Deno.test("RuntimeConfig", async (t) => {
   await t.step("should create valid config with all required fields", () => {
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     const config = new RuntimeConfig({
       runtimeId: "test-runtime",
       runtimeType: "python",
       notebookId: "test-notebook",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-token",
       clientId: "test-client",
+      adapter,
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -189,13 +200,18 @@ Deno.test("RuntimeConfig", async (t) => {
   });
 
   await t.step("should generate unique session IDs", () => {
+    const adapter1 = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     const config1 = new RuntimeConfig({
       runtimeId: "runtime1",
       runtimeType: "python",
       notebookId: "notebook1",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "token1",
       clientId: "client1",
+      adapter: adapter1,
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -204,13 +220,18 @@ Deno.test("RuntimeConfig", async (t) => {
       environmentOptions: {},
     });
 
+    const adapter2 = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     const config2 = new RuntimeConfig({
       runtimeId: "runtime2",
       runtimeType: "python",
       notebookId: "notebook2",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "token2",
       clientId: "client2",
+      adapter: adapter2,
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -224,13 +245,18 @@ Deno.test("RuntimeConfig", async (t) => {
   });
 
   await t.step("should allow custom heartbeat interval", () => {
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
     const _config = new RuntimeConfig({
       runtimeId: "test-runtime",
       runtimeType: "python",
       notebookId: "test-notebook",
-      syncUrl: "ws://localhost:8787",
+      syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-token",
       clientId: "test-client",
+      adapter,
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -8,14 +8,45 @@
 
 import { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
-import { createLogger } from "@runt/lib";
+import {
+  createLogger,
+  createRuntimeConfig,
+  discoverUserIdentity,
+} from "@runt/lib";
 
 // Run the agent if this file is executed directly
 if (import.meta.main) {
   const name = "PyoRunt";
   const logger = createLogger(name);
 
-  const agent = new PyodideRuntimeAgent();
+  logger.info("Authenticating...");
+
+  // Create temporary config to get auth details
+  const tempConfig = createRuntimeConfig(Deno.args, {
+    runtimeType: "python3-pyodide",
+    capabilities: {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: true,
+      availableAiModels: [],
+    },
+    clientId: "temp", // Will be replaced
+  });
+
+  // Discover user identity first
+  const clientId = await discoverUserIdentity({
+    authToken: tempConfig.authToken,
+    syncUrl: tempConfig.syncUrl,
+  });
+
+  logger.info("Authenticated successfully", { clientId });
+
+  // Create agent with discovered clientId
+  const agent = new PyodideRuntimeAgent(
+    Deno.args,
+    {}, // pyodide options
+    { clientId }, // runtime options
+  );
 
   logger.info("Starting Agent");
 

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -7,6 +7,7 @@
 import {
   createRuntimeConfig,
   RuntimeAgent,
+  type RuntimeAgentConstructorOptions,
   type RuntimeConfig,
 } from "@runt/lib";
 import type { ExecutionContext } from "@runt/lib";
@@ -76,9 +77,13 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
     resolve: (result: unknown) => void;
     reject: (error: unknown) => void;
   }>();
-  private options: PyodideAgentOptions;
+  private pyodideOptions: PyodideAgentOptions;
 
-  constructor(args: string[] = Deno.args, options: PyodideAgentOptions = {}) {
+  constructor(
+    args: string[] = Deno.args,
+    options: PyodideAgentOptions = {},
+    runtimeOptions: RuntimeAgentConstructorOptions = {},
+  ) {
     let config: RuntimeConfig;
     try {
       config = createRuntimeConfig(args, {
@@ -113,7 +118,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       onShutdown: async () => {
         await this.cleanupWorker();
       },
-    });
+    }, runtimeOptions);
 
     // Merge config mount paths with options mount paths
     const mergedOptions: PyodideAgentOptions = {
@@ -131,7 +136,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       mergedOptions.outputDir = finalOutputDir;
     }
 
-    this.options = mergedOptions;
+    this.pyodideOptions = mergedOptions;
     this.onExecution(this.executeCell.bind(this));
     this.onCancellation(this.handlePyodideCancellation.bind(this));
   }
@@ -146,7 +151,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
     this.logger.info("Starting Pyodide Python runtime agent");
 
     // Discover available AI models if enabled
-    if (this.options.discoverAiModels !== false) {
+    if (this.pyodideOptions.discoverAiModels !== false) {
       try {
         this.logger.info("Discovering available AI models...");
         const models = await discoverAvailableAiModels();
@@ -180,7 +185,8 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       this.logger.info("Initializing Pyodide worker");
 
       // Determine packages to load based on options
-      const packagesToLoad = this.options.packages || getEssentialPackages();
+      const packagesToLoad = this.pyodideOptions.packages ||
+        getEssentialPackages();
 
       this.logger.info("Loading packages", {
         packageCount: packagesToLoad.length,
@@ -228,19 +234,22 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
           readonly?: boolean;
         }
       > = [];
-      if (this.options.mountPaths && this.options.mountPaths.length > 0) {
+      if (
+        this.pyodideOptions.mountPaths &&
+        this.pyodideOptions.mountPaths.length > 0
+      ) {
         mountData = await this.readMountDirectories(
-          this.options.mountPaths,
-          this.options.mountMappings,
+          this.pyodideOptions.mountPaths,
+          this.pyodideOptions.mountMappings,
         );
 
         // Add readonly flag to all mount entries if mountReadonly is enabled
-        if (this.options.mountReadonly) {
+        if (this.pyodideOptions.mountReadonly) {
           mountData = mountData.map((entry) => ({ ...entry, readonly: true }));
         }
 
         // Start vector store ingestion asynchronously only if indexing is enabled
-        if (this.options.indexMountedFiles) {
+        if (this.pyodideOptions.indexMountedFiles) {
           // Initialize vector store in background to avoid blocking pyodide startup
           Promise.resolve().then(async () => {
             try {
@@ -573,7 +582,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
         }
 
         // Sync /outputs directory back to host if outputDir is configured
-        if (this.options.outputDir) {
+        if (this.pyodideOptions.outputDir) {
           await this.syncOutputsToHost();
         }
 
@@ -915,7 +924,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
    * Sync files from /outputs directory back to host filesystem
    */
   private async syncOutputsToHost(): Promise<void> {
-    if (!this.options.outputDir) {
+    if (!this.pyodideOptions.outputDir) {
       return;
     }
 
@@ -932,7 +941,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
 
       // Ensure output directory exists on host
       try {
-        await Deno.mkdir(this.options.outputDir, { recursive: true });
+        await Deno.mkdir(this.pyodideOptions.outputDir, { recursive: true });
       } catch (_error) {
         // Directory might already exist, ignore error
       }
@@ -941,14 +950,14 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       let syncedCount = 0;
       for (const { path, content } of result.files) {
         try {
-          const hostPath: string = `${this.options.outputDir}/${path}`;
+          const hostPath: string = `${this.pyodideOptions.outputDir}/${path}`;
 
           // Create parent directories if needed
           const parentDir: string = hostPath.substring(
             0,
             hostPath.lastIndexOf("/"),
           );
-          if (parentDir !== this.options.outputDir) {
+          if (parentDir !== this.pyodideOptions.outputDir) {
             try {
               await Deno.mkdir(parentDir, { recursive: true });
             } catch (_error) {
@@ -966,7 +975,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
 
       if (syncedCount > 0) {
         this.logger.info(
-          `Synced ${syncedCount} files from /outputs to ${this.options.outputDir}`,
+          `Synced ${syncedCount} files from /outputs to ${this.pyodideOptions.outputDir}`,
         );
       }
     } catch (error) {

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -7,7 +7,6 @@
 import {
   createRuntimeConfig,
   RuntimeAgent,
-  type RuntimeAgentConstructorOptions,
   type RuntimeConfig,
 } from "@runt/lib";
 import type { ExecutionContext } from "@runt/lib";
@@ -51,6 +50,14 @@ interface PyodideAgentOptions {
 }
 
 /**
+ * Runtime configuration options for PyodideRuntimeAgent
+ */
+interface PyodideRuntimeOptions {
+  adapter?: unknown; // LiveStore Adapter
+  clientId?: string;
+}
+
+/**
  * Pyodide-based Python runtime agent using web workers
  *
  * Extends the generic RuntimeAgent with advanced Python execution capabilities
@@ -82,7 +89,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
   constructor(
     args: string[] = Deno.args,
     options: PyodideAgentOptions = {},
-    runtimeOptions: RuntimeAgentConstructorOptions = {},
+    runtimeOptions: PyodideRuntimeOptions = {},
   ) {
     let config: RuntimeConfig;
     try {
@@ -94,6 +101,8 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
           canExecuteAi: true,
           availableAiModels: [], // Will be populated during startup
         },
+        adapter: runtimeOptions.adapter,
+        clientId: runtimeOptions.clientId,
       });
     } catch (error) {
       // Configuration errors should still go to console for CLI usability
@@ -118,7 +127,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       onShutdown: async () => {
         await this.cleanupWorker();
       },
-    }, runtimeOptions);
+    });
 
     // Merge config mount paths with options mount paths
     const mergedOptions: PyodideAgentOptions = {

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -9,6 +9,7 @@ import {
   RuntimeAgent,
   type RuntimeConfig,
 } from "@runt/lib";
+import type { Adapter } from "npm:@livestore/livestore";
 import type { ExecutionContext } from "@runt/lib";
 
 import { type MediaBundle, validateMediaBundle } from "@runt/lib";
@@ -53,7 +54,7 @@ interface PyodideAgentOptions {
  * Runtime configuration options for PyodideRuntimeAgent
  */
 interface PyodideRuntimeOptions {
-  adapter?: unknown; // LiveStore Adapter
+  adapter?: Adapter;
   clientId?: string;
 }
 
@@ -101,8 +102,8 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
           canExecuteAi: true,
           availableAiModels: [], // Will be populated during startup
         },
-        adapter: runtimeOptions.adapter,
-        clientId: runtimeOptions.clientId,
+        ...(runtimeOptions.adapter && { adapter: runtimeOptions.adapter }),
+        ...(runtimeOptions.clientId && { clientId: runtimeOptions.clientId }),
       });
     } catch (error) {
       // Configuration errors should still go to console for CLI usability

--- a/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
+++ b/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
@@ -5,21 +5,12 @@
 // that allows passing custom LiveStore adapters and stores to PyodideRuntimeAgent.
 
 import { assertEquals, assertExists } from "jsr:@std/assert";
-import { delay } from "jsr:@std/async/delay";
+
 import { crypto } from "jsr:@std/crypto";
 
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
-import {
-  createStorePromise,
-  makeSchema,
-  State,
-} from "npm:@livestore/livestore";
-import { makeAdapter } from "npm:@livestore/adapter-node";
-import { events, materializers, tables } from "@runt/schema";
 
-// Create schema locally (same as runtime-agent.ts)
-const state = State.SQLite.makeState({ tables, materializers });
-const schema = makeSchema({ events, state });
+import { makeAdapter } from "npm:@livestore/adapter-node";
 
 // Configure test environment for quiet logging
 Deno.env.set("RUNT_LOG_LEVEL", "ERROR");

--- a/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
+++ b/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
@@ -9,7 +9,6 @@ import { delay } from "jsr:@std/async/delay";
 import { crypto } from "jsr:@std/crypto";
 
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
-import type { RuntimeAgentConstructorOptions } from "@runt/lib";
 import {
   createStorePromise,
   makeSchema,
@@ -71,31 +70,24 @@ Deno.test({
     const notebookId = `adapter-test-${crypto.randomUUID()}`;
     const runtimeId = `runtime-${crypto.randomUUID()}`;
 
-    const args = [
-      "--notebook",
-      notebookId,
-      "--runtime-id",
-      runtimeId,
-      "--auth-token",
-      "test-token",
-      // No sync-url needed with custom adapter!
-    ];
-
     // Create custom in-memory adapter
     const adapter = makeAdapter({
       storage: { type: "in-memory" },
       // No sync backend needed for pure in-memory testing
     });
 
-    const runtimeOptions: RuntimeAgentConstructorOptions = {
-      adapter,
-      clientId: "test-client-123",
-    };
-
     const agent = new PyodideRuntimeAgent(
-      args,
+      [
+        "--notebook",
+        notebookId,
+        "--runtime-id",
+        runtimeId,
+        "--auth-token",
+        "test-token",
+        // No sync-url needed with custom adapter!
+      ],
       { discoverAiModels: false }, // pyodide options
-      runtimeOptions, // NEW: runtime options with adapter
+      { adapter, clientId: "test-client-123" }, // runtime options
     );
 
     assertExists(agent);
@@ -116,62 +108,35 @@ Deno.test({
     await agent.shutdown();
   });
 
-  await t.step("should accept pre-configured store", async () => {
-    const notebookId = `store-test-${crypto.randomUUID()}`;
+  await t.step(
+    "should accept custom adapter without explicit clientId",
+    async () => {
+      const notebookId = `adapter-test-${crypto.randomUUID()}`;
 
-    // Create pre-configured store with some initial data
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+      // Create adapter without explicit clientId
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
 
-    const store = await createStorePromise({
-      adapter,
-      schema,
-      storeId: notebookId,
-    });
+      const agent = new PyodideRuntimeAgent(
+        [
+          "--notebook",
+          notebookId,
+          "--auth-token",
+          "test-token",
+        ],
+        { discoverAiModels: false },
+        { adapter }, // No explicit clientId - should generate one
+      );
 
-    // Pre-populate store with notebook data
-    store.commit(events.notebookInitialized({
-      id: notebookId,
-      title: "Pre-configured Test Notebook",
-      ownerId: "test-user",
-    }));
+      await agent.start();
 
-    const args = [
-      "--notebook",
-      notebookId,
-      "--auth-token",
-      "test-token",
-    ];
+      // Verify store was created successfully
+      assertExists(agent.store);
 
-    const runtimeOptions: RuntimeAgentConstructorOptions = {
-      store,
-    };
-
-    const agent = new PyodideRuntimeAgent(
-      args,
-      { discoverAiModels: false },
-      runtimeOptions,
-    );
-
-    await agent.start();
-
-    // Verify it's using our pre-configured store
-    assertEquals(agent.store, store);
-
-    // Verify pre-existing data is available through notebook metadata
-    const metadata = agent.store.query(tables.notebookMetadata);
-    assertEquals(metadata.length > 0, true, "Should have notebook metadata");
-
-    // Agent shutdown shouldn't shutdown the custom store
-    await agent.shutdown();
-
-    // Store should still be available
-    assertExists(store);
-
-    // Clean up the store ourselves
-    await store.shutdown();
-  });
+      await agent.shutdown();
+    },
+  );
 
   await t.step(
     "should work with mixed pyodide and runtime options",
@@ -179,21 +144,19 @@ Deno.test({
       const notebookId = `mixed-test-${crypto.randomUUID()}`;
       const runtimeId = `runtime-${crypto.randomUUID()}`;
 
-      const args = [
-        "--notebook",
-        notebookId,
-        "--runtime-id",
-        runtimeId,
-        "--auth-token",
-        "test-token",
-      ];
-
       const adapter = makeAdapter({
         storage: { type: "in-memory" },
       });
 
       const agent = new PyodideRuntimeAgent(
-        args,
+        [
+          "--notebook",
+          notebookId,
+          "--runtime-id",
+          runtimeId,
+          "--auth-token",
+          "test-token",
+        ],
         {
           // Pyodide-specific options
           packages: ["numpy", "pandas"],
@@ -220,76 +183,48 @@ Deno.test({
   );
 
   await t.step(
-    "should handle multiple PyodideRuntimeAgents with shared store",
+    "should handle multiple PyodideRuntimeAgents with same adapter",
     async () => {
-      const notebookId = `shared-${crypto.randomUUID()}`;
-
-      // Create shared store
       const adapter = makeAdapter({
         storage: { type: "in-memory" },
       });
 
-      const sharedStore = await createStorePromise({
-        adapter,
-        schema,
-        storeId: notebookId,
-      });
-
-      // Initialize shared notebook
-      sharedStore.commit(events.notebookInitialized({
-        id: notebookId,
-        title: "Shared Test Notebook",
-        ownerId: "test-user",
-      }));
-
-      // Create two PyodideRuntimeAgents sharing the same store
+      // Create two PyodideRuntimeAgents using the same adapter
       const agent1 = new PyodideRuntimeAgent(
         [
           "--notebook",
-          notebookId,
+          `shared-1-${crypto.randomUUID()}`,
           "--runtime-id",
           "agent-1",
           "--auth-token",
           "token1",
         ],
         { discoverAiModels: false },
-        { store: sharedStore },
+        { adapter, clientId: "client-1" },
       );
 
       const agent2 = new PyodideRuntimeAgent(
         [
           "--notebook",
-          notebookId,
+          `shared-2-${crypto.randomUUID()}`,
           "--runtime-id",
           "agent-2",
           "--auth-token",
           "token2",
         ],
         { discoverAiModels: false },
-        { store: sharedStore },
+        { adapter, clientId: "client-2" },
       );
 
       await agent1.start();
       await agent2.start();
 
-      // Both agents should have the same store instance
-      assertEquals(agent1.store, sharedStore);
-      assertEquals(agent2.store, sharedStore);
-      assertEquals(agent1.store, agent2.store);
-
-      // Both should see the same shared store data
-      assertEquals(agent1.store, agent2.store);
-      const metadata1 = agent1.store.query(tables.notebookMetadata);
-      const metadata2 = agent2.store.query(tables.notebookMetadata);
-      assertEquals(metadata1.length, metadata2.length);
+      // Both agents should have their own stores
+      assertExists(agent1.store);
+      assertExists(agent2.store);
 
       await agent1.shutdown();
       await agent2.shutdown();
-
-      // Shared store should still be available
-      assertExists(sharedStore);
-
-      await sharedStore.shutdown();
     },
   );
 
@@ -372,7 +307,6 @@ Deno.test({
       // Pattern 3: Empty options (should use defaults)
       const agent3 = new PyodideRuntimeAgent(
         ["--notebook", "compat-test-3", "--auth-token", "token"],
-        {},
         {},
       );
       assertExists(agent3);

--- a/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
+++ b/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
@@ -1,0 +1,386 @@
+/// <reference lib="deno.ns" />
+// PyodideRuntimeAgent adapter injection tests
+//
+// These tests verify the new adapter/store injection functionality
+// that allows passing custom LiveStore adapters and stores to PyodideRuntimeAgent.
+
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import { delay } from "jsr:@std/async/delay";
+import { crypto } from "jsr:@std/crypto";
+
+import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
+import type { RuntimeAgentConstructorOptions } from "@runt/lib";
+import {
+  createStorePromise,
+  makeSchema,
+  State,
+} from "npm:@livestore/livestore";
+import { makeAdapter } from "npm:@livestore/adapter-node";
+import { events, materializers, tables } from "@runt/schema";
+
+// Create schema locally (same as runtime-agent.ts)
+const state = State.SQLite.makeState({ tables, materializers });
+const schema = makeSchema({ events, state });
+
+// Configure test environment for quiet logging
+Deno.env.set("RUNT_LOG_LEVEL", "ERROR");
+Deno.env.set("RUNT_DISABLE_CONSOLE_LOGS", "true");
+
+Deno.test({
+  name: "PyodideRuntimeAgent adapter injection",
+  sanitizeOps: false, // Agent uses signal handlers
+  sanitizeResources: false, // Agent creates background processes
+  ignore: Deno.env.get("CI") === "true", // Skip in CI due to Pyodide WASM compatibility
+}, async (t) => {
+  await t.step(
+    "should work with default adapter (backward compatibility)",
+    () => {
+      const notebookId = `test-${crypto.randomUUID()}`;
+      const runtimeId = `runtime-${crypto.randomUUID()}`;
+
+      const args = [
+        "--notebook",
+        notebookId,
+        "--runtime-id",
+        runtimeId,
+        "--auth-token",
+        "test-token",
+        "--sync-url",
+        "ws://fake-url:9999", // Will fail but that's expected for backward compatibility
+      ];
+
+      // Test existing constructor signature - should work exactly as before
+      const agent = new PyodideRuntimeAgent(args);
+
+      assertExists(agent);
+      assertEquals(agent.config.notebookId, notebookId);
+      assertEquals(agent.config.runtimeId, runtimeId);
+
+      // Test constructor with pyodide options (existing pattern)
+      const agentWithOptions = new PyodideRuntimeAgent(args, {
+        packages: ["numpy"],
+        discoverAiModels: false,
+      });
+
+      assertExists(agentWithOptions);
+      assertEquals(agentWithOptions.config.notebookId, notebookId);
+    },
+  );
+
+  await t.step("should accept custom in-memory adapter", async () => {
+    const notebookId = `adapter-test-${crypto.randomUUID()}`;
+    const runtimeId = `runtime-${crypto.randomUUID()}`;
+
+    const args = [
+      "--notebook",
+      notebookId,
+      "--runtime-id",
+      runtimeId,
+      "--auth-token",
+      "test-token",
+      // No sync-url needed with custom adapter!
+    ];
+
+    // Create custom in-memory adapter
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+      // No sync backend needed for pure in-memory testing
+    });
+
+    const runtimeOptions: RuntimeAgentConstructorOptions = {
+      adapter,
+      clientId: "test-client-123",
+    };
+
+    const agent = new PyodideRuntimeAgent(
+      args,
+      { discoverAiModels: false }, // pyodide options
+      runtimeOptions, // NEW: runtime options with adapter
+    );
+
+    assertExists(agent);
+    assertEquals(agent.config.notebookId, notebookId);
+
+    // Test that we can start with custom adapter
+    // This should be much faster than network-dependent startup
+    const startTime = performance.now();
+    await agent.start();
+    const startupTime = performance.now() - startTime;
+
+    // Verify store is available
+    assertExists(agent.store);
+
+    // PyodideRuntimeAgent startup includes Pyodide WASM initialization (under 10 seconds)
+    assertEquals(startupTime < 10000, true, `Startup took ${startupTime}ms`);
+
+    await agent.shutdown();
+  });
+
+  await t.step("should accept pre-configured store", async () => {
+    const notebookId = `store-test-${crypto.randomUUID()}`;
+
+    // Create pre-configured store with some initial data
+    const adapter = makeAdapter({
+      storage: { type: "in-memory" },
+    });
+
+    const store = await createStorePromise({
+      adapter,
+      schema,
+      storeId: notebookId,
+    });
+
+    // Pre-populate store with notebook data
+    store.commit(events.notebookInitialized({
+      id: notebookId,
+      title: "Pre-configured Test Notebook",
+      ownerId: "test-user",
+    }));
+
+    const args = [
+      "--notebook",
+      notebookId,
+      "--auth-token",
+      "test-token",
+    ];
+
+    const runtimeOptions: RuntimeAgentConstructorOptions = {
+      store,
+    };
+
+    const agent = new PyodideRuntimeAgent(
+      args,
+      { discoverAiModels: false },
+      runtimeOptions,
+    );
+
+    await agent.start();
+
+    // Verify it's using our pre-configured store
+    assertEquals(agent.store, store);
+
+    // Verify pre-existing data is available through notebook metadata
+    const metadata = agent.store.query(tables.notebookMetadata);
+    assertEquals(metadata.length > 0, true, "Should have notebook metadata");
+
+    // Agent shutdown shouldn't shutdown the custom store
+    await agent.shutdown();
+
+    // Store should still be available
+    assertExists(store);
+
+    // Clean up the store ourselves
+    await store.shutdown();
+  });
+
+  await t.step(
+    "should work with mixed pyodide and runtime options",
+    async () => {
+      const notebookId = `mixed-test-${crypto.randomUUID()}`;
+      const runtimeId = `runtime-${crypto.randomUUID()}`;
+
+      const args = [
+        "--notebook",
+        notebookId,
+        "--runtime-id",
+        runtimeId,
+        "--auth-token",
+        "test-token",
+      ];
+
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
+
+      const agent = new PyodideRuntimeAgent(
+        args,
+        {
+          // Pyodide-specific options
+          packages: ["numpy", "pandas"],
+          discoverAiModels: false,
+          mountReadonly: true,
+        },
+        {
+          // Runtime options
+          adapter,
+          clientId: "mixed-test-client",
+        },
+      );
+
+      await agent.start();
+
+      // Verify both pyodide and runtime options took effect
+      assertExists(agent.store);
+      assertEquals(agent["pyodideOptions"].packages, ["numpy", "pandas"]);
+      assertEquals(agent["pyodideOptions"].discoverAiModels, false);
+      assertEquals(agent["pyodideOptions"].mountReadonly, true);
+
+      await agent.shutdown();
+    },
+  );
+
+  await t.step(
+    "should handle multiple PyodideRuntimeAgents with shared store",
+    async () => {
+      const notebookId = `shared-${crypto.randomUUID()}`;
+
+      // Create shared store
+      const adapter = makeAdapter({
+        storage: { type: "in-memory" },
+      });
+
+      const sharedStore = await createStorePromise({
+        adapter,
+        schema,
+        storeId: notebookId,
+      });
+
+      // Initialize shared notebook
+      sharedStore.commit(events.notebookInitialized({
+        id: notebookId,
+        title: "Shared Test Notebook",
+        ownerId: "test-user",
+      }));
+
+      // Create two PyodideRuntimeAgents sharing the same store
+      const agent1 = new PyodideRuntimeAgent(
+        [
+          "--notebook",
+          notebookId,
+          "--runtime-id",
+          "agent-1",
+          "--auth-token",
+          "token1",
+        ],
+        { discoverAiModels: false },
+        { store: sharedStore },
+      );
+
+      const agent2 = new PyodideRuntimeAgent(
+        [
+          "--notebook",
+          notebookId,
+          "--runtime-id",
+          "agent-2",
+          "--auth-token",
+          "token2",
+        ],
+        { discoverAiModels: false },
+        { store: sharedStore },
+      );
+
+      await agent1.start();
+      await agent2.start();
+
+      // Both agents should have the same store instance
+      assertEquals(agent1.store, sharedStore);
+      assertEquals(agent2.store, sharedStore);
+      assertEquals(agent1.store, agent2.store);
+
+      // Both should see the same shared store data
+      assertEquals(agent1.store, agent2.store);
+      const metadata1 = agent1.store.query(tables.notebookMetadata);
+      const metadata2 = agent2.store.query(tables.notebookMetadata);
+      assertEquals(metadata1.length, metadata2.length);
+
+      await agent1.shutdown();
+      await agent2.shutdown();
+
+      // Shared store should still be available
+      assertExists(sharedStore);
+
+      await sharedStore.shutdown();
+    },
+  );
+
+  await t.step(
+    "should demonstrate performance benefit of in-memory adapter",
+    async () => {
+      const iterations = 3;
+      const inMemoryTimes: number[] = [];
+
+      // Test in-memory adapter startup times
+      for (let i = 0; i < iterations; i++) {
+        const adapter = makeAdapter({
+          storage: { type: "in-memory" },
+        });
+
+        const agent = new PyodideRuntimeAgent(
+          [`--notebook`, `perf-test-${i}`, "--auth-token", "test"],
+          { discoverAiModels: false },
+          { adapter, clientId: `perf-client-${i}` },
+        );
+
+        const startTime = performance.now();
+        await agent.start();
+        const endTime = performance.now();
+
+        inMemoryTimes.push(endTime - startTime);
+
+        await agent.shutdown();
+      }
+
+      const avgTime = inMemoryTimes.reduce((a, b) => a + b, 0) / iterations;
+
+      // PyodideRuntimeAgent with in-memory should be reasonably fast (under 10 seconds on average)
+      assertEquals(
+        avgTime < 10000,
+        true,
+        `Average startup time: ${avgTime.toFixed(2)}ms`,
+      );
+
+      // Times should be relatively consistent (standard deviation under 3 seconds for Pyodide)
+      const stdDev = Math.sqrt(
+        inMemoryTimes.reduce(
+          (sum, time) => sum + Math.pow(time - avgTime, 2),
+          0,
+        ) / iterations,
+      );
+      assertEquals(
+        stdDev < 3000,
+        true,
+        `Startup times should be consistent (stddev: ${stdDev.toFixed(2)}ms)`,
+      );
+
+      console.log(
+        `✅ In-memory adapter performance: ${avgTime.toFixed(2)}ms ± ${
+          stdDev.toFixed(2)
+        }ms`,
+      );
+    },
+  );
+
+  await t.step(
+    "should maintain backward compatibility for all existing patterns",
+    () => {
+      // Pattern 1: Basic constructor
+      const agent1 = new PyodideRuntimeAgent([
+        "--notebook",
+        "compat-test-1",
+        "--auth-token",
+        "token",
+      ]);
+      assertExists(agent1);
+
+      // Pattern 2: Constructor with pyodide options
+      const agent2 = new PyodideRuntimeAgent(
+        ["--notebook", "compat-test-2", "--auth-token", "token"],
+        { packages: ["numpy"] },
+      );
+      assertExists(agent2);
+
+      // Pattern 3: Empty options (should use defaults)
+      const agent3 = new PyodideRuntimeAgent(
+        ["--notebook", "compat-test-3", "--auth-token", "token"],
+        {},
+        {},
+      );
+      assertExists(agent3);
+
+      // All existing patterns should work without changes
+      assertEquals(agent1.config.notebookId, "compat-test-1");
+      assertEquals(agent2.config.notebookId, "compat-test-2");
+      assertEquals(agent3.config.notebookId, "compat-test-3");
+    },
+  );
+});

--- a/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
+++ b/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
@@ -117,7 +117,7 @@ Deno.test({
           "test-token",
         ],
         { discoverAiModels: false },
-        { adapter }, // No explicit clientId - should generate one
+        { adapter, clientId: "test-client-generated" }, // explicit clientId
       );
 
       await agent.start();
@@ -277,35 +277,37 @@ Deno.test({
   );
 
   await t.step(
-    "should maintain backward compatibility for all existing patterns",
+    "should require clientId for programmatic usage (CLI handles auth separately)",
     () => {
-      // Pattern 1: Basic constructor
-      const agent1 = new PyodideRuntimeAgent([
-        "--notebook",
-        "compat-test-1",
-        "--auth-token",
-        "token",
-      ]);
+      // Note: CLI usage (import.meta.main in mod.ts) handles auth first,
+      // but programmatic usage now requires explicit clientId
+
+      // Pattern 1: Constructor with clientId (now required)
+      const agent1 = new PyodideRuntimeAgent(
+        [
+          "--notebook",
+          "programmatic-test-1",
+          "--auth-token",
+          "token",
+        ],
+        {}, // pyodide options
+        { clientId: "programmatic-client-1" }, // now required
+      );
       assertExists(agent1);
 
-      // Pattern 2: Constructor with pyodide options
+      // Pattern 2: Constructor with pyodide options and clientId
       const agent2 = new PyodideRuntimeAgent(
-        ["--notebook", "compat-test-2", "--auth-token", "token"],
-        { packages: ["numpy"] },
+        ["--notebook", "programmatic-test-2", "--auth-token", "token"],
+        { packages: ["numpy"] }, // pyodide options
+        { clientId: "programmatic-client-2" }, // now required
       );
       assertExists(agent2);
 
-      // Pattern 3: Empty options (should use defaults)
-      const agent3 = new PyodideRuntimeAgent(
-        ["--notebook", "compat-test-3", "--auth-token", "token"],
-        {},
-      );
-      assertExists(agent3);
-
-      // All existing patterns should work without changes
-      assertEquals(agent1.config.notebookId, "compat-test-1");
-      assertEquals(agent2.config.notebookId, "compat-test-2");
-      assertEquals(agent3.config.notebookId, "compat-test-3");
+      // Verify configs are set correctly
+      assertEquals(agent1.config.notebookId, "programmatic-test-1");
+      assertEquals(agent1.config.clientId, "programmatic-client-1");
+      assertEquals(agent2.config.notebookId, "programmatic-test-2");
+      assertEquals(agent2.config.clientId, "programmatic-client-2");
     },
   );
 });

--- a/packages/pyodide-runtime-agent/test/ai-cancellation.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cancellation.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals, assertExists } from "jsr:@std/assert@1.0.13";
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import { makeAdapter } from "npm:@livestore/adapter-node";
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
 import {
   cellReferences$,
@@ -20,6 +21,11 @@ Deno.test({
 
     await t.step("setup AI cancellation test environment", async () => {
       await withQuietConsole(async () => {
+        // Create explicit in-memory adapter for true isolation
+        const adapter = makeAdapter({
+          storage: { type: "in-memory" },
+        });
+
         const agentArgs = [
           "--runtime-id",
           "ai-cancel-test-runtime",
@@ -28,19 +34,17 @@ Deno.test({
           "--auth-token",
           "ai-cancel-test-token",
           "--sync-url",
-          "ws://localhost:8787",
+          "ws://localhost:8787", // Not used with explicit adapter
         ];
 
         agent = new PyodideRuntimeAgent(agentArgs, {}, {
+          adapter,
           clientId: "ai-cancellation-test-client",
         });
         assertExists(agent);
         assertEquals(agent.config.capabilities.canExecuteAi, true);
 
-        await withQuietConsole(async () => {
-          if (!agent) throw new Error("Agent not initialized");
-          await agent.start();
-        });
+        await agent.start();
       });
     });
 

--- a/packages/pyodide-runtime-agent/test/ai-cancellation.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cancellation.test.ts
@@ -31,7 +31,9 @@ Deno.test({
           "ws://localhost:8787",
         ];
 
-        agent = new PyodideRuntimeAgent(agentArgs);
+        agent = new PyodideRuntimeAgent(agentArgs, {}, {
+          clientId: "ai-cancellation-test-client",
+        });
         assertExists(agent);
         assertEquals(agent.config.capabilities.canExecuteAi, true);
 

--- a/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals, assertExists } from "jsr:@std/assert@1.0.13";
+import { assertEquals, assertExists } from "jsr:@std/assert";
+import { makeAdapter } from "npm:@livestore/adapter-node";
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
 import {
   cellReferences$,
@@ -6,6 +7,7 @@ import {
   events,
   tables,
 } from "@runt/schema";
+
 import { withQuietConsole } from "../../lib/test/test-config.ts";
 
 // Configure test environment for quiet logging
@@ -21,6 +23,11 @@ Deno.test({
   try {
     await t.step("setup", async () => {
       await withQuietConsole(async () => {
+        // Create explicit in-memory adapter for true isolation
+        const adapter = makeAdapter({
+          storage: { type: "in-memory" },
+        });
+
         const agentArgs = [
           "--runtime-id",
           "ai-error-test-runtime",
@@ -29,10 +36,11 @@ Deno.test({
           "--auth-token",
           "ai-error-test-token",
           "--sync-url",
-          "ws://localhost:8787",
+          "ws://localhost:8787", // Not used with explicit adapter
         ];
 
         agent = new PyodideRuntimeAgent(agentArgs, {}, {
+          adapter,
           clientId: "ai-error-test-client",
         });
         assertExists(agent);
@@ -81,10 +89,9 @@ Deno.test({
       // Wait for execution to complete
       let attempts = 0;
       while (attempts < 10) {
-        const queueEntries = agent.store.query(
+        const queueEntries = (agent.store.query(
           tables.executionQueue.select().where({ cellId: aiCellId }),
-        );
-
+        ) as unknown) as Array<{ cellId: string; status?: string }>;
         if (queueEntries.length > 0) {
           const entry = queueEntries[0];
           if (

--- a/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
@@ -32,7 +32,9 @@ Deno.test({
           "ws://localhost:8787",
         ];
 
-        agent = new PyodideRuntimeAgent(agentArgs);
+        agent = new PyodideRuntimeAgent(agentArgs, {}, {
+          clientId: "ai-error-test-client",
+        });
         assertExists(agent);
         assertEquals(agent.config.capabilities.canExecuteAi, true);
 

--- a/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
@@ -7,6 +7,7 @@
 import { assertEquals, assertExists } from "jsr:@std/assert";
 import { delay } from "jsr:@std/async/delay";
 import { crypto } from "jsr:@std/crypto";
+import { makeAdapter } from "npm:@livestore/adapter-node";
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
 import {
   cellReferences$,
@@ -35,7 +36,11 @@ Deno.test({
         const notebookId = `test-${crypto.randomUUID()}`;
         const runtimeId = `runtime-${crypto.randomUUID()}`;
 
-        // Use a local-only sync URL - LiveStore works purely in-memory
+        // Create explicit in-memory adapter for true isolation
+        const adapter = makeAdapter({
+          storage: { type: "in-memory" },
+        });
+
         const agentArgs = [
           "--runtime-id",
           runtimeId,
@@ -44,10 +49,11 @@ Deno.test({
           "--auth-token",
           "test-token",
           "--sync-url",
-          "ws://localhost:9999", // Won't connect, but that's fine
+          "ws://localhost:9999", // Not used with explicit adapter
         ];
 
         agent = new PyodideRuntimeAgent(agentArgs, {}, {
+          adapter,
           clientId: "test-client",
         });
 

--- a/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
@@ -47,7 +47,9 @@ Deno.test({
           "ws://localhost:9999", // Won't connect, but that's fine
         ];
 
-        agent = new PyodideRuntimeAgent(agentArgs);
+        agent = new PyodideRuntimeAgent(agentArgs, {}, {
+          clientId: "test-client",
+        });
 
         assertExists(agent);
         assertEquals(agent.config.notebookId, notebookId);

--- a/packages/pyodide-runtime-agent/test/mount-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/mount-integration.test.ts
@@ -48,7 +48,9 @@ Deno.test({
       } as typeof Worker;
 
       try {
-        const agent = new PyodideRuntimeAgent(args);
+        const agent = new PyodideRuntimeAgent(args, {}, {
+          clientId: "test-client",
+        });
 
         // Don't actually start the agent (since we're mocking the worker)
         // Just verify that the mount paths are properly configured
@@ -159,7 +161,9 @@ Deno.test({
     ];
 
     // This should not throw
-    const agent = new PyodideRuntimeAgent(args);
+    const agent = new PyodideRuntimeAgent(args, {}, {
+      clientId: "test-client",
+    });
     assertEquals(Array.isArray(agent["pyodideOptions"].mountPaths), true);
     assertEquals(agent["pyodideOptions"].mountPaths?.length, 1);
     assertEquals(agent["pyodideOptions"].mountPaths?.[0], "/valid/path");
@@ -173,7 +177,9 @@ Deno.test({
       "--auth-token=test-token",
     ];
 
-    const agent = new PyodideRuntimeAgent(args);
+    const agent = new PyodideRuntimeAgent(args, {}, {
+      clientId: "test-client",
+    });
     assertEquals(agent["pyodideOptions"].mountPaths, []);
 
     console.log("✅ Empty mount paths handled correctly");

--- a/packages/pyodide-runtime-agent/test/mount-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/mount-integration.test.ts
@@ -52,7 +52,7 @@ Deno.test({
 
         // Don't actually start the agent (since we're mocking the worker)
         // Just verify that the mount paths are properly configured
-        assertEquals(agent["options"].mountPaths, [
+        assertEquals(agent["pyodideOptions"].mountPaths, [
           "/tmp/test-data",
           "/tmp/test-scripts",
         ]);
@@ -160,9 +160,9 @@ Deno.test({
 
     // This should not throw
     const agent = new PyodideRuntimeAgent(args);
-    assertEquals(Array.isArray(agent["options"].mountPaths), true);
-    assertEquals(agent["options"].mountPaths?.length, 1);
-    assertEquals(agent["options"].mountPaths?.[0], "/valid/path");
+    assertEquals(Array.isArray(agent["pyodideOptions"].mountPaths), true);
+    assertEquals(agent["pyodideOptions"].mountPaths?.length, 1);
+    assertEquals(agent["pyodideOptions"].mountPaths?.[0], "/valid/path");
 
     console.log("✅ Mount path validation works correctly");
   });
@@ -174,7 +174,7 @@ Deno.test({
     ];
 
     const agent = new PyodideRuntimeAgent(args);
-    assertEquals(agent["options"].mountPaths, []);
+    assertEquals(agent["pyodideOptions"].mountPaths, []);
 
     console.log("✅ Empty mount paths handled correctly");
   });

--- a/packages/pyodide-runtime-agent/test/output-sync.test.ts
+++ b/packages/pyodide-runtime-agent/test/output-sync.test.ts
@@ -16,6 +16,8 @@ Deno.test({
       `--output-dir=${tempOutputDir}`,
     ], {
       outputDir: tempOutputDir,
+    }, {
+      clientId: "test-client",
     });
 
     // Initialize the agent
@@ -131,10 +133,16 @@ Deno.test({
   name: "PyodideRuntimeAgent no output sync when outputDir not configured",
   ignore: true,
 }, async () => {
-  const agent = new PyodideRuntimeAgent([
-    "--notebook=test-notebook",
-    "--auth-token=test-token",
-  ]);
+  const agent = new PyodideRuntimeAgent(
+    [
+      "--notebook=test-notebook",
+      "--auth-token=test-token",
+    ],
+    {},
+    {
+      clientId: "test-client",
+    },
+  );
 
   await agent.start();
 
@@ -213,6 +221,8 @@ Deno.test({
       `--output-dir=${tempOutputDir}`,
     ], {
       outputDir: tempOutputDir,
+    }, {
+      clientId: "test-client",
     });
 
     await agent.start();

--- a/packages/pyodide-runtime-agent/test/readonly-mount.test.ts
+++ b/packages/pyodide-runtime-agent/test/readonly-mount.test.ts
@@ -37,6 +37,8 @@ Deno.test({
     ], {
       mountPaths: [tempMountDir],
       mountReadonly: true,
+    }, {
+      clientId: "test-client",
     });
 
     // Initialize the agent
@@ -108,7 +110,7 @@ with open(f"{mount_dir}/readonly.txt", 'r') as f:
     content = f.read()
     print(f"File content: {content}")
 
-# Read the CSV file  
+# Read the CSV file
 with open(f"{mount_dir}/data.csv", 'r') as f:
     csv_content = f.read()
     print(f"CSV content: {csv_content}")
@@ -276,7 +278,7 @@ try:
     with open(f"{mount_dir}/writable.txt", 'w') as f:
         f.write("Modified content")
     print("SUCCESS: Write operation succeeded as expected")
-    
+
     # Verify the content was changed
     with open(f"{mount_dir}/writable.txt", 'r') as f:
         content = f.read()
@@ -284,12 +286,12 @@ try:
             print("SUCCESS: File content was correctly modified")
         else:
             print(f"ERROR: File content is unexpected: {content}")
-    
+
     # Create a new file (should succeed)
     with open(f"{mount_dir}/new_file.txt", 'w') as f:
         f.write("New file content")
     print("SUCCESS: New file creation succeeded")
-    
+
 except Exception as e:
     print(f"ERROR: Write operation failed unexpectedly: {e}")
 

--- a/packages/pyodide-runtime-agent/test/real-execution.test.ts
+++ b/packages/pyodide-runtime-agent/test/real-execution.test.ts
@@ -25,7 +25,9 @@ function createTestAgent(packages?: string[]): PyodideRuntimeAgent {
     "ws://localhost:8787",
   ];
 
-  return new PyodideRuntimeAgent(validArgs, packages ? { packages } : {});
+  return new PyodideRuntimeAgent(validArgs, packages ? { packages } : {}, {
+    clientId: "test-client",
+  });
 }
 
 // Simple output capture for testing

--- a/packages/pyodide-runtime-agent/test/real-execution.test.ts
+++ b/packages/pyodide-runtime-agent/test/real-execution.test.ts
@@ -5,6 +5,7 @@ import {
   assertExists,
   assertStringIncludes,
 } from "jsr:@std/assert";
+import { makeAdapter } from "npm:@livestore/adapter-node";
 import { PyodideRuntimeAgent } from "../src/pyodide-agent.ts";
 import type {
   ExecutionContext,
@@ -14,6 +15,11 @@ import type {
 
 // Create test agent with minimal packages for speed
 function createTestAgent(packages?: string[]): PyodideRuntimeAgent {
+  // Create explicit in-memory adapter for true isolation
+  const adapter = makeAdapter({
+    storage: { type: "in-memory" },
+  });
+
   const validArgs = [
     "--runtime-id",
     "test-execution-runtime",
@@ -22,10 +28,11 @@ function createTestAgent(packages?: string[]): PyodideRuntimeAgent {
     "--auth-token",
     "test-token",
     "--sync-url",
-    "ws://localhost:8787",
+    "ws://localhost:8787", // Not used with explicit adapter
   ];
 
   return new PyodideRuntimeAgent(validArgs, packages ? { packages } : {}, {
+    adapter,
     clientId: "test-client",
   });
 }


### PR DESCRIPTION
This switches up the runtime agent entrypoint to accept an adapter, making it easier to pass in the web adapter, the persisted adapter, the node adapter, the in memory testing adapter etc. so that the store can get used as is and reuse the agents for browser use.