### PR TITLE
discover ai models before connecting

### DIFF
--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -198,9 +198,6 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
    * Start the Pyodide runtime agent
    */
   override async start(): Promise<void> {
-    // Call parent start first to initialize logger and LiveStore
-    await super.start();
-
     logger.info("Starting Pyodide Python runtime agent");
 
     // Discover available AI models if enabled
@@ -227,6 +224,8 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
         });
       }
     }
+    // Call parent to initialize LiveStore
+    await super.start();
 
     // Initialize Pyodide worker after logger is available
     await this.initializePyodideWorker();


### PR DESCRIPTION
## Problem

AI Models weren't showing in the cell drop down

## Solution

Make sure AI models get discovered before connecting. 

An alternate future solution is to connect first and then update the capabilities, but that would require a new event (I think?).


cc @AlbertDeFusco 