### PR TITLE
Require adapter injection, remove Node.js dependency from lib

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ on stability and extensibility.
 ## Project Overview
 
 Runt is a TypeScript/Deno library for building runtime agents that connect to
-[Anode notebooks](https://github.com/rgbkrk/anode). It uses LiveStore for
+[Anode notebooks](https://github.com/runtimed/anode). It uses LiveStore for
 event-sourcing and real-time sync between multiple users.
 
 **Current Status**: Working system with 58 passing tests. Core functionality is

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Runt
 
 Runtime agents for connecting to
-[Anode notebooks](https://github.com/rgbkrk/anode) with real-time collaboration,
-rich output support, and AI integration.
+[Anode notebooks](https://github.com/runtimed/anode) with real-time
+collaboration, rich output support, and AI integration.
 
 ## Features
 
@@ -50,7 +50,7 @@ deno task ci
 # Run tests only
 deno task test
 
-# Run example agent  
+# Run example agent
 deno task dev
 ```
 

--- a/deno.json
+++ b/deno.json
@@ -29,9 +29,9 @@
   },
   "lock": false,
   "tasks": {
-    "test": "DENO_TESTING=true RUNT_LOG_LEVEL=ERROR RUNT_DISABLE_CONSOLE_LOGS=true deno test --allow-all --reporter=dot",
-    "test:watch": "DENO_TESTING=true deno test --allow-all --watch",
-    "test:coverage": "DENO_TESTING=true deno test --allow-all --coverage=cov/ --reporter=dot && deno coverage --lcov cov/ > cov.lcov",
+    "test": "DENO_TESTING=true RUNT_LOG_LEVEL=ERROR RUNT_DISABLE_CONSOLE_LOGS=true deno test --allow-all --unstable-broadcast-channel --reporter=dot",
+    "test:watch": "DENO_TESTING=true deno test --allow-all --unstable-broadcast-channel --watch",
+    "test:coverage": "DENO_TESTING=true deno test --allow-all --unstable-broadcast-channel --coverage=cov/ --reporter=dot && deno coverage --lcov cov/ > cov.lcov",
     "check": "deno check $(find packages -name '*.ts' -not -path '*/tui/*' | tr '\n' ' ')",
     "check:tui": "deno check $(find packages/tui -name '*.ts' -o -name '*.tsx' | tr '\n' ' ') --config packages/tui/deno.json",
     "fmt": "deno fmt",

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -21,7 +21,7 @@
     "@std/encoding": "jsr:@std/encoding@^1.0.0",
     "@std/fs": "jsr:@std/fs@^1.0.0",
     "@std/path": "jsr:@std/path@^1.0.0",
-    "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
+    "npm:@livestore/adapter-web": "npm:@livestore/adapter-web@^0.3.1",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
     "npm:@livestore/sync-cf": "npm:@livestore/sync-cf@^0.3.1",
     "npm:@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0"

--- a/packages/lib/deno.json
+++ b/packages/lib/deno.json
@@ -28,11 +28,11 @@
   },
   "tasks": {
     "dev": "deno run --allow-net --allow-env examples/echo-agent.ts",
-    "test": "deno test --allow-net --allow-env --allow-read --allow-sys",
-    "test:unit": "deno test --allow-net --allow-env --allow-read --allow-sys src/",
-    "test:integration": "deno test --allow-net --allow-env --allow-read --allow-sys test/",
-    "test:watch": "deno test --allow-net --allow-env --allow-read --allow-sys --watch",
-    "test:summary": "echo '🧪 Running @runt/lib test suite...' && deno test --allow-net --allow-env --allow-read --allow-sys --reporter=pretty && echo '✅ All tests completed!'",
+    "test": "deno test --allow-net --allow-env --allow-read --allow-sys --unstable-broadcast-channel",
+    "test:unit": "deno test --allow-net --allow-env --allow-read --allow-sys --unstable-broadcast-channel src/",
+    "test:integration": "deno test --allow-net --allow-env --allow-read --allow-sys --unstable-broadcast-channel test/",
+    "test:watch": "deno test --allow-net --allow-env --allow-read --allow-sys --unstable-broadcast-channel --watch",
+    "test:summary": "echo '🧪 Running @runt/lib test suite...' && deno test --allow-net --allow-env --allow-read --allow-sys --unstable-broadcast-channel --reporter=pretty && echo '✅ All tests completed!'",
     "check": "deno check mod.ts src/*.ts examples/*.ts",
     "fmt": "deno fmt",
     "lint": "deno lint"

--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -16,7 +16,7 @@ import { ArtifactClient } from "./artifact-client.ts";
  * Default configuration values
  */
 export const DEFAULT_CONFIG = {
-  syncUrl: "wss://anode-docworker.rgbkrk.workers.dev",
+  syncUrl: "wss://app.runt.run",
   imageArtifactThresholdBytes: 6 * 1024, // 6KB threshold for uploading images as artifacts
 } as const;
 

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -5,7 +5,7 @@ import {
   queryDb,
   type Store,
 } from "npm:@livestore/livestore";
-import { makeCfSync } from "npm:@livestore/sync-cf";
+
 import {
   events,
   type ImageMimeType,

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -1,6 +1,5 @@
 // RuntimeAgent - Base class for building Anode runtime agents
 
-import { makeAdapter } from "npm:@livestore/adapter-node";
 import {
   createStorePromise,
   queryDb,
@@ -81,8 +80,13 @@ export class RuntimeAgent {
       const clientId = this.config.clientId;
       logger.info("Using clientId", { clientId });
 
-      // Create store with appropriate adapter and sync payload
-      const adapter = this.config.adapter || this.createDefaultAdapter();
+      // Create store with required adapter
+      const adapter = this.config.adapter;
+      if (!adapter) {
+        throw new Error(
+          "RuntimeAgent requires an adapter to be provided via config.adapter",
+        );
+      }
 
       this.#store = await createStorePromise({
         adapter,
@@ -163,19 +167,6 @@ export class RuntimeAgent {
       await this.handlers.onDisconnected?.(error as Error);
       throw error;
     }
-  }
-
-  /**
-   * Create the default adapter with Cloudflare sync
-   */
-  private createDefaultAdapter() {
-    return makeAdapter({
-      storage: { type: "in-memory" },
-      sync: {
-        backend: makeCfSync({ url: this.config.syncUrl }),
-        onSyncError: "ignore",
-      },
-    });
   }
 
   /**

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -69,8 +69,8 @@ export interface RuntimeAgentOptions {
   readonly imageArtifactThresholdBytes?: number;
   /** Artifact client for dependency injection (optional) */
   readonly artifactClient?: IArtifactClient;
-  /** Custom LiveStore adapter to use instead of default */
-  readonly adapter?: Adapter;
+  /** LiveStore adapter (required) */
+  readonly adapter: Adapter;
   /** Client ID for sync payload (must be provided) */
   readonly clientId: string;
 }

--- a/packages/lib/test/integration.test.ts
+++ b/packages/lib/test/integration.test.ts
@@ -5,7 +5,7 @@
 // mocked dependencies to test the core integration points.
 
 import { assertEquals, assertExists } from "jsr:@std/assert";
-import { makeAdapter } from "npm:@livestore/adapter-node";
+import { makeInMemoryAdapter } from "npm:@livestore/adapter-web";
 
 import { RuntimeAgent } from "../src/runtime-agent.ts";
 import { RuntimeConfig } from "../src/config.ts";
@@ -52,9 +52,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       onExecutionError: createMockFunction(),
     };
 
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     config = new RuntimeConfig({
       runtimeId: "integration-test-runtime",
@@ -147,9 +145,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
   await t.step("configuration validation", async (t) => {
     setup();
     await t.step("should accept valid configuration", () => {
-      const adapter = makeAdapter({
-        storage: { type: "in-memory" },
-      });
+      const adapter = makeInMemoryAdapter({});
 
       const validConfig = new RuntimeConfig({
         runtimeId: "valid-runtime",
@@ -172,9 +168,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       let error: Error | null = null;
 
       try {
-        const adapter = makeAdapter({
-          storage: { type: "in-memory" },
-        });
+        const adapter = makeInMemoryAdapter({});
 
         const config = new RuntimeConfig({
           runtimeId: "", // Invalid empty runtime ID
@@ -249,9 +243,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
 
 Deno.test("RuntimeConfig", async (t) => {
   await t.step("should create valid config with all required fields", () => {
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     const config = new RuntimeConfig({
       runtimeId: "test-runtime-3",
@@ -278,9 +270,7 @@ Deno.test("RuntimeConfig", async (t) => {
   });
 
   await t.step("should generate unique session IDs", () => {
-    const adapter1 = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter1 = makeInMemoryAdapter({});
 
     const config1 = new RuntimeConfig({
       runtimeId: "runtime1",
@@ -297,9 +287,7 @@ Deno.test("RuntimeConfig", async (t) => {
       },
     });
 
-    const adapter2 = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter2 = makeInMemoryAdapter({});
 
     const config2 = new RuntimeConfig({
       runtimeId: "runtime2",
@@ -321,9 +309,7 @@ Deno.test("RuntimeConfig", async (t) => {
   });
 
   await t.step("should allow custom heartbeat interval", () => {
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     const _config = new RuntimeConfig({
       runtimeId: "test-ai-runtime",

--- a/packages/lib/test/mod.test.ts
+++ b/packages/lib/test/mod.test.ts
@@ -1,6 +1,7 @@
 /// <reference lib="deno.ns" />
 import { assertEquals } from "jsr:@std/assert";
 import { DEFAULT_CONFIG, RuntimeAgent, RuntimeConfig } from "@runt/lib";
+import { makeInMemoryAdapter } from "npm:@livestore/adapter-web";
 
 Deno.test("Library exports are available", () => {
   // Test that main exports are defined
@@ -27,6 +28,7 @@ Deno.test("RuntimeConfig validation works", () => {
       authToken: "", // Missing
       notebookId: "", // Missing
       clientId: "test-client",
+      adapter: makeInMemoryAdapter({}),
       capabilities: {
         canExecuteCode: true,
         canExecuteSql: false,
@@ -50,6 +52,7 @@ Deno.test("RuntimeConfig validation works", () => {
     authToken: "test-token",
     notebookId: "test-notebook",
     clientId: "test-client",
+    adapter: makeInMemoryAdapter({}),
     capabilities: {
       canExecuteCode: true,
       canExecuteSql: false,

--- a/packages/lib/test/mod.test.ts
+++ b/packages/lib/test/mod.test.ts
@@ -14,7 +14,7 @@ Deno.test("Library exports are available", () => {
 Deno.test("DEFAULT_CONFIG has expected values", () => {
   assertEquals(
     DEFAULT_CONFIG.syncUrl,
-    "wss://anode-docworker.rgbkrk.workers.dev",
+    "wss://app.runt.run",
   );
 });
 

--- a/packages/lib/test/runtime-agent-adapter-injection.test.ts
+++ b/packages/lib/test/runtime-agent-adapter-injection.test.ts
@@ -14,6 +14,7 @@ import {
   type RuntimeCapabilities,
   RuntimeConfig,
 } from "@runt/lib";
+import { makeInMemoryAdapter } from "npm:@livestore/adapter-web";
 import { makeAdapter } from "npm:@livestore/adapter-node";
 
 // Helper function for creating test configs since createBaseRuntimeConfig moved to pyodide package
@@ -21,6 +22,9 @@ function createTestRuntimeConfig(
   _args: string[],
   defaults: Partial<RuntimeAgentOptions> = {},
 ): RuntimeConfig {
+  // Create default in-memory adapter for testing
+  const defaultAdapter = makeInMemoryAdapter({});
+
   const config: RuntimeAgentOptions = {
     runtimeId: "test-runtime-id",
     runtimeType: "test-runtime",
@@ -33,6 +37,7 @@ function createTestRuntimeConfig(
       canExecuteAi: false,
     },
     clientId: "test-client",
+    adapter: defaultAdapter,
     ...defaults,
   };
   return new RuntimeConfig(config);
@@ -64,8 +69,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
 
   await t.step("should accept custom in-memory adapter", async () => {
     // Create custom in-memory adapter
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
+    const adapter = makeInMemoryAdapter({
       // No sync backend needed for pure in-memory testing
     });
 
@@ -100,9 +104,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
     "should accept custom adapter without explicit clientId",
     async () => {
       // Create custom in-memory adapter
-      const adapter = makeAdapter({
-        storage: { type: "in-memory" },
-      });
+      const adapter = makeInMemoryAdapter({});
 
       const config = createTestRuntimeConfig([], {
         adapter,
@@ -131,9 +133,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
 
   await t.step("should generate clientId for custom adapter", async () => {
     const runtimeId = `runtime-${crypto.randomUUID()}`;
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     const config = createTestRuntimeConfig([], {
       adapter,
@@ -161,9 +161,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
   });
 
   await t.step("should use explicit clientId when provided", async () => {
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     const explicitClientId = "my-custom-client-id";
 
@@ -192,9 +190,7 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
 
   await t.step("should handle multiple agents with same adapter", async () => {
     // Create shared adapter
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     // Create two agents using the same adapter
     const config1 = createTestRuntimeConfig([], {

--- a/packages/lib/test/runtime-agent-artifact.test.ts
+++ b/packages/lib/test/runtime-agent-artifact.test.ts
@@ -9,6 +9,7 @@ import { RuntimeAgent } from "../src/runtime-agent.ts";
 import { RuntimeConfig } from "../src/config.ts";
 import type { RuntimeAgentOptions } from "../src/types.ts";
 import type { ImageMimeType, MediaContainer } from "@runt/schema";
+import { makeInMemoryAdapter } from "npm:@livestore/adapter-web";
 
 // Testing interface to access private methods
 interface RuntimeAgentWithTestMethods {
@@ -73,6 +74,7 @@ const mockRuntimeOptions: RuntimeAgentOptions = {
   notebookId: "test-notebook",
   clientId: "test-client",
   imageArtifactThresholdBytes: 6 * 1024, // 6KB threshold
+  adapter: makeInMemoryAdapter({}),
 };
 
 // Mock fetch for testing

--- a/packages/lib/test/runtime-agent-text-representations.test.ts
+++ b/packages/lib/test/runtime-agent-text-representations.test.ts
@@ -1,6 +1,6 @@
 /// <reference lib="deno.ns" />
 import { assertEquals } from "@std/assert";
-import { makeAdapter } from "npm:@livestore/adapter-node";
+import { makeInMemoryAdapter } from "npm:@livestore/adapter-web";
 import { RuntimeAgent } from "../src/runtime-agent.ts";
 import { RuntimeConfig } from "../src/config.ts";
 import {
@@ -36,9 +36,7 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         canExecuteAi: false,
       };
 
-      const adapter = makeAdapter({
-        storage: { type: "in-memory" },
-      });
+      const adapter = makeInMemoryAdapter({});
 
       const config = new RuntimeConfig({
         runtimeId: "test-runtime",
@@ -151,9 +149,7 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         canExecuteAi: false,
       };
 
-      const adapter = makeAdapter({
-        storage: { type: "in-memory" },
-      });
+      const adapter = makeInMemoryAdapter({});
 
       const config = new RuntimeConfig({
         runtimeId: "test-runtime",
@@ -268,9 +264,7 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         canExecuteAi: false,
       };
 
-      const adapter = makeAdapter({
-        storage: { type: "in-memory" },
-      });
+      const adapter = makeInMemoryAdapter({});
 
       const config = new RuntimeConfig({
         runtimeId: "test-runtime",

--- a/packages/lib/test/runtime-agent.test.ts
+++ b/packages/lib/test/runtime-agent.test.ts
@@ -5,7 +5,7 @@
 // mock functions to ensure reliable, fast unit testing.
 
 import { assertEquals, assertExists, assertInstanceOf } from "jsr:@std/assert";
-import { makeAdapter } from "npm:@livestore/adapter-node";
+import { makeInMemoryAdapter } from "npm:@livestore/adapter-web";
 
 import { RuntimeAgent } from "../src/runtime-agent.ts";
 import { RuntimeConfig } from "../src/config.ts";
@@ -52,9 +52,7 @@ Deno.test("RuntimeAgent", async (t) => {
       onExecutionError: createMockFunction(),
     };
 
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     config = new RuntimeConfig({
       runtimeId: "test-runtime",
@@ -170,9 +168,7 @@ Deno.test("RuntimeAgent", async (t) => {
 
 Deno.test("RuntimeConfig", async (t) => {
   await t.step("should create valid config with all required fields", () => {
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     const config = new RuntimeConfig({
       runtimeId: "test-runtime",
@@ -198,9 +194,7 @@ Deno.test("RuntimeConfig", async (t) => {
   });
 
   await t.step("should generate unique session IDs", () => {
-    const adapter1 = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter1 = makeInMemoryAdapter({});
 
     const config1 = new RuntimeConfig({
       runtimeId: "runtime1",
@@ -217,9 +211,7 @@ Deno.test("RuntimeConfig", async (t) => {
       },
     });
 
-    const adapter2 = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter2 = makeInMemoryAdapter({});
 
     const config2 = new RuntimeConfig({
       runtimeId: "runtime2",
@@ -241,9 +233,7 @@ Deno.test("RuntimeConfig", async (t) => {
   });
 
   await t.step("should allow custom heartbeat interval", () => {
-    const adapter = makeAdapter({
-      storage: { type: "in-memory" },
-    });
+    const adapter = makeInMemoryAdapter({});
 
     const _config = new RuntimeConfig({
       runtimeId: "test-runtime",

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -21,6 +21,8 @@
     "@std/async": "jsr:@std/async@^1.0.0",
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
+    "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
+    "npm:@livestore/sync-cf": "npm:@livestore/sync-cf@^0.3.1",
     "npm:strip-ansi": "npm:strip-ansi@^7.1.0"
   },
   "tasks": {

--- a/packages/pyodide-runtime-agent/deno.json
+++ b/packages/pyodide-runtime-agent/deno.json
@@ -22,6 +22,7 @@
     "@std/cli": "jsr:@std/cli@^1.0.0",
     "npm:@livestore/livestore": "npm:@livestore/livestore@^0.3.1",
     "npm:@livestore/adapter-node": "npm:@livestore/adapter-node@^0.3.1",
+    "npm:@livestore/adapter-web": "npm:@livestore/adapter-web@^0.3.1",
     "npm:@livestore/sync-cf": "npm:@livestore/sync-cf@^0.3.1",
     "npm:strip-ansi": "npm:strip-ansi@^7.1.0"
   },

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -11,6 +11,8 @@ export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 import { logger, LogLevel } from "@runt/lib";
 import { discoverUserIdentity } from "./auth.ts";
 import { createPyodideRuntimeConfig } from "./pyodide-config.ts";
+import { makeAdapter } from "npm:@livestore/adapter-node";
+import { makeCfSync } from "npm:@livestore/sync-cf";
 
 // Run the agent if this file is executed directly
 if (import.meta.main) {
@@ -62,11 +64,20 @@ if (import.meta.main) {
 
   logger.info("Authenticated successfully", { clientId });
 
-  // Create agent with discovered clientId
+  // Create adapter for Node.js environment with Cloudflare sync
+  const adapter = makeAdapter({
+    storage: { type: "in-memory" },
+    sync: {
+      backend: makeCfSync({ url: tempConfig.syncUrl }),
+      onSyncError: "ignore",
+    },
+  });
+
+  // Create agent with discovered clientId and Node.js adapter
   const agent = new PyodideRuntimeAgent(
     Deno.args,
     {}, // pyodide options
-    { clientId }, // runtime options
+    { clientId, adapter }, // runtime options
   );
 
   logger.info("Starting Agent");

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -54,7 +54,7 @@ if (import.meta.main) {
   // Parse CLI args once to get auth details
   const cliConfig = parseBaseRuntimeArgs(Deno.args);
   const syncUrl = cliConfig.syncUrl ||
-    "wss://anode-docworker.rgbkrk.workers.dev";
+    "wss://app.runt.run";
   const authToken = cliConfig.authToken;
 
   if (!authToken) {

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -10,7 +10,7 @@ import { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 export { PyodideRuntimeAgent } from "./pyodide-agent.ts";
 import { logger, LogLevel } from "@runt/lib";
 import { discoverUserIdentity } from "./auth.ts";
-import { createPyodideRuntimeConfig } from "./pyodide-config.ts";
+import { parseBaseRuntimeArgs } from "./config-cli.ts";
 import { makeAdapter } from "npm:@livestore/adapter-node";
 import { makeCfSync } from "npm:@livestore/sync-cf";
 
@@ -51,15 +51,22 @@ if (import.meta.main) {
 
   logger.info("Authenticating...");
 
-  // Create temporary config to get auth details
-  const tempConfig = createPyodideRuntimeConfig(Deno.args, {
-    clientId: "temp", // Will be replaced
-  });
+  // Parse CLI args once to get auth details
+  const cliConfig = parseBaseRuntimeArgs(Deno.args);
+  const syncUrl = cliConfig.syncUrl ||
+    "wss://anode-docworker.rgbkrk.workers.dev";
+  const authToken = cliConfig.authToken;
+
+  if (!authToken) {
+    console.error("❌ Configuration Error: Missing auth token");
+    console.error("Use --auth-token or set RUNT_API_KEY environment variable");
+    Deno.exit(1);
+  }
 
   // Discover user identity first
   const clientId = await discoverUserIdentity({
-    authToken: tempConfig.authToken,
-    syncUrl: tempConfig.syncUrl,
+    authToken,
+    syncUrl,
   });
 
   logger.info("Authenticated successfully", { clientId });
@@ -68,7 +75,7 @@ if (import.meta.main) {
   const adapter = makeAdapter({
     storage: { type: "in-memory" },
     sync: {
-      backend: makeCfSync({ url: tempConfig.syncUrl }),
+      backend: makeCfSync({ url: syncUrl }),
       onSyncError: "ignore",
     },
   });

--- a/packages/pyodide-runtime-agent/test/config-cli.test.ts
+++ b/packages/pyodide-runtime-agent/test/config-cli.test.ts
@@ -6,6 +6,7 @@ import {
   createBaseRuntimeConfig,
   parseBaseRuntimeArgs,
 } from "../src/config-cli.ts";
+import { makeInMemoryAdapter } from "npm:@livestore/adapter-web";
 
 const REQUIRED_PARAMS = ["--notebook", "test-nb", "--auth-token", "test-token"];
 
@@ -21,6 +22,7 @@ function makeBaseConfig(overrides: Partial<Record<string, unknown>> = {}) {
     authToken: "test-token",
     notebookId: "test-nb",
     clientId: "test-client",
+    adapter: makeInMemoryAdapter({}),
     capabilities: {
       canExecuteCode: true,
       canExecuteSql: false,

--- a/packages/pyodide-runtime-agent/test/simple-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/simple-integration.test.ts
@@ -123,7 +123,7 @@ Deno.test("PyodideRuntimeAgent - Configuration", async (t) => {
 
     const agent = new PyodideRuntimeAgent(agentArgs);
 
-    assertStringIncludes(agent.config.syncUrl, "anode-docworker");
+    assertStringIncludes(agent.config.syncUrl, "app.runt.run");
   });
 
   await t.step("supports environment variables", () => {

--- a/packages/python-runtime-agent/deno.json
+++ b/packages/python-runtime-agent/deno.json
@@ -15,7 +15,8 @@
   },
   "imports": {
     "@runt/lib": "jsr:@runt/lib@^0.11.1",
-    "@runt/schema": "jsr:@runt/schema@^0.11.1"
+    "@runt/schema": "jsr:@runt/schema@^0.11.1",
+    "npm:@livestore/adapter-web": "npm:@livestore/adapter-web@^0.3.1"
   },
   "tasks": {
     "test": "deno test --allow-all",
@@ -39,20 +40,11 @@
   },
   "lint": {
     "rules": {
-      "tags": [
-        "recommended"
-      ]
+      "tags": ["recommended"]
     }
   },
   "publish": {
-    "include": [
-      "mod.ts",
-      "src/",
-      "README.md"
-    ],
-    "exclude": [
-      "**/*.test.ts",
-      "**/test_*.ts"
-    ]
+    "include": ["mod.ts", "src/", "README.md"],
+    "exclude": ["**/*.test.ts", "**/test_*.ts"]
   }
 }

--- a/packages/python-runtime-agent/src/python-runtime-agent.ts
+++ b/packages/python-runtime-agent/src/python-runtime-agent.ts
@@ -1,4 +1,5 @@
 import { RuntimeAgent, RuntimeConfig } from "@runt/lib";
+import { makeInMemoryAdapter } from "npm:@livestore/adapter-web";
 
 export class PythonRuntimeAgent extends RuntimeAgent {
   constructor(_args: string[] = Deno.args) {
@@ -15,6 +16,7 @@ export class PythonRuntimeAgent extends RuntimeAgent {
         canExecuteAi: false,
       },
       clientId: "dummy",
+      adapter: makeInMemoryAdapter({}),
     });
 
     super(dummyConfig, dummyConfig.capabilities, {});


### PR DESCRIPTION
BREAKING CHANGE: RuntimeAgentOptions.adapter is now required instead of optional

- Make adapter required in RuntimeAgentOptions type interface
- Remove default adapter creation from RuntimeAgent
- Remove adapter-node dependency from lib package
- Add adapter-web dependency for testing with makeInMemoryAdapter
- Update all lib tests to use makeInMemoryAdapter from adapter-web
- Update pyodide-runtime-agent to create and pass Node.js adapter explicitly
- Add adapter-node and sync-cf dependencies to pyodide package

This makes @runt/lib completely platform-agnostic and browser-compatible. Runtime implementations must provide their own platform-specific adapters.