### PR TITLE
Stop making clientIds and let LiveStore handle them

### DIFF
--- a/packages/lib/src/config.ts
+++ b/packages/lib/src/config.ts
@@ -35,7 +35,6 @@ export class RuntimeConfig {
   public readonly imageArtifactThresholdBytes: number;
   public readonly artifactClient: IArtifactClient;
   public readonly adapter: Adapter | undefined;
-  public readonly clientId: string;
   public readonly userId: string;
 
   constructor(options: RuntimeAgentOptions) {
@@ -48,7 +47,6 @@ export class RuntimeConfig {
     this.imageArtifactThresholdBytes = options.imageArtifactThresholdBytes ??
       DEFAULT_CONFIG.imageArtifactThresholdBytes;
     this.adapter = options.adapter;
-    this.clientId = options.clientId;
     this.userId = options.userId;
 
     // Use injected artifact client or create default one

--- a/packages/lib/src/runtime-agent.ts
+++ b/packages/lib/src/runtime-agent.ts
@@ -76,10 +76,6 @@ export class RuntimeAgent {
         notebookId: this.config.notebookId,
       });
 
-      // Use provided clientId (now required)
-      const clientId = this.config.clientId;
-      logger.info("Using clientId", { clientId });
-
       // Create store with required adapter
       const adapter = this.config.adapter;
       if (!adapter) {
@@ -97,7 +93,6 @@ export class RuntimeAgent {
           runtime: true,
           runtimeId: this.config.runtimeId,
           sessionId: this.config.sessionId,
-          clientId,
           userId: this.config.userId,
         },
       });

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -71,8 +71,6 @@ export interface RuntimeAgentOptions {
   readonly artifactClient?: IArtifactClient;
   /** LiveStore adapter (required) */
   readonly adapter: Adapter;
-  /** Client ID for sync payload (must be provided) */
-  readonly clientId: string;
   /** User ID for sync payload authorization (must be provided) */
   readonly userId: string;
 }

--- a/packages/lib/test/integration.test.ts
+++ b/packages/lib/test/integration.test.ts
@@ -60,7 +60,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
       notebookId: "test-notebook-integration",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-integration-token",
-      clientId: "test-integration-client",
+
       userId: "test-user-id",
       adapter,
 
@@ -154,7 +154,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
         notebookId: "test-notebook",
         syncUrl: "ws://localhost:8787", // Not used with adapter
         authToken: "valid-token",
-        clientId: "valid-client",
+
         userId: "test-user-id",
         adapter,
         capabilities: capabilities,
@@ -178,7 +178,7 @@ Deno.test("RuntimeAgent Integration Tests", async (t) => {
           notebookId: "test",
           syncUrl: "ws://localhost:8787", // Not used with adapter
           authToken: "token",
-          clientId: "test-client",
+
           userId: "test-user-id",
           adapter,
           capabilities: capabilities,
@@ -254,7 +254,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "test-notebook",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-token",
-      clientId: "test-client-3",
+
       userId: "test-user-id",
       adapter,
       capabilities: {
@@ -282,8 +282,8 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "notebook1",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "token1",
-      clientId: "client1",
-      userId: "test-user-1",
+
+      userId: "test-user-id",
       adapter: adapter1,
       capabilities: {
         canExecuteCode: true,
@@ -300,8 +300,8 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "notebook2",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "token2",
-      clientId: "client2",
-      userId: "test-user-2",
+
+      userId: "test-user-id",
       adapter: adapter2,
       capabilities: {
         canExecuteCode: true,
@@ -323,7 +323,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "test-ai-notebook",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-ai-token",
-      clientId: "test-client-ai",
+
       userId: "test-user-id",
       adapter,
       capabilities: {

--- a/packages/lib/test/mod.test.ts
+++ b/packages/lib/test/mod.test.ts
@@ -27,7 +27,7 @@ Deno.test("RuntimeConfig validation works", () => {
       syncUrl: "ws://test",
       authToken: "", // Missing
       notebookId: "", // Missing
-      clientId: "test-client",
+
       userId: "test-user-id",
       adapter: makeInMemoryAdapter({}),
       capabilities: {
@@ -52,7 +52,7 @@ Deno.test("RuntimeConfig validation works", () => {
     syncUrl: "ws://test",
     authToken: "test-token",
     notebookId: "test-notebook",
-    clientId: "test-client",
+
     userId: "test-user-id",
     adapter: makeInMemoryAdapter({}),
     capabilities: {

--- a/packages/lib/test/runtime-agent-adapter-injection.test.ts
+++ b/packages/lib/test/runtime-agent-adapter-injection.test.ts
@@ -31,16 +31,16 @@ function createTestRuntimeConfig(
     syncUrl: "ws://fake-url:9999",
     authToken: "test-token",
     notebookId: "test-notebook",
+    userId: "test-user-id",
+    adapter: defaultAdapter,
     capabilities: {
       canExecuteCode: true,
       canExecuteSql: false,
       canExecuteAi: false,
     },
-    clientId: "test-client",
-    userId: "test-user-id",
-    adapter: defaultAdapter,
     ...defaults,
   };
+
   return new RuntimeConfig(config);
 }
 
@@ -49,7 +49,6 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
     "should work with default adapter (backward compatibility)",
     () => {
       const config = createTestRuntimeConfig([], {
-        clientId: "test-client-backward-compat",
         userId: "test-user-id",
         notebookId: "test-notebook",
         syncUrl: "ws://fake-url:9999", // Will fail but that's expected
@@ -77,7 +76,6 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
 
     const config = createTestRuntimeConfig([], {
       adapter,
-      clientId: "test-client-adapter",
       userId: "test-user-id",
       notebookId: "adapter-test",
       syncUrl: "ws://fake-url:9999",
@@ -111,7 +109,6 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
 
       const config = createTestRuntimeConfig([], {
         adapter,
-        clientId: "test-client-generated",
         userId: "test-user-id",
         notebookId: "adapter-test-2",
         authToken: "test-token",
@@ -135,65 +132,6 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
     },
   );
 
-  await t.step("should generate clientId for custom adapter", async () => {
-    const runtimeId = `runtime-${crypto.randomUUID()}`;
-    const adapter = makeInMemoryAdapter({});
-
-    const config = createTestRuntimeConfig([], {
-      adapter,
-      runtimeId,
-      userId: "test-user-id",
-      notebookId: "clientid-test",
-      syncUrl: "ws://fake-url:9999",
-    });
-
-    const capabilities: RuntimeCapabilities = {
-      canExecuteCode: true,
-      canExecuteSql: false,
-      canExecuteAi: false,
-    };
-
-    const agent = new RuntimeAgent(config, capabilities);
-
-    await agent.start();
-
-    // The generated clientId should be "runtime-{runtimeId}"
-    // We can't directly verify this without accessing internals,
-    // but we can verify the store was created successfully
-    assertExists(agent.store);
-
-    await agent.shutdown();
-  });
-
-  await t.step("should use explicit clientId when provided", async () => {
-    const adapter = makeInMemoryAdapter({});
-
-    const explicitClientId = "my-custom-client-id";
-
-    const config = createTestRuntimeConfig([], {
-      adapter,
-      clientId: explicitClientId,
-      userId: "test-user-id",
-      notebookId: "explicit-clientid-test",
-      syncUrl: "ws://fake-url:9999",
-    });
-
-    const capabilities: RuntimeCapabilities = {
-      canExecuteCode: true,
-      canExecuteSql: false,
-      canExecuteAi: false,
-    };
-
-    const agent = new RuntimeAgent(config, capabilities);
-
-    await agent.start();
-
-    // Store should be created successfully with custom clientId
-    assertExists(agent.store);
-
-    await agent.shutdown();
-  });
-
   await t.step("should handle multiple agents with same adapter", async () => {
     // Create shared adapter
     const adapter = makeInMemoryAdapter({});
@@ -201,16 +139,13 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
     // Create two agents using the same adapter
     const config1 = createTestRuntimeConfig([], {
       adapter,
-      clientId: "client-1",
       notebookId: "shared-adapter-1",
       runtimeId: "agent-1",
       authToken: "token1",
-      syncUrl: "ws://fake-url:9999",
     });
 
     const config2 = createTestRuntimeConfig([], {
       adapter,
-      clientId: "client-2",
       notebookId: "shared-adapter-2",
       runtimeId: "agent-2",
       authToken: "token2",
@@ -250,7 +185,6 @@ Deno.test("RuntimeAgent adapter injection", async (t) => {
 
     const config = createTestRuntimeConfig([], {
       adapter: fsAdapter,
-      clientId: "fs-client",
       notebookId: "fs-test",
       authToken: "test-token",
       syncUrl: "ws://fake-url:9999",

--- a/packages/lib/test/runtime-agent-artifact.test.ts
+++ b/packages/lib/test/runtime-agent-artifact.test.ts
@@ -72,7 +72,7 @@ const mockRuntimeOptions: RuntimeAgentOptions = {
   syncUrl: "wss://test.runt.run",
   authToken: "test-token",
   notebookId: "test-notebook",
-  clientId: "test-client",
+
   userId: "test-user-id",
   imageArtifactThresholdBytes: 6 * 1024, // 6KB threshold
   adapter: makeInMemoryAdapter({}),

--- a/packages/lib/test/runtime-agent-text-representations.test.ts
+++ b/packages/lib/test/runtime-agent-text-representations.test.ts
@@ -44,7 +44,7 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         notebookId: "test-notebook",
         syncUrl: "ws://localhost:8787",
         authToken: "test-token",
-        clientId: "test-client",
+
         userId: "test-user-id",
         adapter,
         capabilities: capabilities,
@@ -159,7 +159,7 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         notebookId: "test-notebook",
         syncUrl: "ws://localhost:8787", // Not used with adapter
         authToken: "test-token",
-        clientId: "test-client",
+
         userId: "test-user-id",
         adapter,
         capabilities,
@@ -275,7 +275,7 @@ Deno.test("RuntimeAgent Text Representations for Artifacts", async (t) => {
         notebookId: "test-notebook",
         syncUrl: "ws://localhost:8787", // Not used with adapter
         authToken: "test-token",
-        clientId: "test-client",
+
         userId: "test-user-id",
         adapter,
         capabilities,

--- a/packages/lib/test/runtime-agent.test.ts
+++ b/packages/lib/test/runtime-agent.test.ts
@@ -60,7 +60,7 @@ Deno.test("RuntimeAgent", async (t) => {
       notebookId: "test-notebook",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-token",
-      clientId: "test-client",
+
       userId: "test-user-id",
       adapter,
       capabilities,
@@ -177,7 +177,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "test-notebook",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-token",
-      clientId: "test-client",
+
       userId: "test-user-id",
       adapter,
       capabilities: {
@@ -204,7 +204,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "notebook1",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "token1",
-      clientId: "client1",
+
       userId: "test-user-1",
       adapter: adapter1,
       capabilities: {
@@ -222,7 +222,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "notebook2",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "token2",
-      clientId: "client2",
+
       userId: "test-user-2",
       adapter: adapter2,
       capabilities: {
@@ -245,7 +245,7 @@ Deno.test("RuntimeConfig", async (t) => {
       notebookId: "test-notebook",
       syncUrl: "ws://localhost:8787", // Not used with adapter
       authToken: "test-token",
-      clientId: "test-client",
+
       userId: "test-user-id",
       adapter,
       capabilities: {

--- a/packages/pyodide-runtime-agent/src/auth.ts
+++ b/packages/pyodide-runtime-agent/src/auth.ts
@@ -32,19 +32,17 @@ export interface UserInfo {
  */
 export interface AuthenticationResult {
   userId: string;
-  clientId: string;
   userInfo: UserInfo;
 }
 
 /**
  * Discover authenticated user identity via /api/me endpoint
  *
- * This should be called before creating runtime agents to get the clientId.
- * The clientId is generated using the user ID as a prefix plus a unique identifier,
- * following LiveStore best practices where clientId identifies device/app instances.
+ * This should be called before creating runtime agents to get user identity.
+ * LiveStore will handle clientId generation internally for device/app instances.
  *
  * @param options - Configuration for identity discovery
- * @returns Promise resolving to authentication result with userId and generated clientId
+ * @returns Promise resolving to authentication result with userId and user info
  * @throws Error if authentication fails
  */
 export async function discoverUserIdentity(
@@ -67,10 +65,8 @@ export async function discoverUserIdentity(
     if (isTestEnvironment) {
       logger.debug("Skipping authentication in test environment");
       const userId = "test-user-id";
-      const clientId = `${userId}-${crypto.randomUUID()}`;
       return {
         userId,
-        clientId,
         userInfo: { id: userId, email: "test@example.com" },
       };
     }
@@ -121,21 +117,17 @@ export async function discoverUserIdentity(
       throw new Error("User ID not found in response");
     }
 
-    // Generate clientId using user ID as prefix plus unique identifier
-    // This follows LiveStore best practices where clientId identifies device/app instances
+    // User identity discovered - LiveStore will handle clientId internally
     const userId = userInfo.id;
-    const clientId = `${userId}-${crypto.randomUUID()}`;
 
-    logger.debug("User identity discovered and clientId generated", {
+    logger.debug("User identity discovered", {
       userId,
-      clientId,
       email: userInfo.email,
       name: userInfo.name,
     });
 
     return {
       userId,
-      clientId,
       userInfo,
     };
   } catch (error) {
@@ -177,6 +169,3 @@ export async function discoverUserIdentity(
  * @param runtimeId - The runtime ID
  * @returns Generated client ID in the format "runtime-{runtimeId}"
  */
-export function generateRuntimeClientId(runtimeId: string): string {
-  return `runtime-${runtimeId}`;
-}

--- a/packages/pyodide-runtime-agent/src/mod.ts
+++ b/packages/pyodide-runtime-agent/src/mod.ts
@@ -69,15 +69,14 @@ if (import.meta.main) {
     Deno.exit(1);
   }
 
-  // Discover user identity and generate proper clientId
-  const { userId, clientId, userInfo } = await discoverUserIdentity({
+  // Discover user identity - LiveStore will handle clientId internally
+  const { userId, userInfo } = await discoverUserIdentity({
     authToken,
     syncUrl,
   });
 
   logger.info("Authenticated successfully", {
     userId,
-    clientId,
     email: userInfo.email,
   });
 
@@ -90,11 +89,11 @@ if (import.meta.main) {
     },
   });
 
-  // Create agent with discovered clientId, userId, and Node.js adapter
+  // Create agent with discovered userId and Node.js adapter
   const agent = new PyodideRuntimeAgent(
     Deno.args,
     {}, // pyodide options
-    { clientId, adapter, userId }, // runtime options
+    { adapter, userId }, // runtime options
   );
 
   logger.info("Starting Agent");

--- a/packages/pyodide-runtime-agent/src/pyodide-agent.ts
+++ b/packages/pyodide-runtime-agent/src/pyodide-agent.ts
@@ -59,7 +59,6 @@ interface PyodideAgentOptions {
  */
 interface PyodideRuntimeOptions {
   adapter?: Adapter;
-  clientId?: string;
   userId?: string;
 }
 
@@ -146,7 +145,7 @@ export class PyodideRuntimeAgent extends RuntimeAgent {
         },
         ...options, // Merge options into config
         ...(runtimeOptions.adapter && { adapter: runtimeOptions.adapter }),
-        ...(runtimeOptions.clientId && { clientId: runtimeOptions.clientId }),
+
         ...(runtimeOptions.userId && { userId: runtimeOptions.userId }),
       });
     } catch (error) {

--- a/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
+++ b/packages/pyodide-runtime-agent/test/adapter-injection.test.ts
@@ -78,7 +78,7 @@ Deno.test({
         // No sync-url needed with custom adapter!
       ],
       { discoverAiModels: false }, // pyodide options
-      { adapter, clientId: "test-client-123" }, // runtime options
+      { adapter }, // runtime options
     );
 
     assertExists(agent);
@@ -100,11 +100,11 @@ Deno.test({
   });
 
   await t.step(
-    "should accept custom adapter without explicit clientId",
+    "should accept custom adapter",
     async () => {
       const notebookId = `adapter-test-${crypto.randomUUID()}`;
 
-      // Create adapter without explicit clientId
+      // Create adapter - LiveStore will handle clientId internally
       const adapter = makeAdapter({
         storage: { type: "in-memory" },
       });
@@ -117,7 +117,7 @@ Deno.test({
           "test-token",
         ],
         { discoverAiModels: false },
-        { adapter, clientId: "test-client-generated" }, // explicit clientId
+        { adapter }, // LiveStore handles clientId
       );
 
       await agent.start();
@@ -157,7 +157,6 @@ Deno.test({
         {
           // Runtime options
           adapter,
-          clientId: "mixed-test-client",
         },
       );
 
@@ -191,7 +190,7 @@ Deno.test({
           "token1",
         ],
         { discoverAiModels: false },
-        { adapter, clientId: "client-1" },
+        { adapter },
       );
 
       const agent2 = new PyodideRuntimeAgent(
@@ -204,7 +203,7 @@ Deno.test({
           "token2",
         ],
         { discoverAiModels: false },
-        { adapter, clientId: "client-2" },
+        { adapter },
       );
 
       await agent1.start();
@@ -234,7 +233,7 @@ Deno.test({
         const agent = new PyodideRuntimeAgent(
           [`--notebook`, `perf-test-${i}`, "--auth-token", "test"],
           { discoverAiModels: false },
-          { adapter, clientId: `perf-client-${i}` },
+          { adapter },
         );
 
         const startTime = performance.now();
@@ -277,12 +276,12 @@ Deno.test({
   );
 
   await t.step(
-    "should require clientId for programmatic usage (CLI handles auth separately)",
+    "should support programmatic usage (LiveStore handles clientId)",
     () => {
       // Note: CLI usage (import.meta.main in mod.ts) handles auth first,
-      // but programmatic usage now requires explicit clientId
+      // but programmatic usage works with LiveStore managing clientId
 
-      // Pattern 1: Constructor with clientId (now required)
+      // Pattern 1: Constructor without explicit clientId
       const agent1 = new PyodideRuntimeAgent(
         [
           "--notebook",
@@ -291,23 +290,23 @@ Deno.test({
           "token",
         ],
         {}, // pyodide options
-        { clientId: "programmatic-client-1" }, // now required
+        {}, // LiveStore handles clientId
       );
+
       assertExists(agent1);
 
-      // Pattern 2: Constructor with pyodide options and clientId
+      // Pattern 2: Constructor with pyodide options
       const agent2 = new PyodideRuntimeAgent(
         ["--notebook", "programmatic-test-2", "--auth-token", "token"],
         { packages: ["numpy"] }, // pyodide options
-        { clientId: "programmatic-client-2" }, // now required
+        {}, // LiveStore handles clientId
       );
+
       assertExists(agent2);
 
       // Verify configs are set correctly
       assertEquals(agent1.config.notebookId, "programmatic-test-1");
-      assertEquals(agent1.config.clientId, "programmatic-client-1");
       assertEquals(agent2.config.notebookId, "programmatic-test-2");
-      assertEquals(agent2.config.clientId, "programmatic-client-2");
     },
   );
 });

--- a/packages/pyodide-runtime-agent/test/ai-cancellation.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cancellation.test.ts
@@ -39,7 +39,6 @@ Deno.test({
 
         agent = new PyodideRuntimeAgent(agentArgs, {}, {
           adapter,
-          clientId: "ai-cancellation-test-client",
         });
         assertExists(agent);
         assertEquals(agent.config.capabilities.canExecuteAi, true);

--- a/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/ai-cell-integration.test.ts
@@ -41,7 +41,6 @@ Deno.test({
 
         agent = new PyodideRuntimeAgent(agentArgs, {}, {
           adapter,
-          clientId: "ai-error-test-client",
         });
         assertExists(agent);
         assertEquals(agent.config.capabilities.canExecuteAi, true);

--- a/packages/pyodide-runtime-agent/test/config-cli.test.ts
+++ b/packages/pyodide-runtime-agent/test/config-cli.test.ts
@@ -21,7 +21,6 @@ function makeBaseConfig(overrides: Partial<Record<string, unknown>> = {}) {
     syncUrl: "wss://test.example.com",
     authToken: "test-token",
     notebookId: "test-nb",
-    clientId: "test-client",
     userId: "test-user-id",
     adapter: makeInMemoryAdapter({}),
     capabilities: {

--- a/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/in-memory-integration.test.ts
@@ -54,7 +54,6 @@ Deno.test({
 
         agent = new PyodideRuntimeAgent(agentArgs, {}, {
           adapter,
-          clientId: "test-client",
         });
 
         assertExists(agent);

--- a/packages/pyodide-runtime-agent/test/mount-integration.test.ts
+++ b/packages/pyodide-runtime-agent/test/mount-integration.test.ts
@@ -48,9 +48,7 @@ Deno.test({
       } as typeof Worker;
 
       try {
-        const agent = new PyodideRuntimeAgent(args, {}, {
-          clientId: "test-client",
-        });
+        const agent = new PyodideRuntimeAgent(args, {}, {});
 
         // Don't actually start the agent (since we're mocking the worker)
         // Just verify that the mount paths are properly configured
@@ -161,9 +159,7 @@ Deno.test({
     ];
 
     // This should not throw
-    const agent = new PyodideRuntimeAgent(args, {}, {
-      clientId: "test-client",
-    });
+    const agent = new PyodideRuntimeAgent(args, {}, {});
     assertEquals(Array.isArray(agent["pyodideOptions"].mountPaths), true);
     assertEquals(agent["pyodideOptions"].mountPaths?.length, 1);
     assertEquals(agent["pyodideOptions"].mountPaths?.[0], "/valid/path");
@@ -177,9 +173,7 @@ Deno.test({
       "--auth-token=test-token",
     ];
 
-    const agent = new PyodideRuntimeAgent(args, {}, {
-      clientId: "test-client",
-    });
+    const agent = new PyodideRuntimeAgent(args, {}, {});
     assertEquals(agent["pyodideOptions"].mountPaths, []);
 
     console.log("✅ Empty mount paths handled correctly");

--- a/packages/pyodide-runtime-agent/test/output-sync.test.ts
+++ b/packages/pyodide-runtime-agent/test/output-sync.test.ts
@@ -16,9 +16,7 @@ Deno.test({
       `--output-dir=${tempOutputDir}`,
     ], {
       outputDir: tempOutputDir,
-    }, {
-      clientId: "test-client",
-    });
+    }, {});
 
     // Initialize the agent
     await agent.start();
@@ -139,9 +137,7 @@ Deno.test({
       "--auth-token=test-token",
     ],
     {},
-    {
-      clientId: "test-client",
-    },
+    {},
   );
 
   await agent.start();
@@ -221,9 +217,7 @@ Deno.test({
       `--output-dir=${tempOutputDir}`,
     ], {
       outputDir: tempOutputDir,
-    }, {
-      clientId: "test-client",
-    });
+    }, {});
 
     await agent.start();
 

--- a/packages/pyodide-runtime-agent/test/readonly-mount.test.ts
+++ b/packages/pyodide-runtime-agent/test/readonly-mount.test.ts
@@ -37,9 +37,7 @@ Deno.test({
     ], {
       mountPaths: [tempMountDir],
       mountReadonly: true,
-    }, {
-      clientId: "test-client",
-    });
+    }, {});
 
     // Initialize the agent
     await agent.start();

--- a/packages/pyodide-runtime-agent/test/real-execution.test.ts
+++ b/packages/pyodide-runtime-agent/test/real-execution.test.ts
@@ -33,7 +33,6 @@ function createTestAgent(packages?: string[]): PyodideRuntimeAgent {
 
   return new PyodideRuntimeAgent(validArgs, packages ? { packages } : {}, {
     adapter,
-    clientId: "test-client",
   });
 }
 

--- a/packages/python-runtime-agent/src/python-runtime-agent.ts
+++ b/packages/python-runtime-agent/src/python-runtime-agent.ts
@@ -15,7 +15,7 @@ export class PythonRuntimeAgent extends RuntimeAgent {
         canExecuteSql: false,
         canExecuteAi: false,
       },
-      clientId: "dummy",
+
       userId: "dummy",
       adapter: makeInMemoryAdapter({}),
     });


### PR DESCRIPTION
Similar to [anode PR #483](https://github.com/runtimed/anode/pull/483), remove clientId generation from runt runtime agents. LiveStore will now handle clientId generation internally for device/app instances.

- Remove clientId from RuntimeAgentOptions interface and RuntimeConfig class
- Remove clientId from sync payload in runtime agent
- Update auth.ts to stop generating clientIds in discoverUserIdentity()
- Remove clientId parameter from PyodideRuntimeOptions
- Update all tests to not pass clientId parameters
- Remove obsolete clientId generation and validation tests

User identity is still validated via JWT tokens, but client identification is now handled entirely by LiveStore's internal mechanisms.