### PR TITLE
refactor: separate pyodide-specific config from generic runtime lib

### DIFF
--- a/packages/lib/mod.ts
+++ b/packages/lib/mod.ts
@@ -2,9 +2,9 @@
 
 export { RuntimeAgent } from "./src/runtime-agent.ts";
 export {
-  createRuntimeConfig,
+  createBaseRuntimeConfig,
   DEFAULT_CONFIG,
-  parseRuntimeArgs,
+  parseBaseRuntimeArgs,
   RuntimeConfig,
 } from "./src/config.ts";
 export {

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -1,7 +1,7 @@
 // Configuration utilities for Anode runtime agents
 //
-// This module provides utilities for parsing command-line arguments and
-// environment variables to configure runtime agents with sensible defaults.
+// This module provides minimal, generic configuration interfaces that can be
+// extended by specific runtime implementations (Python, JavaScript, etc.).
 
 import { parseArgs } from "@std/cli/parse-args";
 import { createLogger } from "./logging.ts";
@@ -22,7 +22,8 @@ export const DEFAULT_CONFIG = {
 } as const;
 
 /**
- * Configuration class for runtime agents
+ * Core configuration class for runtime agents
+ * Can be extended by specific runtime implementations
  */
 export class RuntimeConfig {
   public readonly runtimeId: string;
@@ -32,17 +33,8 @@ export class RuntimeConfig {
   public readonly notebookId: string;
   public readonly capabilities: RuntimeCapabilities;
   public readonly sessionId: string;
-  public readonly environmentOptions: RuntimeAgentOptions["environmentOptions"];
   public readonly imageArtifactThresholdBytes: number;
   public readonly artifactClient: IArtifactClient;
-  public readonly mountPaths: string[];
-  public readonly mountMappings: Array<
-    { hostPath: string; targetPath: string }
-  >;
-  public readonly indexMountedFiles: boolean;
-  public readonly mountReadonly: boolean;
-  public readonly outputDir: string | undefined;
-  public readonly aiMaxIterations: number;
   public readonly adapter: Adapter | undefined;
   public readonly clientId: string;
 
@@ -53,15 +45,8 @@ export class RuntimeConfig {
     this.authToken = options.authToken;
     this.notebookId = options.notebookId;
     this.capabilities = options.capabilities;
-    this.environmentOptions = options.environmentOptions;
     this.imageArtifactThresholdBytes = options.imageArtifactThresholdBytes ??
       DEFAULT_CONFIG.imageArtifactThresholdBytes;
-    this.mountPaths = options.mountPaths ?? [];
-    this.mountMappings = options.mountMappings ?? [];
-    this.indexMountedFiles = options.indexMountedFiles ?? false;
-    this.mountReadonly = options.mountReadonly ?? false;
-    this.outputDir = options.outputDir;
-    this.aiMaxIterations = options.aiMaxIterations ?? 10;
     this.adapter = options.adapter;
     this.clientId = options.clientId;
 
@@ -108,26 +93,25 @@ export class RuntimeConfig {
     if (!this.authToken) {
       missing.push({
         field: "authToken",
-        suggestion:
-          "--auth-token <token> or RUNT_API_KEY env var (AUTH_TOKEN as fallback)",
+        suggestion: "AUTH_TOKEN or RUNT_API_KEY environment variable",
       });
     }
     if (!this.notebookId) {
       missing.push({
         field: "notebookId",
-        suggestion: "--notebook <id> or NOTEBOOK_ID env var",
+        suggestion: "NOTEBOOK_ID environment variable",
       });
     }
     if (!this.runtimeId) {
       missing.push({
         field: "runtimeId",
-        suggestion: "--runtime-id <id> or RUNTIME_ID env var",
+        suggestion: "RUNTIME_ID environment variable",
       });
     }
     if (!this.runtimeType) {
       missing.push({
         field: "runtimeType",
-        suggestion: "--runtime-type <type> or RUNTIME_TYPE env var",
+        suggestion: "RUNTIME_TYPE environment variable",
       });
     }
 
@@ -138,40 +122,19 @@ export class RuntimeConfig {
       throw new Error(
         `Missing required configuration:\n\n${
           messages.join("\n")
-        }\n\nUse --help for more information.`,
+        }\n\nConsult your runtime implementation for configuration details.`,
       );
-    }
-
-    if (this.environmentOptions) {
-      const invalid: string[] = [];
-      const { runtimePackageManager, runtimePythonPath, runtimeEnvPath } =
-        this.environmentOptions;
-      if (runtimePackageManager && runtimePackageManager !== "pip") {
-        invalid.push(`--runtime-package-manager`);
-      }
-
-      if (runtimePythonPath !== undefined && !runtimePythonPath) {
-        invalid.push(`--runtime-python-path`);
-      }
-      if (runtimeEnvPath !== undefined && !runtimeEnvPath) {
-        invalid.push(`--runtime-env-path`);
-      }
-
-      if (invalid.length > 0) {
-        throw new Error(
-          `Invalid value for:\n\n${
-            invalid.join("\n")
-          }\n\nUse --help for more information.`,
-        );
-      }
     }
   }
 }
 
 /**
- * Parse command-line arguments for runtime agent configuration
+ * Parse minimal command-line arguments for runtime agent configuration
+ * Runtime implementations can extend this with their own argument parsing
  */
-export function parseRuntimeArgs(args: string[]): Partial<RuntimeAgentOptions> {
+export function parseBaseRuntimeArgs(
+  args: string[],
+): Partial<RuntimeAgentOptions> {
   const parsed = parseArgs(args, {
     string: [
       "notebook",
@@ -179,21 +142,9 @@ export function parseRuntimeArgs(args: string[]): Partial<RuntimeAgentOptions> {
       "sync-url",
       "runtime-id",
       "runtime-type",
-      "heartbeat-interval",
-      "runtime-python-path",
-      "runtime-env-path",
-      "runtime-package-manager",
       "image-artifact-threshold",
-      "mount",
-      "output-dir",
-      "ai-max-iterations",
     ],
-    boolean: [
-      "help",
-      "runtime-env-externally-managed",
-      "index-mounted-files",
-      "mount-readonly",
-    ],
+    boolean: ["help"],
     alias: {
       n: "notebook",
       t: "auth-token",
@@ -201,62 +152,28 @@ export function parseRuntimeArgs(args: string[]): Partial<RuntimeAgentOptions> {
       r: "runtime-id",
       T: "runtime-type",
       h: "help",
-      m: "mount",
     },
-    collect: ["mount"], // Allow multiple --mount arguments
   });
 
   if (parsed.help) {
-    // Help text should still go to console for CLI usability
     console.log(`
-Runtime Agent Configuration
+Basic Runtime Agent Configuration
 
-Usage:
-  deno run --allow-net --allow-env main.ts [OPTIONS]
-
-Required Options:
+Required:
   --notebook, -n <id>        Notebook ID to connect to
   --auth-token, -t <token>   Authentication token for sync
 
-Optional Options:
+Optional:
   --sync-url, -s <url>       WebSocket URL for LiveStore sync
                              (default: ${DEFAULT_CONFIG.syncUrl})
   --runtime-id, -R <id>      Runtime identifier
-                             (default: <runtime-type>-runtime-{pid})
   --runtime-type, -T <type>  Runtime type identifier
-                             (default: "runtime")
-  --mount, -m <path>         Host directory to mount. Supports two formats:
-                             1. Simple: /path/to/local (mounts to auto-generated /mnt/ path)
-                             2. Docker-style: /path/to/local:/target/path
-                             Examples: --mount /data or --mount /data:/dataset
-                             (can be specified multiple times)
-  --output-dir <path>        Host directory to sync /outputs to after each cell execution
-  --mount-readonly           Mount directories as read-only (prevents modification)
-                             (only applies when --mount is also used)
-  --index-mounted-files      Enable vector store indexing of mounted files for AI search
-                             (only applies when --mount is also used)
-  --ai-max-iterations <num>  Maximum iterations for AI agent tool calling loops
-                             (default: 10)
   --help, -h                 Show this help message
 
-Examples:
-  deno run --allow-net --allow-env main.ts -n my-notebook -t your-token
-  deno run --allow-net --allow-env main.ts --notebook=test --auth-token=abc123
-  deno run --allow-net --allow-env main.ts -n my-notebook -t token --mount /path/to/data
-  deno run --allow-net --allow-env main.ts -n my-notebook -t token --mount /host/data:/data/dataset --index-mounted-files
+Environment Variables:
+  NOTEBOOK_ID, RUNT_API_KEY, AUTH_TOKEN, LIVESTORE_SYNC_URL, RUNTIME_ID, RUNTIME_TYPE
 
-Environment Variables (fallback):
-  NOTEBOOK_ID, RUNT_API_KEY, LIVESTORE_SYNC_URL, RUNTIME_ID, RUNTIME_TYPE
-  IMAGE_ARTIFACT_THRESHOLD_BYTES
-  AUTH_TOKEN (legacy fallback for service-level authentication)
-
-OpenAI Embedding Configuration (for --index-mounted-files):
-  OPENAI_EMBEDDING_API_KEY       OpenAI API key for optimal vector store embeddings
-  OPENAI_EMBEDDING_MODEL         OpenAI embedding model (default: text-embedding-3-large)
-
-Logging Configuration:
-  RUNT_LOG_LEVEL             Set to DEBUG, INFO, WARN, or ERROR (default: INFO)
-  RUNT_DISABLE_CONSOLE_LOGS  Set to disable console output
+For runtime-specific options, consult your runtime implementation documentation.
     `);
     Deno.exit(0);
   }
@@ -268,121 +185,25 @@ Logging Configuration:
 
   const notebookId = parsed.notebook || Deno.env.get("NOTEBOOK_ID");
   if (notebookId) {
-    result = {
-      ...result,
-      notebookId,
-    };
+    result = { ...result, notebookId };
   }
 
   const authToken = parsed["auth-token"] ||
     Deno.env.get("RUNT_API_KEY") ||
     Deno.env.get("AUTH_TOKEN");
   if (authToken) {
-    result = {
-      ...result,
-      authToken,
-    };
+    result = { ...result, authToken };
   }
 
   const runtimeType = parsed["runtime-type"] || Deno.env.get("RUNTIME_TYPE");
   if (runtimeType && typeof runtimeType === "string") {
-    result = {
-      ...result,
-      runtimeType,
-    };
+    result = { ...result, runtimeType };
   }
 
   const runtimeId = parsed["runtime-id"] || Deno.env.get("RUNTIME_ID");
   if (runtimeId && typeof runtimeId === "string") {
-    result = {
-      ...result,
-      runtimeId,
-    };
+    result = { ...result, runtimeId };
   }
-
-  // Handle mount paths - support both simple paths and Docker-style local:target format
-  if (parsed.mount && parsed.mount.length > 0) {
-    const mountArgs = Array.isArray(parsed.mount)
-      ? parsed.mount
-      : [parsed.mount];
-    const mountPaths: string[] = [];
-    const mountMappings: Array<{ hostPath: string; targetPath: string }> = [];
-
-    for (const mountArg of mountArgs) {
-      if (mountArg.includes(":")) {
-        // Docker-style mount: local-path:target-path
-        const [hostPath, targetPath] = mountArg.split(":", 2);
-        if (hostPath && targetPath) {
-          mountMappings.push({ hostPath, targetPath });
-          // Also add to mountPaths for backward compatibility
-          mountPaths.push(hostPath);
-        } else {
-          throw new Error(
-            `Invalid mount format: ${mountArg}. Expected format: <local-path>:<target-path>`,
-          );
-        }
-      } else {
-        // Simple path format (legacy)
-        mountPaths.push(mountArg);
-      }
-    }
-
-    result = {
-      ...result,
-      mountPaths,
-      mountMappings,
-    };
-  }
-
-  // Handle index-mounted-files flag
-  if (parsed["index-mounted-files"]) {
-    result = {
-      ...result,
-      indexMountedFiles: true,
-    };
-  }
-
-  // Handle mount-readonly flag
-  if (parsed["mount-readonly"]) {
-    result = {
-      ...result,
-      mountReadonly: true,
-    };
-  }
-
-  // Handle output-dir option
-  const outputDir = parsed["output-dir"] || Deno.env.get("OUTPUT_DIR");
-  if (outputDir && typeof outputDir === "string") {
-    result = {
-      ...result,
-      outputDir,
-    };
-  }
-
-  const environmentOptions: Record<string, unknown> = {};
-  environmentOptions.runtimePythonPath = parsed["runtime-python-path"] ||
-    Deno.env.get("RUNTIME_PYTHON_PATH") ||
-    "python3";
-  if (parsed["runtime-env-path"] || Deno.env.get("RUNTIME_ENV_PATH")) {
-    environmentOptions.runtimeEnvPath = parsed["runtime-env-path"] ||
-      Deno.env.get("RUNTIME_ENV_PATH");
-  }
-  environmentOptions.runtimePackageManager =
-    parsed["runtime-package-manager"] ||
-    Deno.env.get("RUNTIME_PACKAGE_MANAGER") ||
-    "pip";
-  const cliExternallyManaged = Boolean(
-    parsed["runtime-env-externally-managed"],
-  );
-  const envExternallyManaged =
-    Deno.env.get("RUNTIME_ENV_EXTERNALLY_MANAGED") === "1" ||
-    Deno.env.get("RUNTIME_ENV_EXTERNALLY_MANAGED") === "true";
-  environmentOptions.runtimeEnvExternallyManaged = cliExternallyManaged ||
-    envExternallyManaged;
-  result = {
-    ...result,
-    environmentOptions,
-  };
 
   // Parse image artifact threshold
   const thresholdArg = parsed["image-artifact-threshold"] ||
@@ -390,23 +211,7 @@ Logging Configuration:
   if (thresholdArg) {
     const threshold = parseInt(thresholdArg, 10);
     if (!isNaN(threshold) && threshold > 0) {
-      result = {
-        ...result,
-        imageArtifactThresholdBytes: threshold,
-      };
-    }
-  }
-
-  // Parse AI max iterations
-  const aiMaxIterationsArg = parsed["ai-max-iterations"] ||
-    Deno.env.get("AI_MAX_ITERATIONS");
-  if (aiMaxIterationsArg) {
-    const aiMaxIterations = parseInt(aiMaxIterationsArg, 10);
-    if (!isNaN(aiMaxIterations) && aiMaxIterations > 0) {
-      result = {
-        ...result,
-        aiMaxIterations,
-      };
+      result = { ...result, imageArtifactThresholdBytes: threshold };
     }
   }
 
@@ -414,13 +219,14 @@ Logging Configuration:
 }
 
 /**
- * Create a complete runtime configuration from CLI args and defaults
+ * Create a basic runtime configuration from CLI args and defaults
+ * Runtime implementations should extend this with their own createConfig function
  */
-export function createRuntimeConfig(
+export function createBaseRuntimeConfig(
   args: string[],
   defaults: Partial<RuntimeAgentOptions> = {},
 ): RuntimeConfig {
-  const cliConfig = parseRuntimeArgs(args);
+  const cliConfig = parseBaseRuntimeArgs(args);
 
   // Merge CLI config with defaults - CLI args override defaults
   const mergedDefaults = {
@@ -431,12 +237,6 @@ export function createRuntimeConfig(
       canExecuteSql: false,
       canExecuteAi: false,
     },
-    environmentOptions: {
-      runtimePythonPath: "python3",
-      runtimePackageManager: "pip",
-      runtimeEnvExternallyManaged: false,
-      ...(defaults.environmentOptions ?? {}),
-    },
     ...defaults,
   };
 
@@ -445,7 +245,7 @@ export function createRuntimeConfig(
     Object.entries(cliConfig).filter(([_, value]) => value !== undefined),
   );
 
-  // Compose the config object without mutating any readonly property
+  // Compose the config object
   const runtimeId = cleanCliConfig.runtimeId ||
     Deno.env.get("RUNTIME_ID") ||
     `${
@@ -456,10 +256,6 @@ export function createRuntimeConfig(
     ...mergedDefaults,
     ...cleanCliConfig,
     runtimeId,
-    environmentOptions: {
-      ...mergedDefaults.environmentOptions,
-      ...(cleanCliConfig.environmentOptions ?? {}),
-    },
   } as RuntimeAgentOptions;
 
   const runtimeConfig = new RuntimeConfig(config);
@@ -472,7 +268,6 @@ export function createRuntimeConfig(
     syncUrl: runtimeConfig.syncUrl,
     notebookId: runtimeConfig.notebookId,
     sessionId: runtimeConfig.sessionId,
-    environmentOptions: config.environmentOptions,
   });
 
   return runtimeConfig;

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -67,7 +67,7 @@ export class RuntimeAgent {
    */
   async start(): Promise<void> {
     try {
-      await this.handlers.onStartup?.(this.config.environmentOptions);
+      await this.handlers.onStartup?.();
 
       this.logger = createLogger(`${this.config.runtimeType}-agent`, {
         context: {
@@ -990,7 +990,7 @@ export class RuntimeAgent {
   /**
    * Process image content and upload to artifact service if above size threshold
    */
-  private async processImageContent(
+  protected async processImageContent(
     mimeType: ImageMimeType,
     content: unknown,
     metadata?: Record<string, unknown>,
@@ -1090,7 +1090,7 @@ export class RuntimeAgent {
   /**
    * Generate appropriate text representations for image artifacts
    */
-  private generateTextRepresentationsForArtifacts(
+  protected generateTextRepresentationsForArtifacts(
     representations: Record<string, MediaContainer>,
   ): void {
     for (const [mimeType, container] of Object.entries(representations)) {

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -49,7 +49,8 @@ export interface ArtifactSubmissionResult {
 }
 
 /**
- * Configuration options for runtime agents
+ * Core configuration options for runtime agents
+ * Runtime implementations can extend this interface with their own specific options
  */
 export interface RuntimeAgentOptions {
   /** Unique identifier for this runtime */
@@ -68,29 +69,6 @@ export interface RuntimeAgentOptions {
   readonly imageArtifactThresholdBytes?: number;
   /** Artifact client for dependency injection (optional) */
   readonly artifactClient?: IArtifactClient;
-  /** Host directories to mount into the runtime filesystem */
-  readonly mountPaths?: string[];
-  /** Mount mappings for Docker-style mounts: local-path -> target-path */
-  readonly mountMappings?: Array<{ hostPath: string; targetPath: string }>;
-  /** Whether to index mounted files in vector store for AI search */
-  readonly indexMountedFiles?: boolean;
-  /** Whether to mount directories as read-only */
-  readonly mountReadonly?: boolean;
-  /** Host directory where files from /outputs will be synced */
-  readonly outputDir?: string;
-  /** Environment-related options for the runtime */
-  readonly environmentOptions: Readonly<{
-    /** Path to the python executable to use (default: "python3") */
-    readonly runtimePythonPath?: string;
-    /** Path to the environment/venv to use (default: unset) */
-    readonly runtimeEnvPath?: string;
-    /** Package manager to use (default: "pip") */
-    readonly runtimePackageManager?: string;
-    /** If true, treat the environment as externally managed (default: false) */
-    readonly runtimeEnvExternallyManaged?: boolean;
-  }>;
-  /** Maximum iterations for AI agent tool calling loops (default: 10) */
-  readonly aiMaxIterations?: number;
   /** Custom LiveStore adapter to use instead of default */
   readonly adapter?: Adapter;
   /** Client ID for sync payload (must be provided) */
@@ -246,9 +224,7 @@ export type ExecutionHandler = (
  */
 export interface RuntimeAgentEventHandlers {
   /** Called when agent starts up */
-  onStartup?: (
-    environmentOptions: RuntimeAgentOptions["environmentOptions"],
-  ) => void | Promise<void>;
+  onStartup?: () => void | Promise<void>;
   /** Called when agent shuts down */
   onShutdown?: () => void | Promise<void>;
   /** Called when connection to LiveStore is established */

--- a/packages/lib/test/config.test.ts
+++ b/packages/lib/test/config.test.ts
@@ -1,229 +1,230 @@
 /// <reference lib="deno.ns" />
-import { assert, assertEquals, assertThrows } from "jsr:@std/assert";
+import { assertEquals, assertThrows } from "jsr:@std/assert";
 import { stub } from "jsr:@std/testing/mock";
 import {
-  createRuntimeConfig,
+  createBaseRuntimeConfig,
   DEFAULT_CONFIG,
-  parseRuntimeArgs,
+  parseBaseRuntimeArgs,
   RuntimeConfig,
 } from "../src/config.ts";
 
-const REQUIRED_PARAMS = ["--notebook", "nb", "--auth-token", "tok"];
+const REQUIRED_PARAMS = ["--notebook", "test-nb", "--auth-token", "test-token"];
+
 function addRequiredParams(args: string[]): string[] {
   return [...REQUIRED_PARAMS, ...args];
 }
 
 function makeBaseConfig(overrides: Partial<Record<string, unknown>> = {}) {
   return {
-    runtimeId: "id",
-    runtimeType: "type",
-    syncUrl: "url",
-    authToken: "token",
-    notebookId: "nb",
+    runtimeId: "test-runtime-id",
+    runtimeType: "test-runtime",
+    syncUrl: "wss://test.example.com",
+    authToken: "test-token",
+    notebookId: "test-nb",
     clientId: "test-client",
     capabilities: {
       canExecuteCode: true,
       canExecuteSql: false,
       canExecuteAi: false,
     },
-    environmentOptions: {
-      runtimePackageManager: "pip",
-      runtimePythonPath: "/usr/bin/python3",
-      runtimeEnvPath: "/tmp/venv",
-      ...overrides,
-    },
+    ...overrides,
   };
 }
 
-Deno.test("parseRuntimeArgs: parses required CLI args", () => {
+Deno.test("parseBaseRuntimeArgs: parses required CLI args", () => {
   const args = [
     "--notebook",
     "nb1",
     "--auth-token",
-    "tok",
+    "token1",
     "--runtime-id",
-    "rid",
+    "runtime1",
     "--runtime-type",
     "python",
     "--sync-url",
-    "ws://foo",
-    "--runtime-python-path",
-    "/usr/bin/python3",
-    "--runtime-env-path",
-    "/tmp/venv",
-    "--runtime-package-manager",
-    "pipx",
-    "--runtime-env-externally-managed",
+    "wss://example.com",
   ];
-  const result = parseRuntimeArgs(args);
+
+  const result = parseBaseRuntimeArgs(args);
+
   assertEquals(result.notebookId, "nb1");
-  assertEquals(result.authToken, "tok");
-  assertEquals(result.runtimeId, "rid");
+  assertEquals(result.authToken, "token1");
+  assertEquals(result.runtimeId, "runtime1");
   assertEquals(result.runtimeType, "python");
-  assertEquals(result.syncUrl, "ws://foo");
-  assert(result.environmentOptions);
-  assertEquals(
-    result.environmentOptions?.runtimePythonPath,
-    "/usr/bin/python3",
-  );
-  assertEquals(result.environmentOptions?.runtimeEnvPath, "/tmp/venv");
-  assertEquals(result.environmentOptions?.runtimePackageManager, "pipx");
-  assertEquals(result.environmentOptions?.runtimeEnvExternallyManaged, true);
+  assertEquals(result.syncUrl, "wss://example.com");
 });
 
-Deno.test("parseRuntimeArgs: uses defaults for missing environmentOptions", () => {
-  const result = parseRuntimeArgs([
+Deno.test("parseBaseRuntimeArgs: uses environment variable fallbacks", () => {
+  const envMap: Record<string, string | undefined> = {
+    NOTEBOOK_ID: "env-notebook",
+    RUNT_API_KEY: "env-token",
+    RUNTIME_ID: "env-runtime-id",
+    RUNTIME_TYPE: "env-runtime-type",
+    LIVESTORE_SYNC_URL: "wss://env.example.com",
+  };
+
+  using _getStub = stub(Deno.env, "get", (key: string) => envMap[key]);
+
+  const result = parseBaseRuntimeArgs([]);
+
+  assertEquals(result.notebookId, "env-notebook");
+  assertEquals(result.authToken, "env-token");
+  assertEquals(result.runtimeId, "env-runtime-id");
+  assertEquals(result.runtimeType, "env-runtime-type");
+  assertEquals(result.syncUrl, "wss://env.example.com");
+});
+
+Deno.test("parseBaseRuntimeArgs: CLI args override environment variables", () => {
+  const envMap: Record<string, string | undefined> = {
+    NOTEBOOK_ID: "env-notebook",
+    RUNT_API_KEY: "env-token",
+  };
+
+  using _getStub = stub(Deno.env, "get", (key: string) => envMap[key]);
+
+  const result = parseBaseRuntimeArgs([
     "--notebook",
-    "nb2",
+    "cli-notebook",
     "--auth-token",
-    "tok2",
+    "cli-token",
   ]);
-  assert(result.environmentOptions);
-  assertEquals(result.environmentOptions?.runtimePythonPath, "python3");
-  assertEquals(result.environmentOptions?.runtimePackageManager, "pip");
-  assertEquals(result.environmentOptions?.runtimeEnvExternallyManaged, false);
+
+  assertEquals(result.notebookId, "cli-notebook");
+  assertEquals(result.authToken, "cli-token");
 });
 
-Deno.test("createRuntimeConfig - sets defaults for missing options", () => {
+Deno.test("parseBaseRuntimeArgs: parses image artifact threshold", () => {
+  const result = parseBaseRuntimeArgs([
+    "--notebook",
+    "test-nb",
+    "--auth-token",
+    "test-token",
+    "--image-artifact-threshold",
+    "8192",
+  ]);
+
+  assertEquals(result.imageArtifactThresholdBytes, 8192);
+});
+
+Deno.test("parseBaseRuntimeArgs: uses default sync URL when not provided", () => {
+  const result = parseBaseRuntimeArgs([
+    "--notebook",
+    "test-nb",
+    "--auth-token",
+    "test-token",
+  ]);
+
+  assertEquals(result.syncUrl, DEFAULT_CONFIG.syncUrl);
+});
+
+Deno.test("createBaseRuntimeConfig: creates valid config with defaults", () => {
   using _getStub = stub(Deno.env, "get", () => undefined);
-  const config = createRuntimeConfig(addRequiredParams([]));
+
+  const config = createBaseRuntimeConfig(addRequiredParams([]));
+
+  assertEquals(config.notebookId, "test-nb");
+  assertEquals(config.authToken, "test-token");
   assertEquals(config.syncUrl, DEFAULT_CONFIG.syncUrl);
-  assertEquals(config.environmentOptions?.runtimePythonPath, "python3");
-  assertEquals(config.environmentOptions?.runtimePackageManager, "pip");
-  assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, false);
+  assertEquals(config.runtimeType, "runtime");
+  assertEquals(config.capabilities.canExecuteCode, true);
+  assertEquals(config.capabilities.canExecuteSql, false);
+  assertEquals(config.capabilities.canExecuteAi, false);
 });
 
-Deno.test("createRuntimeConfig - deep merges environmentOptions from CLI, env, and defaults", () => {
-  const envMap: Record<string, string | undefined> = {
-    RUNTIME_PYTHON_PATH: "/env/python",
-    RUNTIME_PACKAGE_MANAGER: "conda",
-    RUNTIME_ENV_EXTERNALLY_MANAGED: "true",
-  };
-  using _getStub = stub(Deno.env, "get", (key: string) => envMap[key]);
-  const args = addRequiredParams(["--runtime-python-path", "/cli/python"]);
-  assertThrows(
-    () =>
-      createRuntimeConfig(args, {
-        runtimeType: "python",
-        capabilities: {
-          canExecuteCode: true,
-          canExecuteSql: false,
-          canExecuteAi: false,
-        },
-        environmentOptions: {
-          runtimePythonPath: "/default/python",
-          runtimePackageManager: "pip",
-          runtimeEnvExternallyManaged: false,
-        },
-      }),
-    Error,
-    "--runtime-package-manager",
-  );
-});
-
-Deno.test("createRuntimeConfig - runtimeEnvExternallyManaged is true if set in CLI", () => {
+Deno.test("createBaseRuntimeConfig: generates runtime ID with defaults", () => {
   using _getStub = stub(Deno.env, "get", () => undefined);
-  const args = addRequiredParams(["--runtime-env-externally-managed"]);
-  const config = createRuntimeConfig(args);
-  assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, true);
+
+  const config = createBaseRuntimeConfig(addRequiredParams([]));
+
+  assertEquals(config.runtimeId.startsWith("runtime-runtime-"), true);
 });
 
-Deno.test("createRuntimeConfig - runtimeEnvExternallyManaged is true if set in env", () => {
-  const envMap: Record<string, string | undefined> = {
-    RUNTIME_ENV_EXTERNALLY_MANAGED: "true",
-  };
-  using _getStub = stub(Deno.env, "get", (key: string) => envMap[key]);
-  const config = createRuntimeConfig(addRequiredParams([]));
-  assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, true);
-});
-
-Deno.test("createRuntimeConfig - runtimeEnvExternallyManaged is false if not set", () => {
+Deno.test("createBaseRuntimeConfig: uses provided runtime ID", () => {
   using _getStub = stub(Deno.env, "get", () => undefined);
-  const config = createRuntimeConfig(addRequiredParams([]));
-  assertEquals(config.environmentOptions?.runtimeEnvExternallyManaged, false);
+
+  const config = createBaseRuntimeConfig(addRequiredParams([
+    "--runtime-id",
+    "custom-id",
+  ]));
+
+  assertEquals(config.runtimeId, "custom-id");
 });
 
-Deno.test("RuntimeConfig.validate - passes with valid environmentOptions", () => {
+Deno.test("createBaseRuntimeConfig: merges with provided defaults", () => {
+  using _getStub = stub(Deno.env, "get", () => undefined);
+
+  const config = createBaseRuntimeConfig(addRequiredParams([]), {
+    runtimeType: "custom-runtime",
+    capabilities: {
+      canExecuteCode: false,
+      canExecuteSql: true,
+      canExecuteAi: true,
+    },
+  });
+
+  assertEquals(config.runtimeType, "custom-runtime");
+  assertEquals(config.capabilities.canExecuteCode, false);
+  assertEquals(config.capabilities.canExecuteSql, true);
+  assertEquals(config.capabilities.canExecuteAi, true);
+});
+
+Deno.test("RuntimeConfig.validate: passes with valid config", () => {
   const config = new RuntimeConfig(makeBaseConfig());
-  config.validate();
+  config.validate(); // Should not throw
 });
 
-Deno.test("RuntimeConfig.validate - throws for invalid manager", () => {
+Deno.test("RuntimeConfig.validate: throws for missing authToken", () => {
   assertThrows(
-    () =>
-      new RuntimeConfig(makeBaseConfig({ runtimePackageManager: "conda" }))
-        .validate(),
+    () => new RuntimeConfig(makeBaseConfig({ authToken: "" })).validate(),
     Error,
-    "--runtime-package-manager",
+    "Missing required configuration",
   );
 });
 
-Deno.test("RuntimeConfig.validate - throws for empty python path", () => {
+Deno.test("RuntimeConfig.validate: throws for missing notebookId", () => {
   assertThrows(
-    () =>
-      new RuntimeConfig(makeBaseConfig({ runtimePythonPath: "" })).validate(),
+    () => new RuntimeConfig(makeBaseConfig({ notebookId: "" })).validate(),
     Error,
-    "--runtime-python-path",
+    "Missing required configuration",
   );
 });
 
-Deno.test("RuntimeConfig.validate - throws for empty env path", () => {
+Deno.test("RuntimeConfig.validate: throws for missing runtimeId", () => {
   assertThrows(
-    () => new RuntimeConfig(makeBaseConfig({ runtimeEnvPath: "" })).validate(),
+    () => new RuntimeConfig(makeBaseConfig({ runtimeId: "" })).validate(),
     Error,
-    "--runtime-env-path",
+    "Missing required configuration",
   );
 });
 
-Deno.test("parseRuntimeArgs: parses mount paths from CLI", () => {
-  const args = [
-    "--notebook=test-nb",
-    "--auth-token=test-token",
-    "--mount=/home/user/data",
-    "--mount=/home/user/scripts",
-  ];
-
-  const result = parseRuntimeArgs(args);
-
-  assertEquals(result.notebookId, "test-nb");
-  assertEquals(result.authToken, "test-token");
-  assertEquals(result.mountPaths, ["/home/user/data", "/home/user/scripts"]);
+Deno.test("RuntimeConfig.validate: throws for missing runtimeType", () => {
+  assertThrows(
+    () => new RuntimeConfig(makeBaseConfig({ runtimeType: "" })).validate(),
+    Error,
+    "Missing required configuration",
+  );
 });
 
-Deno.test("parseRuntimeArgs: handles single mount path", () => {
-  const args = [
-    "--notebook=test-nb",
-    "--auth-token=test-token",
-    "--mount=/home/user/data",
-  ];
+Deno.test("RuntimeConfig: generates unique session IDs", () => {
+  const config1 = new RuntimeConfig(makeBaseConfig());
+  const config2 = new RuntimeConfig(makeBaseConfig());
 
-  const result = parseRuntimeArgs(args);
-
-  assertEquals(result.mountPaths, ["/home/user/data"]);
+  assertEquals(config1.sessionId !== config2.sessionId, true);
+  assertEquals(config1.sessionId.includes(config1.runtimeType), true);
+  assertEquals(config1.sessionId.includes(config1.runtimeId), true);
 });
 
-Deno.test("parseRuntimeArgs: handles no mount paths", () => {
-  const args = [
-    "--notebook=test-nb",
-    "--auth-token=test-token",
-  ];
-
-  const result = parseRuntimeArgs(args);
-
-  assertEquals(result.mountPaths, undefined);
+Deno.test("RuntimeConfig: sets default image artifact threshold", () => {
+  const config = new RuntimeConfig(makeBaseConfig());
+  assertEquals(
+    config.imageArtifactThresholdBytes,
+    DEFAULT_CONFIG.imageArtifactThresholdBytes,
+  );
 });
 
-Deno.test("parseRuntimeArgs: uses short alias for mount", () => {
-  const args = [
-    "--notebook=test-nb",
-    "--auth-token=test-token",
-    "-m",
-    "/home/user/data",
-    "-m",
-    "/home/user/scripts",
-  ];
-
-  const result = parseRuntimeArgs(args);
-
-  assertEquals(result.mountPaths, ["/home/user/data", "/home/user/scripts"]);
+Deno.test("RuntimeConfig: uses provided image artifact threshold", () => {
+  const config = new RuntimeConfig(
+    makeBaseConfig({ imageArtifactThresholdBytes: 10240 }),
+  );
+  assertEquals(config.imageArtifactThresholdBytes, 10240);
 });

--- a/packages/lib/test/integration.test.ts
+++ b/packages/lib/test/integration.test.ts
@@ -64,7 +64,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       authToken: "test-integration-token",
       clientId: "test-integration-client",
       adapter,
-      environmentOptions: {},
+
       capabilities,
     });
   };
@@ -160,7 +160,6 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
         clientId: "valid-client",
         adapter,
         capabilities: capabilities,
-        environmentOptions: {},
       });
 
       const agent = new RuntimeAgent(validConfig, capabilities);
@@ -186,7 +185,6 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
           clientId: "test-client",
           adapter,
           capabilities: capabilities,
-          environmentOptions: {},
         });
         config.validate(); // Explicitly call validate
       } catch (e) {
@@ -268,7 +266,6 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
-      environmentOptions: {},
     });
 
     // Verify all required fields are set correctly
@@ -298,7 +295,6 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
-      environmentOptions: {},
     });
 
     const adapter2 = makeAdapter({
@@ -318,7 +314,6 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
-      environmentOptions: {},
     });
 
     // Session IDs should be different
@@ -343,7 +338,6 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: true,
       },
-      environmentOptions: {},
     });
   });
 });

--- a/packages/lib/test/integration.test.ts
+++ b/packages/lib/test/integration.test.ts
@@ -194,7 +194,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       assertExists(error);
       assertEquals(
         error?.message.includes(
-          "runtimeId: --runtime-id <id> or RUNTIME_ID env var",
+          "runtimeId: RUNTIME_ID environment variable",
         ),
         true,
       );

--- a/packages/lib/test/mod.test.ts
+++ b/packages/lib/test/mod.test.ts
@@ -1,7 +1,7 @@
 /// <reference lib="deno.ns" />
 import { assertEquals } from "jsr:@std/assert";
 import {
-  createRuntimeConfig,
+  createBaseRuntimeConfig,
   DEFAULT_CONFIG,
   RuntimeAgent,
   RuntimeConfig,
@@ -11,7 +11,7 @@ Deno.test("Library exports are available", () => {
   // Test that main exports are defined
   assertEquals(typeof RuntimeAgent, "function");
   assertEquals(typeof RuntimeConfig, "function");
-  assertEquals(typeof createRuntimeConfig, "function");
+  assertEquals(typeof createBaseRuntimeConfig, "function");
   assertEquals(typeof DEFAULT_CONFIG, "object");
 });
 
@@ -37,7 +37,6 @@ Deno.test("RuntimeConfig validation works", () => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
-      environmentOptions: {},
     });
     config.validate();
     throw new Error("Should have thrown validation error");
@@ -61,7 +60,6 @@ Deno.test("RuntimeConfig validation works", () => {
       canExecuteSql: false,
       canExecuteAi: false,
     },
-    environmentOptions: {},
   });
 
   // Should not throw

--- a/packages/lib/test/runtime-agent-adapter-injection.test.ts
+++ b/packages/lib/test/runtime-agent-adapter-injection.test.ts
@@ -9,14 +9,14 @@ import { assertEquals, assertExists } from "jsr:@std/assert";
 import { crypto } from "jsr:@std/crypto";
 
 import { RuntimeAgent, type RuntimeCapabilities } from "@runt/lib";
-import { createRuntimeConfig } from "../src/config.ts";
+import { createBaseRuntimeConfig } from "../src/config.ts";
 import { makeAdapter } from "npm:@livestore/adapter-node";
 
 Deno.test("RuntimeAgent adapter injection", async (t) => {
   await t.step(
     "should work with default adapter (backward compatibility)",
     () => {
-      const config = createRuntimeConfig([
+      const config = createBaseRuntimeConfig([
         "--notebook",
         "test-notebook",
         "--auth-token",
@@ -48,7 +48,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       // No sync backend needed for pure in-memory testing
     });
 
-    const config = createRuntimeConfig([
+    const config = createBaseRuntimeConfig([
       "--notebook",
       "adapter-test",
       "--auth-token",
@@ -86,7 +86,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
         storage: { type: "in-memory" },
       });
 
-      const config = createRuntimeConfig([
+      const config = createBaseRuntimeConfig([
         "--notebook",
         "adapter-test-2",
         "--auth-token",
@@ -119,7 +119,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       storage: { type: "in-memory" },
     });
 
-    const config = createRuntimeConfig([
+    const config = createBaseRuntimeConfig([
       "--notebook",
       "clientid-test",
       "--runtime-id",
@@ -156,7 +156,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
 
     const explicitClientId = "my-custom-client-id";
 
-    const config = createRuntimeConfig([
+    const config = createBaseRuntimeConfig([
       "--notebook",
       "explicit-clientid-test",
       "--auth-token",
@@ -189,7 +189,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
     });
 
     // Create two agents using the same adapter
-    const config1 = createRuntimeConfig([
+    const config1 = createBaseRuntimeConfig([
       "--notebook",
       "shared-adapter-1",
       "--runtime-id",
@@ -201,7 +201,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       clientId: "client-1",
     });
 
-    const config2 = createRuntimeConfig([
+    const config2 = createBaseRuntimeConfig([
       "--notebook",
       "shared-adapter-2",
       "--runtime-id",
@@ -244,7 +244,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
       },
     });
 
-    const config = createRuntimeConfig([
+    const config = createBaseRuntimeConfig([
       "--notebook",
       "fs-test",
       "--auth-token",

--- a/packages/lib/test/runtime-agent-artifact.test.ts
+++ b/packages/lib/test/runtime-agent-artifact.test.ts
@@ -73,7 +73,6 @@ const mockRuntimeOptions: RuntimeAgentOptions = {
   notebookId: "test-notebook",
   clientId: "test-client",
   imageArtifactThresholdBytes: 6 * 1024, // 6KB threshold
-  environmentOptions: {},
 };
 
 // Mock fetch for testing

--- a/packages/lib/test/runtime-agent-text-representations.test.ts
+++ b/packages/lib/test/runtime-agent-text-representations.test.ts
@@ -49,7 +49,6 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         clientId: "test-client",
         adapter,
         capabilities: capabilities,
-        environmentOptions: {},
       });
 
       const agent = new RuntimeAgent(config, capabilities);
@@ -165,7 +164,7 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         clientId: "test-client",
         adapter,
         capabilities,
-        environmentOptions: {},
+
         imageArtifactThresholdBytes: 10, // Very low threshold to trigger artifacting
       });
 
@@ -282,7 +281,7 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         clientId: "test-client",
         adapter,
         capabilities,
-        environmentOptions: {},
+
         imageArtifactThresholdBytes: 10, // Very low threshold to trigger artifacting
         artifactClient: mockArtifactClient,
       });

--- a/packages/lib/test/runtime-agent.test.ts
+++ b/packages/lib/test/runtime-agent.test.ts
@@ -65,7 +65,6 @@ Deno.test("RuntimeAgent", async (t) => {
       clientId: "test-client",
       adapter,
       capabilities,
-      environmentOptions: {},
     });
   };
 
@@ -188,7 +187,6 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: true,
       },
-      environmentOptions: {},
     });
 
     assertEquals(config.runtimeId, "test-runtime");
@@ -217,7 +215,6 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
-      environmentOptions: {},
     });
 
     const adapter2 = makeAdapter({
@@ -237,7 +234,6 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
-      environmentOptions: {},
     });
 
     // Session IDs should be different
@@ -262,7 +258,6 @@ Deno.test("RuntimeConfig", async (t) => {
         canExecuteSql: false,
         canExecuteAi: false,
       },
-      environmentOptions: {},
     });
   });
 });

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -19,6 +19,7 @@
     "@runt/schema": "jsr:@runt/schema@^0.11.1",
     "npm:pyodide": "npm:pyodide@^0.27.7",
     "@std/async": "jsr:@std/async@^1.0.0",
+    "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
     "npm:strip-ansi": "npm:strip-ansi@^7.1.0"
   },
@@ -45,19 +46,11 @@
   },
   "lint": {
     "rules": {
-      "tags": [
-        "recommended"
-      ]
+      "tags": ["recommended"]
     }
   },
   "publish": {
-    "include": [
-      "src/",
-      "README.md"
-    ],
-    "exclude": [
-      "**/*.test.ts",
-      "**/test_*.ts"
-    ]
+    "include": ["src/", "README.md"],
+    "exclude": ["**/*.test.ts", "**/test_*.ts"]
   }
 }

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -8,11 +8,8 @@
 
 import { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
-import {
-  createLogger,
-  createRuntimeConfig,
-  discoverUserIdentity,
-} from "@runt/lib";
+import { createLogger, discoverUserIdentity } from "@runt/lib";
+import { createPyodideRuntimeConfig } from "./pyodide-config.ts";
 
 // Run the agent if this file is executed directly
 if (import.meta.main) {
@@ -22,14 +19,7 @@ if (import.meta.main) {
   logger.info("Authenticating...");
 
   // Create temporary config to get auth details
-  const tempConfig = createRuntimeConfig(Deno.args, {
-    runtimeType: "python3-pyodide",
-    capabilities: {
-      canExecuteCode: true,
-      canExecuteSql: false,
-      canExecuteAi: true,
-      availableAiModels: [],
-    },
+  const tempConfig = createPyodideRuntimeConfig(Deno.args, {
     clientId: "temp", // Will be replaced
   });
 

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -4,11 +4,11 @@
 // IPython integration, rich display support, and true interruption support
 // via Pyodide's built-in interrupt system.
 
+import { RuntimeAgent } from "@runt/lib";
 import {
-  createRuntimeConfig,
-  RuntimeAgent,
-  type RuntimeConfig,
-} from "@runt/lib";
+  createPyodideRuntimeConfig,
+  type PyodideRuntimeConfig,
+} from "./pyodide-config.ts";
 import type { Adapter } from "npm:@livestore/livestore";
 import type { ExecutionContext } from "@runt/lib";
 
@@ -66,6 +66,7 @@ interface PyodideRuntimeOptions {
  * pandas HTML tables, and error formatting.
  */
 export class PyodideRuntimeAgent extends RuntimeAgent {
+  declare public config: PyodideRuntimeConfig;
   private worker: Worker | null = null;
   private interruptBuffer?: SharedArrayBuffer;
   private isInitialized = false;
@@ -92,16 +93,16 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
     options: PyodideAgentOptions = {},
     runtimeOptions: PyodideRuntimeOptions = {},
   ) {
-    let config: RuntimeConfig;
+    let config: PyodideRuntimeConfig;
     try {
-      config = createRuntimeConfig(args, {
-        runtimeType: "python3-pyodide",
+      config = createPyodideRuntimeConfig(args, {
         capabilities: {
           canExecuteCode: true,
           canExecuteSql: false,
           canExecuteAi: true,
           availableAiModels: [], // Will be populated during startup
         },
+        ...options, // Merge options into config
         ...(runtimeOptions.adapter && { adapter: runtimeOptions.adapter }),
         ...(runtimeOptions.clientId && { clientId: runtimeOptions.clientId }),
       });
@@ -125,28 +126,19 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
     }
 
     super(config, config.capabilities, {
+      onStartup: async () => {
+        // Pyodide-specific startup logic if needed
+      },
       onShutdown: async () => {
         await this.cleanupWorker();
       },
     });
 
-    // Merge config mount paths with options mount paths
-    const mergedOptions: PyodideAgentOptions = {
+    // Store simplified options - config now handles the complex merging
+    this.pyodideOptions = {
       ...options,
-      mountPaths: options.mountPaths || config.mountPaths || [],
-      mountMappings: options.mountMappings || config.mountMappings || [],
-      indexMountedFiles: options.indexMountedFiles ??
-        config.indexMountedFiles ?? false,
-      mountReadonly: options.mountReadonly ?? config.mountReadonly ?? false,
+      discoverAiModels: options.discoverAiModels ?? true,
     };
-
-    // Only include outputDir if it has a value
-    const finalOutputDir = options.outputDir ?? config.outputDir;
-    if (finalOutputDir) {
-      mergedOptions.outputDir = finalOutputDir;
-    }
-
-    this.pyodideOptions = mergedOptions;
     this.onExecution(this.executeCell.bind(this));
     this.onCancellation(this.handlePyodideCancellation.bind(this));
   }
@@ -165,7 +157,8 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       try {
         this.logger.info("Discovering available AI models...");
         const models = await discoverAvailableAiModels();
-        this.config.capabilities.availableAiModels = models;
+        // Update the capabilities object with discovered models
+        (this.config.capabilities as any).availableAiModels = models;
 
         if (models.length === 0) {
           this.logger.warn(
@@ -244,22 +237,19 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
           readonly?: boolean;
         }
       > = [];
-      if (
-        this.pyodideOptions.mountPaths &&
-        this.pyodideOptions.mountPaths.length > 0
-      ) {
+      if (this.config.mountPaths && this.config.mountPaths.length > 0) {
         mountData = await this.readMountDirectories(
-          this.pyodideOptions.mountPaths,
-          this.pyodideOptions.mountMappings,
+          this.config.mountPaths,
+          this.config.mountMappings,
         );
 
         // Add readonly flag to all mount entries if mountReadonly is enabled
-        if (this.pyodideOptions.mountReadonly) {
+        if (this.config.mountReadonly) {
           mountData = mountData.map((entry) => ({ ...entry, readonly: true }));
         }
 
         // Start vector store ingestion asynchronously only if indexing is enabled
-        if (this.pyodideOptions.indexMountedFiles) {
+        if (this.config.indexMountedFiles) {
           // Initialize vector store in background to avoid blocking pyodide startup
           Promise.resolve().then(async () => {
             try {
@@ -471,7 +461,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       ) as NotebookTool[];
 
       try {
-        const maxIterations = this.config.aiMaxIterations || 10;
+        const maxIterations = this.config.aiMaxIterations;
         return await executeAI(
           aiContext,
           notebookContext,
@@ -592,7 +582,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
         }
 
         // Sync /outputs directory back to host if outputDir is configured
-        if (this.pyodideOptions.outputDir) {
+        if (this.config.outputDir) {
           await this.syncOutputsToHost();
         }
 
@@ -934,7 +924,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
    * Sync files from /outputs directory back to host filesystem
    */
   private async syncOutputsToHost(): Promise<void> {
-    if (!this.pyodideOptions.outputDir) {
+    if (!this.config.outputDir) {
       return;
     }
 
@@ -951,7 +941,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
 
       // Ensure output directory exists on host
       try {
-        await Deno.mkdir(this.pyodideOptions.outputDir, { recursive: true });
+        await Deno.mkdir(this.config.outputDir, { recursive: true });
       } catch (_error) {
         // Directory might already exist, ignore error
       }
@@ -960,14 +950,14 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
       let syncedCount = 0;
       for (const { path, content } of result.files) {
         try {
-          const hostPath: string = `${this.pyodideOptions.outputDir}/${path}`;
+          const hostPath: string = `${this.config.outputDir}/${path}`;
 
           // Create parent directories if needed
           const parentDir: string = hostPath.substring(
             0,
             hostPath.lastIndexOf("/"),
           );
-          if (parentDir !== this.pyodideOptions.outputDir) {
+          if (parentDir !== this.config.outputDir) {
             try {
               await Deno.mkdir(parentDir, { recursive: true });
             } catch (_error) {
@@ -985,7 +975,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
 
       if (syncedCount > 0) {
         this.logger.info(
-          `Synced ${syncedCount} files from /outputs to ${this.pyodideOptions.outputDir}`,
+          `Synced ${syncedCount} files from /outputs to ${this.config.outputDir}`,
         );
       }
     } catch (error) {

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -10,7 +10,7 @@ import {
   type PyodideRuntimeConfig,
 } from "./pyodide-config.ts";
 import type { Adapter } from "npm:@livestore/livestore";
-import type { ExecutionContext } from "@runt/lib";
+import type { ExecutionContext, RuntimeCapabilities } from "@runt/lib";
 
 import { type MediaBundle, validateMediaBundle } from "@runt/lib";
 import {
@@ -158,7 +158,8 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
         this.logger.info("Discovering available AI models...");
         const models = await discoverAvailableAiModels();
         // Update the capabilities object with discovered models
-        (this.config.capabilities as any).availableAiModels = models;
+        (this.config.capabilities as RuntimeCapabilities).availableAiModels =
+          models;
 
         if (models.length === 0) {
           this.logger.warn(

--- a/packages/pyodide-runtime-agent/src/pyodide-config.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-config.ts
@@ -1,0 +1,388 @@
+// Pyodide-specific configuration utilities
+//
+// This module extends the base runtime configuration with Pyodide-specific
+// options like file mounting, AI capabilities, Python environment settings,
+// and vector store indexing.
+
+import { parseArgs } from "@std/cli/parse-args";
+import {
+  createBaseRuntimeConfig,
+  DEFAULT_CONFIG,
+  parseBaseRuntimeArgs,
+  RuntimeConfig,
+} from "@runt/lib";
+import type { RuntimeAgentOptions } from "@runt/lib";
+import { createLogger } from "@runt/lib";
+
+/**
+ * Pyodide-specific configuration options
+ */
+export interface PyodideRuntimeAgentOptions extends RuntimeAgentOptions {
+  /** Host directories to mount into the runtime filesystem */
+  readonly mountPaths?: string[];
+  /** Mount mappings for Docker-style mounts: local-path -> target-path */
+  readonly mountMappings?: Array<{ hostPath: string; targetPath: string }>;
+  /** Whether to index mounted files in vector store for AI search */
+  readonly indexMountedFiles?: boolean;
+  /** Whether to mount directories as read-only */
+  readonly mountReadonly?: boolean;
+  /** Host directory where files from /outputs will be synced */
+  readonly outputDir?: string;
+  /** Environment-related options for the Python runtime */
+  readonly environmentOptions: Readonly<{
+    /** Path to the python executable to use (default: "python3") */
+    readonly runtimePythonPath?: string;
+    /** Path to the environment/venv to use (default: unset) */
+    readonly runtimeEnvPath?: string;
+    /** Package manager to use (default: "pip") */
+    readonly runtimePackageManager?: string;
+    /** If true, treat the environment as externally managed (default: false) */
+    readonly runtimeEnvExternallyManaged?: boolean;
+  }>;
+  /** Maximum iterations for AI agent tool calling loops (default: 10) */
+  readonly aiMaxIterations?: number;
+}
+
+/**
+ * Pyodide-specific configuration class
+ */
+export class PyodideRuntimeConfig extends RuntimeConfig {
+  public readonly environmentOptions:
+    PyodideRuntimeAgentOptions["environmentOptions"];
+  public readonly mountPaths: string[];
+  public readonly mountMappings: Array<
+    { hostPath: string; targetPath: string }
+  >;
+  public readonly indexMountedFiles: boolean;
+  public readonly mountReadonly: boolean;
+  public readonly outputDir: string | undefined;
+  public readonly aiMaxIterations: number;
+
+  constructor(options: PyodideRuntimeAgentOptions) {
+    super(options);
+    this.environmentOptions = options.environmentOptions;
+    this.mountPaths = options.mountPaths ?? [];
+    this.mountMappings = options.mountMappings ?? [];
+    this.indexMountedFiles = options.indexMountedFiles ?? false;
+    this.mountReadonly = options.mountReadonly ?? false;
+    this.outputDir = options.outputDir;
+    this.aiMaxIterations = options.aiMaxIterations ?? 10;
+  }
+
+  /**
+   * Validate pyodide-specific configuration
+   */
+  override validate(): void {
+    // Call base validation first
+    super.validate();
+
+    // Validate pyodide-specific options
+    if (this.environmentOptions) {
+      const invalid: string[] = [];
+      const { runtimePackageManager, runtimePythonPath, runtimeEnvPath } =
+        this.environmentOptions;
+      if (runtimePackageManager && runtimePackageManager !== "pip") {
+        invalid.push(`--runtime-package-manager`);
+      }
+
+      if (runtimePythonPath !== undefined && !runtimePythonPath) {
+        invalid.push(`--runtime-python-path`);
+      }
+      if (runtimeEnvPath !== undefined && !runtimeEnvPath) {
+        invalid.push(`--runtime-env-path`);
+      }
+
+      if (invalid.length > 0) {
+        throw new Error(
+          `Invalid value for:\n\n${
+            invalid.join("\n")
+          }\n\nUse --help for more information.`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Parse pyodide-specific command-line arguments
+ */
+export function parsePyodideRuntimeArgs(
+  args: string[],
+): Partial<PyodideRuntimeAgentOptions> {
+  const parsed = parseArgs(args, {
+    string: [
+      "notebook",
+      "auth-token",
+      "sync-url",
+      "runtime-id",
+      "runtime-type",
+      "heartbeat-interval",
+      "runtime-python-path",
+      "runtime-env-path",
+      "runtime-package-manager",
+      "image-artifact-threshold",
+      "mount",
+      "output-dir",
+      "ai-max-iterations",
+    ],
+    boolean: [
+      "help",
+      "runtime-env-externally-managed",
+      "index-mounted-files",
+      "mount-readonly",
+    ],
+    alias: {
+      n: "notebook",
+      t: "auth-token",
+      s: "sync-url",
+      r: "runtime-id",
+      T: "runtime-type",
+      h: "help",
+      m: "mount",
+    },
+    collect: ["mount"], // Allow multiple --mount arguments
+  });
+
+  if (parsed.help) {
+    console.log(`
+Pyodide Runtime Agent Configuration
+
+Usage:
+  deno run --allow-net --allow-env main.ts [OPTIONS]
+
+Required Options:
+  --notebook, -n <id>        Notebook ID to connect to
+  --auth-token, -t <token>   Authentication token for sync
+
+Optional Options:
+  --sync-url, -s <url>       WebSocket URL for LiveStore sync
+                             (default: ${DEFAULT_CONFIG.syncUrl})
+  --runtime-id, -R <id>      Runtime identifier
+                             (default: <runtime-type>-runtime-{pid})
+  --runtime-type, -T <type>  Runtime type identifier
+                             (default: "python3-pyodide")
+  --mount, -m <path>         Host directory to mount. Supports two formats:
+                             1. Simple: /path/to/local (mounts to auto-generated /mnt/ path)
+                             2. Docker-style: /path/to/local:/target/path
+                             Examples: --mount /data or --mount /data:/dataset
+                             (can be specified multiple times)
+  --output-dir <path>        Host directory to sync /outputs to after each cell execution
+  --mount-readonly           Mount directories as read-only (prevents modification)
+                             (only applies when --mount is also used)
+  --index-mounted-files      Enable vector store indexing of mounted files for AI search
+                             (only applies when --mount is also used)
+  --ai-max-iterations <num>  Maximum iterations for AI agent tool calling loops
+                             (default: 10)
+  --runtime-python-path <path>     Path to Python executable (default: "python3")
+  --runtime-env-path <path>        Path to virtual environment
+  --runtime-package-manager <mgr>  Package manager to use (default: "pip")
+  --runtime-env-externally-managed Treat environment as externally managed
+  --help, -h                 Show this help message
+
+Examples:
+  deno run --allow-net --allow-env main.ts -n my-notebook -t your-token
+  deno run --allow-net --allow-env main.ts --notebook=test --auth-token=abc123
+  deno run --allow-net --allow-env main.ts -n my-notebook -t token --mount /path/to/data
+  deno run --allow-net --allow-env main.ts -n my-notebook -t token --mount /host/data:/data/dataset --index-mounted-files
+
+Environment Variables (fallback):
+  NOTEBOOK_ID, RUNT_API_KEY, LIVESTORE_SYNC_URL, RUNTIME_ID, RUNTIME_TYPE
+  IMAGE_ARTIFACT_THRESHOLD_BYTES
+  AUTH_TOKEN (legacy fallback for service-level authentication)
+
+Python Environment Configuration:
+  RUNTIME_PYTHON_PATH            Path to Python executable (default: "python3")
+  RUNTIME_ENV_PATH               Path to virtual environment
+  RUNTIME_PACKAGE_MANAGER        Package manager (default: "pip")
+  RUNTIME_ENV_EXTERNALLY_MANAGED Set to "true" for externally managed envs
+
+OpenAI Embedding Configuration (for --index-mounted-files):
+  OPENAI_EMBEDDING_API_KEY       OpenAI API key for optimal vector store embeddings
+  OPENAI_EMBEDDING_MODEL         OpenAI embedding model (default: text-embedding-3-large)
+
+AI Configuration:
+  AI_MAX_ITERATIONS              Maximum AI tool calling iterations (default: 10)
+
+Logging Configuration:
+  RUNT_LOG_LEVEL                 Set to DEBUG, INFO, WARN, or ERROR (default: INFO)
+  RUNT_DISABLE_CONSOLE_LOGS      Set to disable console output
+    `);
+    Deno.exit(0);
+  }
+
+  // Start with base parsing
+  let result = parseBaseRuntimeArgs(args) as Partial<
+    PyodideRuntimeAgentOptions
+  >;
+
+  // Handle mount paths - support both simple paths and Docker-style local:target format
+  if (parsed.mount && parsed.mount.length > 0) {
+    const mountArgs = Array.isArray(parsed.mount)
+      ? parsed.mount
+      : [parsed.mount];
+    const mountPaths: string[] = [];
+    const mountMappings: Array<{ hostPath: string; targetPath: string }> = [];
+
+    for (const mountArg of mountArgs) {
+      if (mountArg.includes(":")) {
+        // Docker-style mount: local-path:target-path
+        const [hostPath, targetPath] = mountArg.split(":", 2);
+        if (hostPath && targetPath) {
+          mountMappings.push({ hostPath, targetPath });
+          // Also add to mountPaths for backward compatibility
+          mountPaths.push(hostPath);
+        } else {
+          throw new Error(
+            `Invalid mount format: ${mountArg}. Expected format: <local-path>:<target-path>`,
+          );
+        }
+      } else {
+        // Simple path format (legacy)
+        mountPaths.push(mountArg);
+      }
+    }
+
+    result = {
+      ...result,
+      mountPaths,
+      mountMappings,
+    };
+  }
+
+  // Handle index-mounted-files flag
+  if (parsed["index-mounted-files"]) {
+    result = {
+      ...result,
+      indexMountedFiles: true,
+    };
+  }
+
+  // Handle mount-readonly flag
+  if (parsed["mount-readonly"]) {
+    result = {
+      ...result,
+      mountReadonly: true,
+    };
+  }
+
+  // Handle output-dir option
+  const outputDir = parsed["output-dir"] || Deno.env.get("OUTPUT_DIR");
+  if (outputDir && typeof outputDir === "string") {
+    result = {
+      ...result,
+      outputDir,
+    };
+  }
+
+  // Handle Python environment options
+  const environmentOptions: Record<string, unknown> = {};
+  environmentOptions.runtimePythonPath = parsed["runtime-python-path"] ||
+    Deno.env.get("RUNTIME_PYTHON_PATH") ||
+    "python3";
+  if (parsed["runtime-env-path"] || Deno.env.get("RUNTIME_ENV_PATH")) {
+    environmentOptions.runtimeEnvPath = parsed["runtime-env-path"] ||
+      Deno.env.get("RUNTIME_ENV_PATH");
+  }
+  environmentOptions.runtimePackageManager =
+    parsed["runtime-package-manager"] ||
+    Deno.env.get("RUNTIME_PACKAGE_MANAGER") ||
+    "pip";
+  const cliExternallyManaged = Boolean(
+    parsed["runtime-env-externally-managed"],
+  );
+  const envExternallyManaged =
+    Deno.env.get("RUNTIME_ENV_EXTERNALLY_MANAGED") === "1" ||
+    Deno.env.get("RUNTIME_ENV_EXTERNALLY_MANAGED") === "true";
+  environmentOptions.runtimeEnvExternallyManaged = cliExternallyManaged ||
+    envExternallyManaged;
+  result = {
+    ...result,
+    environmentOptions,
+  };
+
+  // Parse AI max iterations
+  const aiMaxIterationsArg = parsed["ai-max-iterations"] ||
+    Deno.env.get("AI_MAX_ITERATIONS");
+  if (aiMaxIterationsArg) {
+    const aiMaxIterations = parseInt(aiMaxIterationsArg, 10);
+    if (!isNaN(aiMaxIterations) && aiMaxIterations > 0) {
+      result = {
+        ...result,
+        aiMaxIterations,
+      };
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Create a complete pyodide runtime configuration from CLI args and defaults
+ */
+export function createPyodideRuntimeConfig(
+  args: string[],
+  defaults: Partial<PyodideRuntimeAgentOptions> = {},
+): PyodideRuntimeConfig {
+  const cliConfig = parsePyodideRuntimeArgs(args);
+
+  // Merge CLI config with defaults - CLI args override defaults
+  const mergedDefaults: Partial<PyodideRuntimeAgentOptions> = {
+    runtimeType: "python3-pyodide",
+    syncUrl: DEFAULT_CONFIG.syncUrl,
+    capabilities: {
+      canExecuteCode: true,
+      canExecuteSql: false,
+      canExecuteAi: true,
+      availableAiModels: [], // Will be populated during startup
+    },
+    environmentOptions: {
+      runtimePythonPath: "python3",
+      runtimePackageManager: "pip",
+      runtimeEnvExternallyManaged: false,
+      ...(defaults.environmentOptions ?? {}),
+    },
+    ...defaults,
+  };
+
+  // Only include non-undefined values from CLI config
+  const cleanCliConfig: Partial<PyodideRuntimeAgentOptions> = Object
+    .fromEntries(
+      Object.entries(cliConfig).filter(([_, value]) => value !== undefined),
+    );
+
+  // Compose the config object
+  const runtimeId = cleanCliConfig.runtimeId ||
+    Deno.env.get("RUNTIME_ID") ||
+    `${
+      cleanCliConfig.runtimeType || mergedDefaults.runtimeType
+    }-runtime-${Deno.pid}`;
+
+  const config: PyodideRuntimeAgentOptions = {
+    ...mergedDefaults,
+    ...cleanCliConfig,
+    runtimeId,
+    environmentOptions: {
+      ...mergedDefaults.environmentOptions,
+      ...(cleanCliConfig.environmentOptions ?? {}),
+    },
+  } as PyodideRuntimeAgentOptions;
+
+  const runtimeConfig = new PyodideRuntimeConfig(config);
+  runtimeConfig.validate();
+
+  const logger = createLogger("pyodide-config");
+  logger.debug("Pyodide runtime configuration created", {
+    runtimeType: runtimeConfig.runtimeType,
+    runtimeId: runtimeConfig.runtimeId,
+    syncUrl: runtimeConfig.syncUrl,
+    notebookId: runtimeConfig.notebookId,
+    sessionId: runtimeConfig.sessionId,
+    environmentOptions: config.environmentOptions,
+    mountPaths: runtimeConfig.mountPaths,
+    mountMappings: runtimeConfig.mountMappings,
+    indexMountedFiles: runtimeConfig.indexMountedFiles,
+    aiMaxIterations: runtimeConfig.aiMaxIterations,
+  });
+
+  return runtimeConfig;
+}

--- a/packages/pyodide-runtime-agent/src/pyodide-config.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-config.ts
@@ -5,12 +5,7 @@
 // and vector store indexing.
 
 import { parseArgs } from "@std/cli/parse-args";
-import {
-  createBaseRuntimeConfig,
-  DEFAULT_CONFIG,
-  parseBaseRuntimeArgs,
-  RuntimeConfig,
-} from "@runt/lib";
+import { DEFAULT_CONFIG, parseBaseRuntimeArgs, RuntimeConfig } from "@runt/lib";
 import type { RuntimeAgentOptions } from "@runt/lib";
 import { createLogger } from "@runt/lib";
 

--- a/packages/pyodide-runtime-agent/test/simple-readonly.test.ts
+++ b/packages/pyodide-runtime-agent/test/simple-readonly.test.ts
@@ -23,8 +23,8 @@ Deno.test("Read-only mount configuration", () => {
 });
 
 Deno.test("CLI flag parsing includes mount-readonly", async () => {
-  // Import the config parser
-  const { parseRuntimeArgs } = await import("../../lib/src/config.ts");
+  // Import the pyodide config parser
+  const { parsePyodideRuntimeArgs } = await import("../src/pyodide-config.ts");
 
   const args = [
     "--notebook=test",
@@ -33,7 +33,7 @@ Deno.test("CLI flag parsing includes mount-readonly", async () => {
     "--mount-readonly",
   ];
 
-  const result = parseRuntimeArgs(args);
+  const result = parsePyodideRuntimeArgs(args);
 
   assertEquals(result.mountReadonly, true);
   assertEquals(result.mountPaths?.[0], "/test/path");

--- a/packages/python-runtime-agent/src/python-runtime-agent.ts
+++ b/packages/python-runtime-agent/src/python-runtime-agent.ts
@@ -1,5 +1,5 @@
 import {
-  createRuntimeConfig,
+  createBaseRuntimeConfig,
   RuntimeAgent,
   type RuntimeConfig,
 } from "@runt/lib";
@@ -8,7 +8,7 @@ export class PythonRuntimeAgent extends RuntimeAgent {
   constructor(args: string[] = Deno.args) {
     let config: RuntimeConfig;
     try {
-      config = createRuntimeConfig(args, {
+      config = createBaseRuntimeConfig(args, {
         runtimeType: "python3",
         capabilities: {
           canExecuteCode: true,


### PR DESCRIPTION
- Move mount paths, AI options, Python env config from @runt/lib to @runt/pyodide-runtime-agent
- Create minimal, generic RuntimeAgentOptions interface in @runt/lib
- Add PyodideRuntimeAgentOptions extending base with pyodide-specific options
- Create pyodide-config.ts with parsePyodideRuntimeArgs() and createPyodideRuntimeConfig()
- Rename parseRuntimeArgs() -> parseBaseRuntimeArgs() and createRuntimeConfig() -> createBaseRuntimeConfig()
- Update PyodideRuntimeAgent to use PyodideRuntimeConfig
- Make RuntimeAgent image processing methods protected for extensibility
- Fix all tests and imports throughout codebase